### PR TITLE
feat: Add IEC ANY type constraints to standard library functions

### DIFF
--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -2,12 +2,22 @@
  * STruC++ Runtime - IEC Standard Library
  *
  * This header provides the standard IEC 61131-3 functions and utilities.
- * Functions are implemented as C++ templates for type safety and performance.
+ * Functions are implemented as C++ templates with IEC type constraints
+ * for type safety and compliance with IEC 61131-3 type system.
+ *
+ * Type constraints follow IEC 61131-3 ANY type hierarchy:
+ * - ANY_NUM: Numeric types (integers + reals)
+ * - ANY_INT: Integer types (signed + unsigned)
+ * - ANY_REAL: Floating point types (REAL, LREAL)
+ * - ANY_BIT: Bit string types (BOOL, BYTE, WORD, DWORD, LWORD)
+ * - ANY_ELEMENTARY: All elementary types
+ * - ANY_MAGNITUDE: Numeric + time types
  */
 
 #pragma once
 
 #include "iec_var.hpp"
+#include "iec_traits.hpp"
 #include <cmath>
 #include <algorithm>
 #include <type_traits>
@@ -84,13 +94,14 @@ struct ConfigurationInstance {
 };
 
 // =============================================================================
-// Numeric Functions
+// Numeric Functions (ANY_NUM -> ANY_NUM, or ANY_REAL -> ANY_REAL)
 // =============================================================================
 
 /**
  * ABS - Absolute value
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T ABS(T value) noexcept {
     if constexpr (std::is_same_v<T, IEC_REAL> || std::is_same_v<T, IEC_LREAL>) {
         return T(std::abs(value.get()));
@@ -104,129 +115,142 @@ inline T ABS(T value) noexcept {
 
 /**
  * SQRT - Square root
+ * Input: ANY_REAL, Output: ANY_REAL (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T SQRT(T value) noexcept {
     return T(std::sqrt(static_cast<double>(value.get())));
 }
 
 /**
  * LN - Natural logarithm
+ * Input: ANY_REAL, Output: ANY_REAL (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T LN(T value) noexcept {
     return T(std::log(static_cast<double>(value.get())));
 }
 
 /**
  * LOG - Base-10 logarithm
+ * Input: ANY_REAL, Output: ANY_REAL (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T LOG(T value) noexcept {
     return T(std::log10(static_cast<double>(value.get())));
 }
 
 /**
  * EXP - Exponential (e^x)
+ * Input: ANY_REAL, Output: ANY_REAL (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T EXP(T value) noexcept {
     return T(std::exp(static_cast<double>(value.get())));
 }
 
 /**
  * EXPT - Exponentiation (base^exponent)
+ * Input: ANY_REAL, Output: ANY_REAL (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T EXPT(T base, T exponent) noexcept {
     return T(std::pow(static_cast<double>(base.get()), static_cast<double>(exponent.get())));
 }
 
 // =============================================================================
-// Trigonometric Functions
+// Trigonometric Functions (ANY_REAL -> ANY_REAL)
 // =============================================================================
 
 /**
  * SIN - Sine
+ * Input: ANY_REAL (radians), Output: ANY_REAL
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T SIN(T value) noexcept {
     return T(std::sin(static_cast<double>(value.get())));
 }
 
 /**
  * COS - Cosine
+ * Input: ANY_REAL (radians), Output: ANY_REAL
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T COS(T value) noexcept {
     return T(std::cos(static_cast<double>(value.get())));
 }
 
 /**
  * TAN - Tangent
+ * Input: ANY_REAL (radians), Output: ANY_REAL
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T TAN(T value) noexcept {
     return T(std::tan(static_cast<double>(value.get())));
 }
 
 /**
  * ASIN - Arc sine
+ * Input: ANY_REAL, Output: ANY_REAL (radians)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T ASIN(T value) noexcept {
     return T(std::asin(static_cast<double>(value.get())));
 }
 
 /**
  * ACOS - Arc cosine
+ * Input: ANY_REAL, Output: ANY_REAL (radians)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T ACOS(T value) noexcept {
     return T(std::acos(static_cast<double>(value.get())));
 }
 
 /**
  * ATAN - Arc tangent
+ * Input: ANY_REAL, Output: ANY_REAL (radians)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T ATAN(T value) noexcept {
     return T(std::atan(static_cast<double>(value.get())));
 }
 
 /**
  * ATAN2 - Arc tangent of y/x (two-argument form)
- * Returns angle in radians between -PI and PI
+ * Input: ANY_REAL, Output: ANY_REAL (radians between -PI and PI)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T ATAN2(T y, T x) noexcept {
     return T(std::atan2(static_cast<double>(y.get()), static_cast<double>(x.get())));
 }
 
 /**
  * TRUNC - Truncate toward zero
- * Returns the integer part of a real number
+ * Input: ANY_REAL, Output: ANY_REAL (integer part)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T TRUNC(T value) noexcept {
     return T(std::trunc(static_cast<double>(value.get())));
 }
 
 /**
  * ROUND - Round to nearest integer
+ * Input: ANY_REAL, Output: ANY_REAL
  * Rounds half away from zero (banker's rounding not used)
  */
-template<typename T>
+template<typename T, enable_if_any_real<T> = 0>
 inline T ROUND(T value) noexcept {
     return T(std::round(static_cast<double>(value.get())));
 }
 
 // =============================================================================
-// Selection Functions
+// Selection Functions (ANY_ELEMENTARY for comparisons)
 // =============================================================================
 
 /**
  * SEL - Binary selection
+ * Input: BOOL selector, ANY values, Output: ANY (same type as inputs)
  * Returns in1 if g is FALSE, in0 if g is TRUE
  */
 template<typename T>
@@ -236,24 +260,27 @@ inline T SEL(IEC_BOOL g, T in0, T in1) noexcept {
 
 /**
  * MAX - Maximum of two values
+ * Input: ANY_ELEMENTARY, Output: ANY_ELEMENTARY (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline T MAX(T a, T b) noexcept {
     return a.get() > b.get() ? a : b;
 }
 
 /**
  * MIN - Minimum of two values
+ * Input: ANY_ELEMENTARY, Output: ANY_ELEMENTARY (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline T MIN(T a, T b) noexcept {
     return a.get() < b.get() ? a : b;
 }
 
 /**
  * LIMIT - Limit value to range [mn, mx]
+ * Input: ANY_ELEMENTARY, Output: ANY_ELEMENTARY (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline T LIMIT(T mn, T in, T mx) noexcept {
     if (in.get() < mn.get()) return mn;
     if (in.get() > mx.get()) return mx;
@@ -262,8 +289,8 @@ inline T LIMIT(T mn, T in, T mx) noexcept {
 
 /**
  * MUX - Multiplexer (select from multiple inputs)
- * Note: This is a simplified 2-input version. Full implementation
- * with variable arguments will be added in Phase 1.6.
+ * Input: ANY_INT selector, ANY values, Output: ANY (same type as inputs)
+ * Note: This is a simplified 2-input version.
  */
 template<typename T>
 inline T MUX(IEC_INT k, T in0, T in1) noexcept {
@@ -271,81 +298,90 @@ inline T MUX(IEC_INT k, T in0, T in1) noexcept {
 }
 
 // =============================================================================
-// Comparison Functions
+// Comparison Functions (ANY_ELEMENTARY -> BOOL)
 // =============================================================================
 
 /**
  * GT - Greater than
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GT(T a, T b) noexcept {
     return IEC_BOOL(a.get() > b.get());
 }
 
 /**
  * GE - Greater than or equal
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GE(T a, T b) noexcept {
     return IEC_BOOL(a.get() >= b.get());
 }
 
 /**
  * EQ - Equal
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL EQ(T a, T b) noexcept {
     return IEC_BOOL(a.get() == b.get());
 }
 
 /**
  * LE - Less than or equal
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LE(T a, T b) noexcept {
     return IEC_BOOL(a.get() <= b.get());
 }
 
 /**
  * LT - Less than
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LT(T a, T b) noexcept {
     return IEC_BOOL(a.get() < b.get());
 }
 
 /**
  * NE - Not equal
+ * Input: ANY_ELEMENTARY, Output: BOOL
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL NE(T a, T b) noexcept {
     return IEC_BOOL(a.get() != b.get());
 }
 
 // =============================================================================
-// Bit Shift Functions
+// Bit Shift Functions (ANY_BIT -> ANY_BIT)
 // =============================================================================
 
 /**
  * SHL - Shift left
+ * Input: ANY_BIT, ANY_INT (shift count), Output: ANY_BIT
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T SHL(T in, IEC_INT n) noexcept {
     return T(in.get() << n.get());
 }
 
 /**
  * SHR - Shift right
+ * Input: ANY_BIT, ANY_INT (shift count), Output: ANY_BIT
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T SHR(T in, IEC_INT n) noexcept {
     return T(in.get() >> n.get());
 }
 
 /**
  * ROL - Rotate left
+ * Input: ANY_BIT, ANY_INT (shift count), Output: ANY_BIT
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T ROL(T in, IEC_INT n) noexcept {
     constexpr int bits = sizeof(typename T::value_type) * 8;
     auto v = in.get();
@@ -355,8 +391,9 @@ inline T ROL(T in, IEC_INT n) noexcept {
 
 /**
  * ROR - Rotate right
+ * Input: ANY_BIT, ANY_INT (shift count), Output: ANY_BIT
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T ROR(T in, IEC_INT n) noexcept {
     constexpr int bits = sizeof(typename T::value_type) * 8;
     auto v = in.get();
@@ -422,68 +459,74 @@ inline double TIME_TO_S(IEC_TIME t) noexcept {
 }
 
 // =============================================================================
-// Variadic Arithmetic Functions
+// Variadic Arithmetic Functions (ANY_NUM -> ANY_NUM)
 // =============================================================================
 
 /**
  * NEG - Negation (unary minus)
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T NEG(T value) noexcept {
     return T(-value.get());
 }
 
 /**
  * ADD - Addition (variadic)
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  * Adds two or more values together
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T ADD(T a, T b) noexcept {
     return T(a.get() + b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_num<T> = 0>
 inline T ADD(T first, T second, Args... rest) noexcept {
     return ADD(T(first.get() + second.get()), rest...);
 }
 
 /**
  * MUL - Multiplication (variadic)
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  * Multiplies two or more values together
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T MUL(T a, T b) noexcept {
     return T(a.get() * b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_num<T> = 0>
 inline T MUL(T first, T second, Args... rest) noexcept {
     return MUL(T(first.get() * second.get()), rest...);
 }
 
 /**
  * SUB - Subtraction
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  * Subtracts second value from first
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T SUB(T a, T b) noexcept {
     return T(a.get() - b.get());
 }
 
 /**
  * DIV - Division
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
  * Divides first value by second
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T DIV(T a, T b) noexcept {
     return T(a.get() / b.get());
 }
 
 /**
  * MOD - Modulo
- * Returns remainder of integer division
+ * Input: ANY_NUM, Output: ANY_NUM (same type)
+ * Returns remainder of division
  */
-template<typename T>
+template<typename T, enable_if_any_num<T> = 0>
 inline T MOD(T a, T b) noexcept {
     if constexpr (std::is_floating_point_v<typename T::value_type>) {
         return T(std::fmod(static_cast<double>(a.get()), static_cast<double>(b.get())));
@@ -493,65 +536,70 @@ inline T MOD(T a, T b) noexcept {
 }
 
 // =============================================================================
-// Variadic Bitwise Functions
+// Variadic Bitwise Functions (ANY_BIT -> ANY_BIT)
 // =============================================================================
 
 /**
  * NOT - Bitwise NOT (one's complement)
+ * Input: ANY_BIT, Output: ANY_BIT (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T NOT(T value) noexcept {
     return T(~value.get());
 }
 
 /**
  * AND - Bitwise AND (variadic)
+ * Input: ANY_BIT, Output: ANY_BIT (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T AND(T a, T b) noexcept {
     return T(a.get() & b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_bit<T> = 0>
 inline T AND(T first, T second, Args... rest) noexcept {
     return AND(T(first.get() & second.get()), rest...);
 }
 
 /**
  * OR - Bitwise OR (variadic)
+ * Input: ANY_BIT, Output: ANY_BIT (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T OR(T a, T b) noexcept {
     return T(a.get() | b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_bit<T> = 0>
 inline T OR(T first, T second, Args... rest) noexcept {
     return OR(T(first.get() | second.get()), rest...);
 }
 
 /**
  * XOR - Bitwise XOR (variadic)
+ * Input: ANY_BIT, Output: ANY_BIT (same type)
  */
-template<typename T>
+template<typename T, enable_if_any_bit<T> = 0>
 inline T XOR(T a, T b) noexcept {
     return T(a.get() ^ b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_bit<T> = 0>
 inline T XOR(T first, T second, Args... rest) noexcept {
     return XOR(T(first.get() ^ second.get()), rest...);
 }
 
 // =============================================================================
-// Variadic Selection Functions
+// Variadic Selection Functions (ANY_ELEMENTARY)
 // =============================================================================
 
 /**
  * MAX - Maximum (variadic)
+ * Input: ANY_ELEMENTARY, Output: ANY_ELEMENTARY (same type)
  * Returns the maximum of two or more values
  */
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline T MAX(T first, T second, Args... rest) noexcept {
     T current_max = first.get() > second.get() ? first : second;
     if constexpr (sizeof...(rest) > 0) {
@@ -563,9 +611,10 @@ inline T MAX(T first, T second, Args... rest) noexcept {
 
 /**
  * MIN - Minimum (variadic)
+ * Input: ANY_ELEMENTARY, Output: ANY_ELEMENTARY (same type)
  * Returns the minimum of two or more values
  */
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline T MIN(T first, T second, Args... rest) noexcept {
     T current_min = first.get() < second.get() ? first : second;
     if constexpr (sizeof...(rest) > 0) {
@@ -577,6 +626,7 @@ inline T MIN(T first, T second, Args... rest) noexcept {
 
 /**
  * MUX - Multiplexer (variadic)
+ * Input: ANY_INT selector, ANY values, Output: ANY (same type as inputs)
  * Selects one of multiple inputs based on selector k
  * k=0 returns first input, k=1 returns second, etc.
  */
@@ -593,6 +643,7 @@ inline T MUX_V(IEC_INT k, T in0, Args... rest) noexcept {
 
 /**
  * MOVE - Copy value (identity function)
+ * Input: ANY, Output: ANY (same type)
  * Used for explicit value copying in ST
  */
 template<typename T>
@@ -601,20 +652,21 @@ inline T MOVE(T value) noexcept {
 }
 
 // =============================================================================
-// Variadic Comparison Functions (Chain Support)
+// Variadic Comparison Functions (Chain Support) (ANY_ELEMENTARY -> BOOL)
 // =============================================================================
 
 /**
  * GT_CHAIN - Greater than chain
+ * Input: ANY_ELEMENTARY, Output: BOOL
  * Returns TRUE if all values are in strictly decreasing order
  * GT_CHAIN(a, b, c) = (a > b) AND (b > c)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GT_CHAIN(T a, T b) noexcept {
     return IEC_BOOL(a.get() > b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GT_CHAIN(T first, T second, Args... rest) noexcept {
     if (first.get() <= second.get()) return IEC_BOOL(false);
     if constexpr (sizeof...(rest) > 0) {
@@ -626,15 +678,16 @@ inline IEC_BOOL GT_CHAIN(T first, T second, Args... rest) noexcept {
 
 /**
  * GE_CHAIN - Greater than or equal chain
+ * Input: ANY_ELEMENTARY, Output: BOOL
  * Returns TRUE if all values are in non-increasing order
  * GE_CHAIN(a, b, c) = (a >= b) AND (b >= c)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GE_CHAIN(T a, T b) noexcept {
     return IEC_BOOL(a.get() >= b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL GE_CHAIN(T first, T second, Args... rest) noexcept {
     if (first.get() < second.get()) return IEC_BOOL(false);
     if constexpr (sizeof...(rest) > 0) {
@@ -646,15 +699,16 @@ inline IEC_BOOL GE_CHAIN(T first, T second, Args... rest) noexcept {
 
 /**
  * EQ_CHAIN - Equality chain
+ * Input: ANY_ELEMENTARY, Output: BOOL
  * Returns TRUE if all values are equal
  * EQ_CHAIN(a, b, c) = (a == b) AND (b == c)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL EQ_CHAIN(T a, T b) noexcept {
     return IEC_BOOL(a.get() == b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL EQ_CHAIN(T first, T second, Args... rest) noexcept {
     if (first.get() != second.get()) return IEC_BOOL(false);
     if constexpr (sizeof...(rest) > 0) {
@@ -666,15 +720,16 @@ inline IEC_BOOL EQ_CHAIN(T first, T second, Args... rest) noexcept {
 
 /**
  * LE_CHAIN - Less than or equal chain
+ * Input: ANY_ELEMENTARY, Output: BOOL
  * Returns TRUE if all values are in non-decreasing order
  * LE_CHAIN(a, b, c) = (a <= b) AND (b <= c)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LE_CHAIN(T a, T b) noexcept {
     return IEC_BOOL(a.get() <= b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LE_CHAIN(T first, T second, Args... rest) noexcept {
     if (first.get() > second.get()) return IEC_BOOL(false);
     if constexpr (sizeof...(rest) > 0) {
@@ -686,15 +741,16 @@ inline IEC_BOOL LE_CHAIN(T first, T second, Args... rest) noexcept {
 
 /**
  * LT_CHAIN - Less than chain
+ * Input: ANY_ELEMENTARY, Output: BOOL
  * Returns TRUE if all values are in strictly increasing order
  * LT_CHAIN(a, b, c) = (a < b) AND (b < c)
  */
-template<typename T>
+template<typename T, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LT_CHAIN(T a, T b) noexcept {
     return IEC_BOOL(a.get() < b.get());
 }
 
-template<typename T, typename... Args>
+template<typename T, typename... Args, enable_if_any_elementary<T> = 0>
 inline IEC_BOOL LT_CHAIN(T first, T second, Args... rest) noexcept {
     if (first.get() >= second.get()) return IEC_BOOL(false);
     if constexpr (sizeof...(rest) > 0) {

--- a/src/runtime/include/iec_traits.hpp
+++ b/src/runtime/include/iec_traits.hpp
@@ -464,6 +464,9 @@ template<typename T>
 using enable_if_any_magnitude = std::enable_if_t<is_any_magnitude_v<T>, int>;
 
 template<typename T>
+using enable_if_any_elementary = std::enable_if_t<is_any_elementary_v<T>, int>;
+
+template<typename T>
 using enable_if_iec_array = std::enable_if_t<is_iec_array_v<T>, int>;
 
 template<typename T>


### PR DESCRIPTION
## Summary

- Add proper IEC 61131-3 type constraints to all standard library functions using SFINAE (`enable_if`)
- Functions now enforce type safety at compile time according to the IEC type hierarchy
- Add `enable_if_any_elementary<T>` helper to `iec_traits.hpp`

### Type constraints applied:

| Category | Functions | Constraint |
|----------|-----------|------------|
| Numeric | ABS, NEG, ADD, SUB, MUL, DIV, MOD | `ANY_NUM` |
| Real Math | SQRT, LN, LOG, EXP, EXPT | `ANY_REAL` |
| Trigonometric | SIN, COS, TAN, ASIN, ACOS, ATAN, ATAN2 | `ANY_REAL` |
| Rounding | TRUNC, ROUND | `ANY_REAL` |
| Comparison | GT, GE, EQ, LE, LT, NE | `ANY_ELEMENTARY` |
| Selection | MAX, MIN, LIMIT | `ANY_ELEMENTARY` |
| Bit Shift | SHL, SHR, ROL, ROR | `ANY_BIT` |
| Bitwise | NOT, AND, OR, XOR | `ANY_BIT` |

### Example - Invalid usage now fails at compile time:

```cpp
IEC_STRING s1{"hello"};
IEC_STRING s2{"world"};
auto result = ADD(s1, s2);  // Compile error: ADD requires ANY_NUM
```

## Test plan

- [x] All 309 existing tests pass
- [x] C++ compilation tests verify type constraints work correctly
- [x] Manual verification with g++ -std=c++17

🤖 Generated with [Claude Code](https://claude.ai/code)