### PR TITLE
feat: Scan-cycle-based TIME() with ADVANCE_TIME test support

### DIFF
--- a/src/backend/repl-main-gen.ts
+++ b/src/backend/repl-main-gen.ts
@@ -230,6 +230,8 @@ interface ProgramInfo {
   varsDescName: string;
   /** Variables to expose in the REPL */
   vars: Array<{ name: string; typeName: string }>;
+  /** Task interval in nanoseconds (0 = REPL applies 20ms default) */
+  intervalNs: number;
 }
 
 /**
@@ -263,7 +265,7 @@ function emitProgramDescriptorsAndMain(
   lines.push(`static ProgramDescriptor programs[] = {`);
   for (const prog of programs) {
     lines.push(
-      `    {"${prog.displayName}", &${prog.instanceExpr}, ${prog.varsDescName}, ${prog.vars.length}},`,
+      `    {"${prog.displayName}", &${prog.instanceExpr}, ${prog.varsDescName}, ${prog.vars.length}, ${prog.intervalNs}LL},`,
     );
   }
   lines.push("};");
@@ -293,6 +295,7 @@ function generateStandalone(
       instanceExpr: instanceVar,
       varsDescName: `${instanceVar}_vars`,
       vars: collectVarsFromBlocks(prog.varBlocks),
+      intervalNs: 0,
     };
   });
 
@@ -328,6 +331,7 @@ function generateWithConfiguration(
   const programs: ProgramInfo[] = [];
   for (const resource of config.resources) {
     for (const task of resource.tasks) {
+      const intervalNs = task.interval?.nanoseconds ?? 0;
       for (const inst of task.programInstances) {
         const astProg = ast.programs.find(
           (p) => p.name.toUpperCase() === inst.programType.toUpperCase(),
@@ -337,6 +341,7 @@ function generateWithConfiguration(
           instanceExpr: `${configInstanceVar}.${inst.instanceName}`,
           varsDescName: `vars_${inst.instanceName}`,
           vars: astProg ? collectVarsFromBlocks(astProg.varBlocks) : [],
+          intervalNs,
         });
       }
     }

--- a/src/backend/test-main-gen.ts
+++ b/src/backend/test-main-gen.ts
@@ -15,6 +15,7 @@ import type {
   TestCase,
   TestStatement,
   AssertCall,
+  AdvanceTimeStatement,
   SetupBlock,
   TeardownBlock,
   MockFBStatement,
@@ -540,6 +541,9 @@ class TestFunctionGenerator {
       case "AssertCall":
         this.generateAssertCall(lines, stmt);
         break;
+      case "AdvanceTimeStatement":
+        this.generateAdvanceTime(lines, stmt);
+        break;
       case "MockFBStatement":
         this.generateMockFB(lines, stmt);
         break;
@@ -562,6 +566,16 @@ class TestFunctionGenerator {
         lines.push(...this.testCodegen.getOutput());
         break;
     }
+  }
+
+  private generateAdvanceTime(
+    lines: string[],
+    stmt: AdvanceTimeStatement,
+  ): void {
+    const durationExpr = this.testCodegen.emitExpression(stmt.duration);
+    lines.push(
+      `${this.indent}strucpp::__CURRENT_TIME_NS += static_cast<int64_t>(${durationExpr});`,
+    );
   }
 
   // ===========================================================================

--- a/src/frontend/ast-builder.ts
+++ b/src/frontend/ast-builder.ts
@@ -3047,6 +3047,10 @@ export class ASTBuilder {
     if (assertNode) {
       return this.buildAssertCall(assertNode);
     }
+    const advanceTimeNode = getFirstNode(children.advanceTimeStatement);
+    if (advanceTimeNode) {
+      return this.buildAdvanceTimeStatement(advanceTimeNode);
+    }
     const mockNode = getFirstNode(children.mockStatement);
     if (mockNode) {
       return this.buildMockStatement(mockNode);
@@ -3061,6 +3065,24 @@ export class ASTBuilder {
       if (stmt) return stmt;
     }
     throw new Error("Empty test statement");
+  }
+
+  /**
+   * Build an AdvanceTimeStatement from an advanceTimeStatement CST node.
+   */
+  buildAdvanceTimeStatement(
+    cst: CstNode,
+  ): import("./ast.js").AdvanceTimeStatement {
+    const children = cst.children as CstChildren;
+    const exprNode = getFirstNode(children.expression);
+    const duration = exprNode
+      ? (this.buildExpression(exprNode) ?? this.createDummyLiteral(cst))
+      : this.createDummyLiteral(cst);
+    return {
+      kind: "AdvanceTimeStatement",
+      duration,
+      sourceSpan: nodeToSourceSpan(cst),
+    };
   }
 
   /**

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -829,9 +829,19 @@ export interface MockVerifyCallCountStatement extends ASTNode {
 /**
  * A statement within a test block (either a regular statement, assert call, or mock statement).
  */
+/**
+ * ADVANCE_TIME(duration) - Advance scan-cycle time in tests.
+ */
+export interface AdvanceTimeStatement extends ASTNode {
+  kind: "AdvanceTimeStatement";
+  duration: Expression;
+  sourceSpan: SourceSpan;
+}
+
 export type TestStatement =
   | Statement
   | AssertCall
+  | AdvanceTimeStatement
   | MockFBStatement
   | MockFunctionStatement
   | MockVerifyCalledStatement

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -395,6 +395,12 @@ export const ASSERT_NEAR = createToken({
   pattern: /ASSERT_NEAR/i,
 });
 
+// ADVANCE_TIME for test time simulation
+export const ADVANCE_TIME = createToken({
+  name: "ADVANCE_TIME",
+  pattern: /ADVANCE_TIME/i,
+});
+
 // SETUP/TEARDOWN for test organization
 export const SETUP = createToken({ name: "SETUP", pattern: /SETUP/i });
 export const END_SETUP = createToken({
@@ -602,6 +608,7 @@ const testKeywordTokens = [
   SETUP,
   END_TEARDOWN,
   TEARDOWN,
+  ADVANCE_TIME,
   ASSERT_EQ,
   ASSERT_NEQ,
   ASSERT_TRUE,

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1620,6 +1620,10 @@ export class STParser extends CstParser {
           GATE: () => this.isAssertAhead(),
         },
         {
+          ALT: () => this.SUBRULE(this.advanceTimeStatement),
+          GATE: () => this.LA(1).tokenType === tokens.ADVANCE_TIME,
+        },
+        {
           ALT: () => this.SUBRULE(this.mockVerifyStatement),
           GATE: () => this.isMockVerifyAhead(),
         },
@@ -1631,6 +1635,17 @@ export class STParser extends CstParser {
       ],
       IGNORE_AMBIGUITIES: true,
     });
+  });
+
+  /**
+   * ADVANCE_TIME(expression) ; - Advance scan-cycle time in tests
+   */
+  public advanceTimeStatement = this.RULE("advanceTimeStatement", () => {
+    this.CONSUME(tokens.ADVANCE_TIME);
+    this.CONSUME(tokens.LParen);
+    this.SUBRULE(this.expression);
+    this.CONSUME(tokens.RParen);
+    this.CONSUME(tokens.Semicolon);
   });
 
   /**

--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -21,7 +21,6 @@
 #include "iec_retain.hpp"
 #include <cmath>
 #include <algorithm>
-#include <chrono>
 #include <cstddef>
 #include <cstring>
 #include <type_traits>
@@ -803,19 +802,27 @@ inline IEC_BOOL LT_CHAIN(T first, T second, Args... rest) noexcept {
 }
 
 // =============================================================================
-// TIME() - Absolute Runtime Time (CODESYS-compatible)
+// Scan-Cycle Time (CODESYS/MatIEC-compatible)
 // =============================================================================
 
 /**
- * Returns the absolute runtime time (elapsed since runtime start).
- * CODESYS-compatible: TIME() returns monotonic elapsed time.
- * Uses std::chrono::steady_clock for monotonic timing.
+ * Global scan-cycle time in nanoseconds.
+ * Advanced by the runtime before each scan cycle.
+ * - REPL advances by common_ticktime each cycle.
+ * - OpenPLC runtime advances before each task execution.
+ * - Test runner resets to 0 before each test case.
+ *
+ * All calls to TIME() within the same cycle return the same value,
+ * matching CODESYS behavior.
+ */
+inline int64_t __CURRENT_TIME_NS = 0;
+
+/**
+ * Returns the current scan-cycle time.
+ * CODESYS-compatible: TIME() returns the same value for the entire cycle.
  */
 inline IEC_TIME TIME() {
-    static auto start = std::chrono::steady_clock::now();
-    auto now = std::chrono::steady_clock::now();
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
-    return IEC_TIME(static_cast<TIME_t>(ns));
+    return IEC_TIME(static_cast<TIME_t>(__CURRENT_TIME_NS));
 }
 
 // =============================================================================

--- a/src/runtime/repl/iec_repl.hpp
+++ b/src/runtime/repl/iec_repl.hpp
@@ -65,6 +65,7 @@ struct ProgramDescriptor {
     ProgramBase* instance;
     VarDescriptor* vars;
     size_t var_count;
+    int64_t interval_ns;  // Task interval in nanoseconds (0 = default 20ms)
 };
 
 struct STLineMap {
@@ -505,6 +506,15 @@ static void repl_highlighter(ic_highlight_env_t* henv, const char* input, void* 
 }
 
 // =============================================================================
+// GCD Helper for Common Tick Time
+// =============================================================================
+
+inline int64_t repl_gcd(int64_t a, int64_t b) {
+    while (b) { a %= b; std::swap(a, b); }
+    return a;
+}
+
+// =============================================================================
 // REPL Entry Point
 // =============================================================================
 
@@ -513,6 +523,18 @@ inline void repl_run(ProgramDescriptor* programs, size_t program_count,
                      const char* cpp_source = nullptr,
                      const STLineMap* line_map = nullptr,
                      size_t line_map_count = 0) {
+    // Resolve default intervals and calculate common tick time
+    constexpr int64_t DEFAULT_INTERVAL_NS = 20000000LL; // 20ms
+    for (size_t i = 0; i < program_count; ++i) {
+        if (programs[i].interval_ns <= 0)
+            programs[i].interval_ns = DEFAULT_INTERVAL_NS;
+    }
+
+    int64_t common_ticktime = programs[0].interval_ns;
+    for (size_t i = 1; i < program_count; ++i) {
+        common_ticktime = repl_gcd(common_ticktime, programs[i].interval_ns);
+    }
+
     // Set up isocline
     ic_set_history(".strucpp_history", 200);
     ic_enable_auto_tab(true);
@@ -557,6 +579,20 @@ inline void repl_run(ProgramDescriptor* programs, size_t program_count,
         ic_printf(" [b]%s[/][gray](%zu vars)[/]", programs[i].name, programs[i].var_count);
     }
     ic_println("");
+    // Show cycle time info
+    {
+        double tick_ms = static_cast<double>(common_ticktime) / 1000000.0;
+        ic_printf("[gray]Cycle:[/] %.3gms", tick_ms);
+        if (program_count > 1) {
+            ic_print(" [gray](tasks:[/]");
+            for (size_t i = 0; i < program_count; ++i) {
+                double int_ms = static_cast<double>(programs[i].interval_ns) / 1000000.0;
+                ic_printf(" %.3gms", int_ms);
+            }
+            ic_print("[gray])[/]");
+        }
+        ic_println("");
+    }
     if (!source_lines.empty()) {
         ic_printf("[gray]Source:[/] %zu lines loaded\n", source_lines.size());
     }
@@ -642,8 +678,12 @@ inline void repl_run(ProgramDescriptor* programs, size_t program_count,
                 if (n < 1) n = 1;
             }
             for (int c = 0; c < n; ++c) {
+                __CURRENT_TIME_NS += common_ticktime;
                 for (size_t i = 0; i < program_count; ++i) {
-                    programs[i].instance->run();
+                    int64_t divisor = programs[i].interval_ns / common_ticktime;
+                    if (divisor <= 0 || (cycle_count % static_cast<unsigned long long>(divisor)) == 0) {
+                        programs[i].instance->run();
+                    }
                 }
                 cycle_count++;
             }

--- a/src/runtime/test/iec_test.hpp
+++ b/src/runtime/test/iec_test.hpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
+#include <cstdint>
 #include <exception>
 #include <vector>
 #include <functional>
@@ -18,6 +19,9 @@
 #include <sstream>
 
 namespace strucpp {
+
+// Forward declaration of scan-cycle time global (defined in iec_std_lib.hpp)
+extern int64_t __CURRENT_TIME_NS;
 
 // ============================================================================
 // Value formatting
@@ -250,6 +254,7 @@ public:
         for (auto& tc : tests_) {
             TestContext ctx;
             ctx.test_file = test_file_;
+            __CURRENT_TIME_NS = 0;  // Reset scan-cycle time for each test
             try {
                 bool result = tc.func(ctx);
                 if (result && ctx.failures == 0) {

--- a/src/testing/test-model.ts
+++ b/src/testing/test-model.ts
@@ -13,6 +13,7 @@ export type {
   TeardownBlock,
   TestCase,
   AssertCall,
+  AdvanceTimeStatement,
   MockFBStatement,
   MockFunctionStatement,
   MockVerifyCalledStatement,

--- a/tests/backend/repl-main-gen.test.ts
+++ b/tests/backend/repl-main-gen.test.ts
@@ -156,7 +156,7 @@ describe('Phase 3.6 - REPL Main Generator', () => {
 
       expect(mainCpp).toContain('Program_EMPTY');
       expect(mainCpp).toContain('prog_EMPTY_vars = nullptr');
-      expect(mainCpp).toContain('"EMPTY", &prog_EMPTY, prog_EMPTY_vars, 0');
+      expect(mainCpp).toContain('"EMPTY", &prog_EMPTY, prog_EMPTY_vars, 0, 0LL');
     });
 
     it('should include VAR_INPUT and VAR_OUTPUT but skip VAR_EXTERNAL', () => {

--- a/tests/st-validation/standard_fbs/test_timers.st
+++ b/tests/st-validation/standard_fbs/test_timers.st
@@ -15,3 +15,93 @@ TEST 'TP initial state Q=FALSE'
   t(IN := FALSE, PT := T#1s);
   ASSERT_FALSE(t.Q);
 END_TEST
+
+TEST 'TON does not fire before PT elapsed'
+  VAR t : TON; END_VAR
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ASSERT_FALSE(t.Q);
+  ASSERT_EQ(t.ET, T#80ms);
+END_TEST
+
+TEST 'TON fires exactly at PT'
+  VAR t : TON; END_VAR
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ASSERT_TRUE(t.Q);
+  ASSERT_EQ(t.ET, T#100ms);
+END_TEST
+
+TEST 'TON resets when IN goes FALSE'
+  VAR t : TON; END_VAR
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  (* Reset *)
+  t(IN := FALSE, PT := T#100ms);
+  ASSERT_FALSE(t.Q);
+  ASSERT_EQ(t.ET, T#0s);
+END_TEST
+
+TEST 'TON multiple calls same cycle do not advance'
+  VAR t : TON; END_VAR
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#100ms);
+  t(IN := TRUE, PT := T#100ms);
+  t(IN := TRUE, PT := T#100ms);
+  (* All three calls see same TIME(), so ET should be 0ms *)
+  ASSERT_EQ(t.ET, T#0ms);
+  ASSERT_FALSE(t.Q);
+END_TEST
+
+TEST 'TOF holds Q after IN drops'
+  VAR t : TOF; END_VAR
+  t(IN := TRUE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ASSERT_TRUE(t.Q);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ASSERT_TRUE(t.Q);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := FALSE, PT := T#100ms);
+  ASSERT_FALSE(t.Q);
+END_TEST
+
+TEST 'TP generates pulse for PT duration'
+  VAR t : TP; END_VAR
+  t(IN := TRUE, PT := T#60ms);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#60ms);
+  ASSERT_TRUE(t.Q);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#60ms);
+  ASSERT_TRUE(t.Q);
+  ADVANCE_TIME(T#20ms);
+  t(IN := TRUE, PT := T#60ms);
+  ASSERT_FALSE(t.Q);
+END_TEST


### PR DESCRIPTION
## Summary

- Replace wall-clock `TIME()` with scan-cycle-based `__CURRENT_TIME_NS` global, matching the MatIEC/CODESYS model where all calls to `TIME()` within the same cycle return the same value
- Add GCD-based common tick time and task-gated execution to the REPL, so multi-rate tasks execute at correct intervals
- Add `ADVANCE_TIME(duration)` test framework statement for deterministic timer testing
- Full compiler pipeline: lexer token → parser rule → AST node → AST builder → test codegen

## Test plan

- [x] All 870 core tests pass (unit, integration, C++ compile, REPL runner, test runner, mock runner)
- [x] 9 timer validation tests pass (3 original + 6 new ADVANCE_TIME-based: TON fire/reset/same-cycle, TOF hold, TP pulse)
- [x] REPL main generator tests updated for new `ProgramDescriptor` format with `interval_ns`
- [x] Pre-existing OSCAT failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)