### PR TITLE
feat: Deep struct forcing — per-field IECVar wrapping

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -388,12 +388,12 @@ export class CodeGenerator {
     let baseType: string;
 
     // Handle inline array types with dimension info
-    // Use raw C++ types (INT_t, BOOL_t) for array elements, not IEC_* (IECVar<>)
-    // because Array1D internally wraps elements in IECVar<T> already
+    // Array1D stores T directly — use IECVar-wrapped types for elementary elements
+    // and bare names for composites (whose fields already contain IECVar leaves)
     if (typeRef.arrayDimensions && typeRef.elementTypeName) {
       const elemCpp = this.isUserDefinedType(typeRef.elementTypeName)
         ? typeRef.elementTypeName
-        : this.typeCodeGen.mapTypeToCpp(typeRef.elementTypeName);
+        : this.mapVarTypeToCpp(typeRef.elementTypeName);
       baseType = formatArrayType(elemCpp, typeRef.arrayDimensions);
     } else {
       baseType = this.mapVarTypeToCpp(
@@ -2679,7 +2679,6 @@ export class CodeGenerator {
     baseNameUpper: string,
   ): string {
     let result = base;
-    let prevKind: "field" | "subscript" | "dereference" | "base" = "base";
     let currentType = this.currentScopeVarTypes.get(baseNameUpper);
 
     for (let i = 0; i < chain.length; i++) {
@@ -2691,18 +2690,13 @@ export class CodeGenerator {
           // Bit access: numeric field like .0, .15, .31
           if (/^\d+$/.test(step.name)) {
             result = `((static_cast<uint64_t>(${result}) >> ${step.name}) & 1)`;
-            prevKind = "field";
             continue;
           }
           // Property access on the last step
           if (isLast) {
             const propName = this.resolvePropertyName(currentType, step.name);
             if (propName) {
-              const accessor =
-                prevKind === "subscript"
-                  ? `->${`get_${propName}`}()`
-                  : `.get_${propName}()`;
-              result += accessor;
+              result += `.get_${propName}()`;
               return result;
             }
           }
@@ -2710,14 +2704,9 @@ export class CodeGenerator {
           const fieldCppName = this.needsFieldMangling(step.name, fieldType)
             ? `${step.name}_`
             : step.name;
-          // After subscript, use -> to access members of IECVar<struct>
-          if (prevKind === "subscript") {
-            result += `->${fieldCppName}`;
-          } else {
-            result += `.${fieldCppName}`;
-          }
+          // Array elements store T directly — always use . for field access
+          result += `.${fieldCppName}`;
           currentType = fieldType;
-          prevKind = "field";
           break;
         }
         case "subscript": {
@@ -2729,12 +2718,10 @@ export class CodeGenerator {
           } else if (step.indices.length === 1) {
             result += `[${this.generateExpression(step.indices[0]!)}]`;
           }
-          prevKind = "subscript";
           break;
         }
         case "dereference": {
           result = `(*${result})`;
-          prevKind = "dereference";
           break;
         }
       }

--- a/src/backend/type-codegen.ts
+++ b/src/backend/type-codegen.ts
@@ -73,11 +73,47 @@ const IEC_TO_CPP_TYPE: Record<string, string> = {
 };
 
 /**
+ * Map IEC elementary type names to their IECVar-wrapped C++ type names.
+ * Used for struct fields and array elements that need per-element forcing.
+ */
+const IEC_TO_CPP_VAR_TYPE: Record<string, string> = {
+  BOOL: "IEC_BOOL",
+  BYTE: "IEC_BYTE",
+  WORD: "IEC_WORD",
+  DWORD: "IEC_DWORD",
+  LWORD: "IEC_LWORD",
+  SINT: "IEC_SINT",
+  INT: "IEC_INT",
+  DINT: "IEC_DINT",
+  LINT: "IEC_LINT",
+  USINT: "IEC_USINT",
+  UINT: "IEC_UINT",
+  UDINT: "IEC_UDINT",
+  ULINT: "IEC_ULINT",
+  REAL: "IEC_REAL",
+  LREAL: "IEC_LREAL",
+  TIME: "IEC_TIME",
+  DATE: "IEC_DATE",
+  TIME_OF_DAY: "IEC_TOD",
+  TOD: "IEC_TOD",
+  DATE_AND_TIME: "IEC_DT",
+  DT: "IEC_DT",
+  LTIME: "IEC_LTIME",
+  LDATE: "IEC_LDATE",
+  LTOD: "IEC_LTOD",
+  LDT: "IEC_LDT",
+  CHAR: "IEC_CHAR",
+  WCHAR: "IEC_WCHAR",
+};
+
+/**
  * Type Code Generator for user-defined types
  */
 export class TypeCodeGenerator {
   private options: TypeCodeGenOptions;
   private output: string[] = [];
+  /** Track known enum type names (uppercase) so struct fields can use IEC_ wrapper */
+  private knownEnumNames: Set<string> = new Set();
 
   constructor(options: Partial<TypeCodeGenOptions> = {}) {
     this.options = { ...defaultTypeCodeGenOptions, ...options };
@@ -99,6 +135,7 @@ export class TypeCodeGenerator {
    */
   generateTypes(types: TypeDeclaration[]): string {
     this.output = [];
+    this.knownEnumNames = new Set();
 
     if (types.length === 0) {
       return "";
@@ -123,11 +160,12 @@ export class TypeCodeGenerator {
     switch (def.kind) {
       case "StructDefinition":
         this.generateStructType(type.name, def);
-        // Generate IEC_ wrapper for struct variables
-        this.emit(`using IEC_${type.name} = IECVar<${type.name}>;`);
+        // Struct fields already contain IECVar leaves — identity alias
+        this.emit(`using IEC_${type.name} = ${type.name};`);
         this.emit("");
         break;
       case "EnumDefinition":
+        this.knownEnumNames.add(type.name.toUpperCase());
         this.generateEnumType(type.name, def);
         // Generate IEC_ wrapper for enum variables using IEC_ENUM
         this.emit(`using IEC_${type.name} = IEC_ENUM<${type.name}>;`);
@@ -135,8 +173,8 @@ export class TypeCodeGenerator {
         break;
       case "ArrayDefinition":
         this.generateArrayType(type.name, def);
-        // Generate IEC_ wrapper for array variables
-        this.emit(`using IEC_${type.name} = IECVar<${type.name}>;`);
+        // Array elements already contain IECVar leaves — identity alias
+        this.emit(`using IEC_${type.name} = ${type.name};`);
         this.emit("");
         break;
       case "SubrangeDefinition":
@@ -206,11 +244,16 @@ export class TypeCodeGenerator {
     for (const field of def.fields) {
       let cppType: string;
       if (field.type.arrayDimensions && field.type.elementTypeName) {
-        // Inline array type: emit Array1D/2D/3D<ElementType, bounds...>
-        const elemCpp = this.mapTypeToCpp(field.type.elementTypeName);
+        // Inline array type: emit Array1D/2D/3D<WrappedElementType, bounds...>
+        const elemCpp = this.mapStructFieldTypeToCpp(
+          field.type.elementTypeName,
+        );
         cppType = formatArrayType(elemCpp, field.type.arrayDimensions);
       } else {
-        cppType = this.mapTypeToCpp(field.type.name);
+        cppType = this.mapStructFieldTypeToCpp(
+          field.type.name,
+          field.type.maxLength,
+        );
       }
       if (field.type.referenceKind === "pointer_to") {
         cppType += "*";
@@ -298,7 +341,7 @@ export class TypeCodeGenerator {
    * IEC 61131-3 array semantics (arrays can have arbitrary start indices).
    */
   private generateArrayType(name: string, def: ArrayDefinition): void {
-    const elementType = this.mapTypeToCpp(def.elementType.name);
+    const elementType = this.mapStructFieldTypeToCpp(def.elementType.name);
     const numDims = def.dimensions.length;
 
     // Collect bounds for all dimensions (skip variable-length dimensions)
@@ -383,7 +426,7 @@ export class TypeCodeGenerator {
   }
 
   /**
-   * Map an IEC type name to its C++ equivalent
+   * Map an IEC type name to its C++ equivalent (raw/unwrapped)
    */
   mapTypeToCpp(typeName: string): string {
     const upperName = typeName.toUpperCase();
@@ -392,6 +435,42 @@ export class TypeCodeGenerator {
       return IEC_TO_CPP_TYPE[upperName] ?? `${upperName}_t`;
     }
 
+    return typeName;
+  }
+
+  /**
+   * Map a type name to its IECVar-wrapped C++ equivalent for struct fields
+   * and array elements. Wraps elementary types with IECVar for per-field forcing.
+   * Composites (structs, arrays, FBs) use bare names since their fields
+   * already contain IECVar leaves.
+   */
+  mapStructFieldTypeToCpp(
+    typeName: string,
+    maxLength?: number | string,
+  ): string {
+    const upperName = typeName.toUpperCase();
+
+    // STRING/WSTRING with optional length → IECStringVar/IECWStringVar (forceable)
+    if (upperName === "STRING") {
+      const len = maxLength ?? 254;
+      return `IECStringVar<${len}>`;
+    }
+    if (upperName === "WSTRING") {
+      const len = maxLength ?? 254;
+      return `IECWStringVar<${len}>`;
+    }
+
+    // Elementary types → IEC_<TYPE> (IECVar-wrapped)
+    if (isElementaryType(upperName)) {
+      return IEC_TO_CPP_VAR_TYPE[upperName] ?? `IEC_${upperName}`;
+    }
+
+    // Enum types → IEC_<Name> (resolves to IEC_ENUM<Name> via alias)
+    if (this.knownEnumNames.has(upperName)) {
+      return `IEC_${typeName}`;
+    }
+
+    // Composite types (struct, array, FB) → bare name
     return typeName;
   }
 

--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -28,17 +28,18 @@ struct ArrayBounds {
 };
 
 // Single-dimensional array
-// Elements are IECVar<T> to support individual element forcing
+// T is stored directly — caller controls wrapping (IECVar<INT_t> for elementary,
+// bare StructName for composites whose fields already contain IECVar leaves).
 template<typename T, typename Bounds>
 class IEC_ARRAY_1D {
 public:
     using element_type = T;
     using bounds_type = Bounds;
-    using var_type = IECVar<T>;
+    using var_type = T;
     static constexpr size_t size = Bounds::size;
-    
+
 private:
-    std::array<var_type, size> data_;
+    std::array<T, size> data_;
     
     // Convert IEC 1-based index to 0-based internal index
     static constexpr size_t to_internal_index(int64_t index) noexcept {
@@ -50,11 +51,12 @@ public:
     IEC_ARRAY_1D() noexcept : data_{} {}
     
     // Initializer list constructor
-    IEC_ARRAY_1D(std::initializer_list<T> init) noexcept : data_{} {
+    template<typename U>
+    IEC_ARRAY_1D(std::initializer_list<U> init) noexcept : data_{} {
         size_t i = 0;
         for (const auto& val : init) {
             if (i >= size) break;
-            data_[i].set(val);
+            data_[i] = val;
             ++i;
         }
     }
@@ -106,13 +108,13 @@ template<typename T, typename Bounds1, typename Bounds2>
 class IEC_ARRAY_2D {
 public:
     using element_type = T;
-    using var_type = IECVar<T>;
+    using var_type = T;
     static constexpr size_t rows = Bounds1::size;
     static constexpr size_t cols = Bounds2::size;
     static constexpr size_t total_size = rows * cols;
-    
+
 private:
-    std::array<var_type, total_size> data_;
+    std::array<T, total_size> data_;
     
     // Convert 2D IEC indices to linear internal index
     static constexpr size_t to_linear_index(int64_t i, int64_t j) noexcept {
@@ -170,14 +172,14 @@ template<typename T, typename Bounds1, typename Bounds2, typename Bounds3>
 class IEC_ARRAY_3D {
 public:
     using element_type = T;
-    using var_type = IECVar<T>;
+    using var_type = T;
     static constexpr size_t dim1 = Bounds1::size;
     static constexpr size_t dim2 = Bounds2::size;
     static constexpr size_t dim3 = Bounds3::size;
     static constexpr size_t total_size = dim1 * dim2 * dim3;
-    
+
 private:
-    std::array<var_type, total_size> data_;
+    std::array<T, total_size> data_;
     
     static constexpr size_t to_linear_index(int64_t i, int64_t j, int64_t k) noexcept {
         return static_cast<size_t>(
@@ -227,7 +229,7 @@ using Array3D = IEC_ARRAY_3D<T, ArrayBounds<L1, U1>, ArrayBounds<L2, U2>, ArrayB
 // 1D ArrayView - type-erased wrapper for ARRAY[*] OF T
 template<typename T>
 class ArrayView1D {
-    IECVar<T>* data_;
+    T* data_;
     int64_t lower_;
     int64_t upper_;
 
@@ -239,11 +241,11 @@ public:
         , lower_(Bounds::lower)
         , upper_(Bounds::upper) {}
 
-    IECVar<T>& operator[](int64_t index) noexcept {
+    T& operator[](int64_t index) noexcept {
         return data_[index - lower_];
     }
 
-    const IECVar<T>& operator[](int64_t index) const noexcept {
+    const T& operator[](int64_t index) const noexcept {
         return data_[index - lower_];
     }
 
@@ -255,7 +257,7 @@ public:
 // 2D ArrayView - type-erased wrapper for ARRAY[*, *] OF T
 template<typename T>
 class ArrayView2D {
-    IECVar<T>* data_;
+    T* data_;
     int64_t lower1_, upper1_;
     int64_t lower2_, upper2_;
     int64_t dim2_;
@@ -268,11 +270,11 @@ public:
         , lower2_(Bounds2::lower), upper2_(Bounds2::upper)
         , dim2_(Bounds2::upper - Bounds2::lower + 1) {}
 
-    IECVar<T>& operator()(int64_t i, int64_t j) noexcept {
+    T& operator()(int64_t i, int64_t j) noexcept {
         return data_[(i - lower1_) * dim2_ + (j - lower2_)];
     }
 
-    const IECVar<T>& operator()(int64_t i, int64_t j) const noexcept {
+    const T& operator()(int64_t i, int64_t j) const noexcept {
         return data_[(i - lower1_) * dim2_ + (j - lower2_)];
     }
 

--- a/src/runtime/include/iec_var.hpp
+++ b/src/runtime/include/iec_var.hpp
@@ -50,6 +50,15 @@ public:
     /** Construct with initial value (non-explicit to allow IEC_INT val = 10 syntax) */
     IECVar(T v) noexcept : value_{v}, forced_{false}, forced_value_{} {}
 
+    /** Cross-type converting constructor: IECVar<SINT_t> → IECVar<INT_t> etc.
+     *  Enables implicit widening when struct fields (now IECVar-wrapped) are passed
+     *  to functions expecting a wider IECVar type. Without this, C++ would need
+     *  two user-defined conversions (IECVar<U>→U→T→IECVar<T>) which is disallowed. */
+    template<typename U, std::enable_if_t<
+        std::is_convertible_v<U, T> && !std::is_same_v<U, T>, int> = 0>
+    IECVar(const IECVar<U>& other) noexcept
+        : value_{static_cast<T>(other.get())}, forced_{false}, forced_value_{} {}
+
     /** Copy constructor */
     IECVar(const IECVar&) = default;
 
@@ -160,6 +169,17 @@ public:
     /** Assignment from raw value */
     IECVar& operator=(T v) noexcept {
         set(v);
+        return *this;
+    }
+
+    /** Cross-type assignment: IECVar<SINT_t> → IECVar<INT_t> etc.
+     *  Resolves ambiguity when assigning between different IECVar specializations
+     *  by providing a direct match (template is preferred over two indirect paths
+     *  that each require one user-defined conversion). */
+    template<typename U, std::enable_if_t<
+        std::is_convertible_v<U, T> && !std::is_same_v<U, T>, int> = 0>
+    IECVar& operator=(const IECVar<U>& other) noexcept {
+        set(static_cast<T>(other.get()));
         return *this;
     }
 

--- a/tests/backend/codegen-composite.test.ts
+++ b/tests/backend/codegen-composite.test.ts
@@ -248,8 +248,8 @@ describe("Phase 3.3: Combined Array/Struct Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("POINTS[1]->X = 100;");
-    expect(result.cppCode).toContain("POINTS[I]->Y = 200;");
+    expect(result.cppCode).toContain("POINTS[1].X = 100;");
+    expect(result.cppCode).toContain("POINTS[I].Y = 200;");
   });
 
   it("should generate array of struct access in loop", () => {
@@ -273,8 +273,8 @@ describe("Phase 3.3: Combined Array/Struct Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("POINTS[I]->X = I;");
-    expect(result.cppCode).toContain("POINTS[I]->Y = I * 2;");
+    expect(result.cppCode).toContain("POINTS[I].X = I;");
+    expect(result.cppCode).toContain("POINTS[I].Y = I * 2;");
   });
 });
 
@@ -357,7 +357,7 @@ describe("Phase 3.3: Validation Examples", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("POINTS[I]->X = I;");
-    expect(result.cppCode).toContain("POINTS[I]->Y = I * 2;");
+    expect(result.cppCode).toContain("POINTS[I].X = I;");
+    expect(result.cppCode).toContain("POINTS[I].Y = I * 2;");
   });
 });

--- a/tests/backend/codegen-vla.test.ts
+++ b/tests/backend/codegen-vla.test.ts
@@ -197,7 +197,7 @@ describe("Phase 3.4: Fixed Array Type Declarations Still Work", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.headerCode).toContain("Array1D<INT_t, 0, 4>");
+    expect(result.headerCode).toContain("Array1D<IEC_INT, 0, 4>");
     expect(result.cppCode).toContain("ARR[0] = 1;");
   });
 
@@ -214,7 +214,7 @@ describe("Phase 3.4: Fixed Array Type Declarations Still Work", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.headerCode).toContain("Array2D<REAL_t, 1, 3, 1, 3>");
+    expect(result.headerCode).toContain("Array2D<IEC_REAL, 1, 3, 1, 3>");
   });
 });
 

--- a/tests/backend/type-codegen.test.ts
+++ b/tests/backend/type-codegen.test.ts
@@ -127,8 +127,8 @@ describe('TypeCodeGenerator', () => {
 
       const result = generator.generateTypes([type]);
       expect(result).toContain('struct Point {');
-      expect(result).toContain('INT_t x');
-      expect(result).toContain('REAL_t y');
+      expect(result).toContain('IEC_INT x');
+      expect(result).toContain('IEC_REAL y');
       expect(result).toContain('};');
     });
 
@@ -199,8 +199,8 @@ describe('TypeCodeGenerator', () => {
       };
 
       const result = generator.generateTypes([type]);
-      // Uses Array1D with preserved bounds (0..9)
-      expect(result).toContain('using IntArray = Array1D<INT_t, 0, 9>;');
+      // Uses Array1D with preserved bounds (0..9), element type is IECVar-wrapped
+      expect(result).toContain('using IntArray = Array1D<IEC_INT, 0, 9>;');
     });
 
     it('should generate multi-dimensional array type', () => {
@@ -219,8 +219,8 @@ describe('TypeCodeGenerator', () => {
       };
 
       const result = generator.generateTypes([type]);
-      // Uses Array2D with preserved bounds for both dimensions
-      expect(result).toContain('using Matrix = Array2D<REAL_t, 0, 2, 0, 2>;');
+      // Uses Array2D with preserved bounds for both dimensions, element type is IECVar-wrapped
+      expect(result).toContain('using Matrix = Array2D<IEC_REAL, 0, 2, 0, 2>;');
     });
 
     it('should generate non-zero-based array type', () => {
@@ -239,8 +239,8 @@ describe('TypeCodeGenerator', () => {
       };
 
       const result = generator.generateTypes([type]);
-      // Uses Array1D with preserved non-zero bounds (3..7)
-      expect(result).toContain('using OffsetArray = Array1D<INT_t, 3, 7>;');
+      // Uses Array1D with preserved non-zero bounds (3..7), element type is IECVar-wrapped
+      expect(result).toContain('using OffsetArray = Array1D<IEC_INT, 3, 7>;');
     });
 
     it('should generate subrange type', () => {

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -136,7 +136,7 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // Verify the generated code uses Array1D with correct bounds
-    expect(result.headerCode).toContain('Array1D<INT_t, 3, 7>');
+    expect(result.headerCode).toContain('Array1D<IEC_INT, 3, 7>');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'offset_array');
     expect(cppResult.success).toBe(true);
@@ -156,7 +156,7 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // Verify the generated code uses Array1D with 1-based bounds
-    expect(result.headerCode).toContain('Array1D<REAL_t, 1, 10>');
+    expect(result.headerCode).toContain('Array1D<IEC_REAL, 1, 10>');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'one_based_array');
     expect(cppResult.success).toBe(true);
@@ -176,7 +176,7 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // Verify the generated code uses Array2D with correct bounds
-    expect(result.headerCode).toContain('Array2D<DINT_t, 1, 3, 5, 8>');
+    expect(result.headerCode).toContain('Array2D<IEC_DINT, 1, 3, 5, 8>');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'offset_matrix');
     expect(cppResult.success).toBe(true);
@@ -196,7 +196,7 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // Verify the generated code uses Array3D with correct bounds
-    expect(result.headerCode).toContain('Array3D<SINT_t, 1, 2, 3, 5, 10, 12>');
+    expect(result.headerCode).toContain('Array3D<IEC_SINT, 1, 2, 3, 5, 10, 12>');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'cube_3d');
     expect(cppResult.success).toBe(true);


### PR DESCRIPTION
## Summary
- Push `IECVar` wrapping down to elementary leaf fields in structs so individual fields (e.g., `point.x`, `point.y`) can be forced from a debugger
- Array templates (`Array1D`/`2D`/`3D`) now store `T` directly — caller controls wrapping (`IEC_INT` for elementary, bare `StructName` for composites)
- Add cross-type converting constructor and assignment to `IECVar` to handle implicit widening between wrapped types (e.g., `IECVar<SINT_t>` → `IECVar<INT_t>`)

## Changes

**Runtime (`src/runtime/include/`)**
- `iec_array.hpp`: Store `T` directly instead of `IECVar<T>`; update `ArrayView1D`/`ArrayView2D` accordingly
- `iec_var.hpp`: Cross-type converting constructor + assignment operator for implicit widening

**Code generation (`src/backend/`)**
- `type-codegen.ts`: New `mapStructFieldTypeToCpp()` wraps elementary fields with `IEC_` prefix; struct/array `IEC_` aliases become identity (`using IEC_Point = Point;`)
- `codegen.ts`: Inline array elements use wrapped types; access chain uses `.` instead of `->` after subscript

## Test plan
- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm test` — all 1231 tests pass (46/46 test files)
- [x] OSCAT g++ compilation — 554 files transpile, g++ compile+link with 0 errors, 164 FB instantiation tests pass
- [x] C++ integration tests — all 36 g++ compile tests pass
- [x] Updated assertions in `codegen-composite`, `codegen-vla`, `type-codegen`, `cpp-compile` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)