### PR TITLE
fix: replace dist/ with src/ in test imports (#71)

### DIFF
--- a/tests/backend/codegen-composite.test.ts
+++ b/tests/backend/codegen-composite.test.ts
@@ -12,9 +12,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
-function compileST(source: string): { cppCode: string; headerCode: string; success: boolean; errors: unknown[] } {
+function compileST(source: string): {
+  cppCode: string;
+  headerCode: string;
+  success: boolean;
+  errors: unknown[];
+} {
   const result = compile(source);
   return {
     cppCode: result.cppCode,

--- a/tests/backend/codegen-control-flow.test.ts
+++ b/tests/backend/codegen-control-flow.test.ts
@@ -12,9 +12,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
-function compileST(source: string): { cppCode: string; headerCode: string; success: boolean; errors: unknown[] } {
+function compileST(source: string): {
+  cppCode: string;
+  headerCode: string;
+  success: boolean;
+  errors: unknown[];
+} {
   const result = compile(source);
   return {
     cppCode: result.cppCode,
@@ -226,7 +231,6 @@ describe("Phase 3.2: CASE Statement Code Generation", () => {
     expect(result.cppCode).toContain("case 89:");
     expect(result.cppCode).toContain("default:");
   });
-
 
   it("should generate CASE with enum dot-notation labels using ::", () => {
     const result = compileST(`
@@ -684,7 +688,7 @@ describe("Phase 3.2: Complex Control Flow", () => {
     const nsEnd = progSection.indexOf("}  // namespace");
     const funcSection = nsEnd > 0 ? progSection.slice(0, nsEnd) : progSection;
     const lines = funcSection.split("\n");
-    const elseLines = lines.filter(l => l.trim() === "} else {");
+    const elseLines = lines.filter((l) => l.trim() === "} else {");
     expect(elseLines.length).toBe(0);
   });
 

--- a/tests/backend/codegen-dynamic-memory.test.ts
+++ b/tests/backend/codegen-dynamic-memory.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): {
   cppCode: string;
@@ -215,7 +215,8 @@ describe("Phase 3.5: Combined __NEW/__DELETE Usage", () => {
     expect(result.success).toBe(true);
     // Should have two iec_new calls and two iec_delete calls
     const newCount = (result.cppCode.match(/strucpp::iec_new</g) || []).length;
-    const deleteCount = (result.cppCode.match(/strucpp::iec_delete/g) || []).length;
+    const deleteCount = (result.cppCode.match(/strucpp::iec_delete/g) || [])
+      .length;
     expect(newCount).toBe(2);
     expect(deleteCount).toBe(2);
   });

--- a/tests/backend/codegen-fb.test.ts
+++ b/tests/backend/codegen-fb.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileAndCheck(source: string) {
   const result = compile(source);

--- a/tests/backend/codegen-oop.test.ts
+++ b/tests/backend/codegen-oop.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileAndCheck(source: string) {
   const result = compile(source);
@@ -229,9 +229,7 @@ describe("Codegen - OOP Features (Phase 5.2)", () => {
         PROGRAM Main END_PROGRAM
       `);
 
-      expect(result.headerCode).toContain(
-        "class WORKER : public IRUNNABLE {",
-      );
+      expect(result.headerCode).toContain("class WORKER : public IRUNNABLE {");
     });
   });
 
@@ -368,7 +366,10 @@ describe("Codegen - OOP Features (Phase 5.2)", () => {
       const childSection = result.cppCode.slice(
         result.cppCode.indexOf("void CHILD::operator()()"),
       );
-      const childBody = childSection.slice(0, childSection.indexOf("\n}\n") + 3);
+      const childBody = childSection.slice(
+        0,
+        childSection.indexOf("\n}\n") + 3,
+      );
       expect(childBody).not.toContain("BASE::operator()()");
     });
   });

--- a/tests/backend/codegen-vla.test.ts
+++ b/tests/backend/codegen-vla.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): {
   cppCode: string;

--- a/tests/backend/test-main-gen.test.ts
+++ b/tests/backend/test-main-gen.test.ts
@@ -5,9 +5,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { generateTestMain } from "../../dist/backend/test-main-gen.js";
-import type { POUInfo } from "../../dist/backend/test-main-gen.js";
-import type { TestFile } from "../../dist/testing/test-model.js";
+import { generateTestMain } from "../../src/backend/test-main-gen.js";
+import type { POUInfo } from "../../src/backend/test-main-gen.js";
+import type { TestFile } from "../../src/testing/test-model.js";
 
 /** Helper to create a basic POUInfo for a program */
 function programPOU(name: string, vars: Record<string, string> = {}): POUInfo {
@@ -28,7 +28,13 @@ function makeTestFile(
 }
 
 /** Default source span */
-const span = { file: "test.st", startLine: 1, endLine: 1, startCol: 1, endCol: 1 };
+const span = {
+  file: "test.st",
+  startLine: 1,
+  endLine: 1,
+  startCol: 1,
+  endCol: 1,
+};
 
 describe("Test Main Generator", () => {
   describe("basic generation", () => {

--- a/tests/library/codesys-import.test.ts
+++ b/tests/library/codesys-import.test.ts
@@ -16,16 +16,13 @@ import {
   readLEB128,
   formatPOU,
   pouToSources,
-} from "../../dist/library/codesys-import/index.js";
-import type { ExtractedPOU } from "../../dist/library/codesys-import/index.js";
+} from "../../src/library/codesys-import/index.js";
+import type { ExtractedPOU } from "../../src/library/codesys-import/index.js";
 
 // Path to CODESYS library fixtures checked into the repository
 const FIXTURES_DIR = resolve(__dirname, "../fixtures/codesys");
 const OSCAT_V23_PATH = resolve(FIXTURES_DIR, "oscat_basic_335.lib");
-const OSCAT_V3_PATH = resolve(
-  FIXTURES_DIR,
-  "oscat_basic_335_codesys3.library",
-);
+const OSCAT_V3_PATH = resolve(FIXTURES_DIR, "oscat_basic_335_codesys3.library");
 const V23_REFERENCE_DIR = resolve(FIXTURES_DIR, "v23-reference");
 
 describe("detectFormat", () => {


### PR DESCRIPTION
Closes #71

## Summary

- 8 test files imported from `dist/` causing tests to silently validate stale compiled output instead of current source
- Replace `dist/` with `src/` in all import paths; Vitest's Vite pipeline transpiles `.ts` on-the-fly so `dist/` is never needed
- `cli-library.test.ts` left unchanged — it invokes `dist/cli.js` as a subprocess which correctly requires a built binary

## Testing

`npm test`: 51 test files passed, 1414 tests passed, 7 skipped — no regressions