### PR TITLE
fix: AVR/Arduino compatibility for C++ standard library headers

### DIFF
--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -12,8 +12,9 @@
 
 #pragma once
 
+#include "iec_platform.hpp"
+
 #include <array>
-#include <cstdint>
 #include <stdexcept>
 #include "iec_var.hpp"
 

--- a/src/runtime/include/iec_char.hpp
+++ b/src/runtime/include/iec_char.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include "iec_types.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_date.hpp
+++ b/src/runtime/include/iec_date.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include "iec_types.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_dt.hpp
+++ b/src/runtime/include/iec_dt.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include "iec_types.hpp"
 #include "iec_date.hpp"
 #include "iec_tod.hpp"

--- a/src/runtime/include/iec_enum.hpp
+++ b/src/runtime/include/iec_enum.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include <ostream>
 #include <type_traits>
 #include "iec_var.hpp"

--- a/src/runtime/include/iec_located.hpp
+++ b/src/runtime/include/iec_located.hpp
@@ -15,7 +15,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include <stdexcept>
 
 namespace strucpp {

--- a/src/runtime/include/iec_memory.hpp
+++ b/src/runtime/include/iec_memory.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdlib>
-#include <cstddef>
+#include "iec_platform.hpp"
+
 #include <new>
 #include "iec_ptr.hpp"
 

--- a/src/runtime/include/iec_platform.hpp
+++ b/src/runtime/include/iec_platform.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later WITH STruCpp-runtime-exception
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+// This file is part of the STruC++ Runtime Library and is covered by the
+// STruC++ Runtime Library Exception. See COPYING.RUNTIME for details.
+/**
+ * STruC++ Runtime - Platform Compatibility Header
+ *
+ * AVR (Arduino) toolchains don't ship C++ standard library wrappers like
+ * <cstdint>, <cstring>, etc. This header provides a single compatibility
+ * shim that maps to the correct C headers on AVR and C++ headers elsewhere.
+ *
+ * All other runtime headers should include this instead of <cstdint> etc.
+ */
+
+#pragma once
+
+#if defined(__AVR__) || defined(ARDUINO)
+  // AVR libc provides C headers only, not C++ wrappers
+  #include <stdint.h>
+  #include <stddef.h>
+  #include <string.h>
+  #include <stdlib.h>
+  #include <math.h>
+#else
+  #include <cstdint>
+  #include <cstddef>
+  #include <cstring>
+  #include <cstdlib>
+  #include <cmath>
+#endif

--- a/src/runtime/include/iec_pointer.hpp
+++ b/src/runtime/include/iec_pointer.hpp
@@ -45,7 +45,8 @@
 
 #pragma once
 
-#include <cstddef>
+#include "iec_platform.hpp"
+
 #include <stdexcept>
 #include <string>
 #include "iec_var.hpp"

--- a/src/runtime/include/iec_ptr.hpp
+++ b/src/runtime/include/iec_ptr.hpp
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
+#include "iec_platform.hpp"
+
 #include <type_traits>
 
 namespace strucpp {

--- a/src/runtime/include/iec_retain.hpp
+++ b/src/runtime/include/iec_retain.hpp
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include "iec_platform.hpp"
+
 
 namespace strucpp {
 

--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -20,14 +20,13 @@
 
 #pragma once
 
+#include "iec_platform.hpp"
+
 #include "iec_var.hpp"
 #include "iec_traits.hpp"
 #include "iec_retain.hpp"
 #include "iec_ptr.hpp"
-#include <cmath>
 #include <algorithm>
-#include <cstddef>
-#include <cstring>
 #include <type_traits>
 
 namespace strucpp {

--- a/src/runtime/include/iec_string.hpp
+++ b/src/runtime/include/iec_string.hpp
@@ -12,10 +12,9 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <algorithm>
 #include <type_traits>
 #include "iec_types.hpp"

--- a/src/runtime/include/iec_subrange.hpp
+++ b/src/runtime/include/iec_subrange.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include "iec_var.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_time.hpp
+++ b/src/runtime/include/iec_time.hpp
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cmath>
+#include "iec_platform.hpp"
+
 #include "iec_types.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_tod.hpp
+++ b/src/runtime/include/iec_tod.hpp
@@ -12,7 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
+#include "iec_platform.hpp"
+
 #include "iec_types.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_traits.hpp
+++ b/src/runtime/include/iec_traits.hpp
@@ -12,9 +12,9 @@
 
 #pragma once
 
+#include "iec_platform.hpp"
+
 #include <type_traits>
-#include <cstdint>
-#include <cstddef>
 #include "iec_types.hpp"
 
 namespace strucpp {

--- a/src/runtime/include/iec_types.hpp
+++ b/src/runtime/include/iec_types.hpp
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
+#include "iec_platform.hpp"
+
 
 namespace strucpp {
 

--- a/src/runtime/include/iec_wstring.hpp
+++ b/src/runtime/include/iec_wstring.hpp
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstring>
+#include "iec_platform.hpp"
+
 #include <algorithm>
 #include "iec_types.hpp"
 


### PR DESCRIPTION
Add iec_platform.hpp shim for AVR libc which doesn't have <cstdint> etc.