### PR TITLE
fix: AVR compatibility for runtime headers

### DIFF
--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cstdint>
+#include <initializer_list>
 #ifndef __AVR__
 #include <stdexcept>
 #endif

--- a/src/runtime/include/iec_enum.hpp
+++ b/src/runtime/include/iec_enum.hpp
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <cstdint>
+#ifndef __AVR__
 #include <ostream>
+#endif
 #include <type_traits>
 #include "iec_var.hpp"
 
@@ -213,12 +215,14 @@ public:
 template<typename EnumType>
 using IEC_ENUM = IEC_ENUM_Var<EnumType>;
 
+#ifndef __AVR__
 // Stream output for IEC_ENUM_Var — outputs underlying integer value
 template<typename EnumType>
 inline std::ostream& operator<<(std::ostream& os, const IEC_ENUM_Var<EnumType>& v) {
     return os << static_cast<typename std::underlying_type<EnumType>::type>(
         static_cast<EnumType>(v));
 }
+#endif
 
 /*
  * Example generated enumeration:

--- a/src/runtime/include/iec_located.hpp
+++ b/src/runtime/include/iec_located.hpp
@@ -120,9 +120,11 @@ struct LocatedVar {
     }
 };
 
-// Verify expected layout
-static_assert(sizeof(LocatedVar) == 16, "LocatedVar should be 16 bytes");
-static_assert(alignof(LocatedVar) == 8, "LocatedVar should be 8-byte aligned");
+// Verify expected layout (size varies by platform: 16 bytes on 64-bit, 8 on 32-bit, 6 on AVR)
+#if INTPTR_MAX == INT64_MAX
+static_assert(sizeof(LocatedVar) == 16, "LocatedVar should be 16 bytes on 64-bit");
+static_assert(alignof(LocatedVar) == 8, "LocatedVar should be 8-byte aligned on 64-bit");
+#endif
 
 // =============================================================================
 // Helper Functions for Address Parsing

--- a/src/runtime/include/iec_traits.hpp
+++ b/src/runtime/include/iec_traits.hpp
@@ -382,11 +382,11 @@ template<typename T> struct is_iec_array : std::false_type {};
 template<typename T, typename B>
 struct is_iec_array<IEC_ARRAY_1D<T, B>> : std::true_type {};
 
-template<typename T, typename B1, typename B2>
-struct is_iec_array<IEC_ARRAY_2D<T, B1, B2>> : std::true_type {};
+template<typename T, typename Bnd1, typename Bnd2>
+struct is_iec_array<IEC_ARRAY_2D<T, Bnd1, Bnd2>> : std::true_type {};
 
-template<typename T, typename B1, typename B2, typename B3>
-struct is_iec_array<IEC_ARRAY_3D<T, B1, B2, B3>> : std::true_type {};
+template<typename T, typename Bnd1, typename Bnd2, typename Bnd3>
+struct is_iec_array<IEC_ARRAY_3D<T, Bnd1, Bnd2, Bnd3>> : std::true_type {};
 
 template<typename T>
 inline constexpr bool is_iec_array_v = is_iec_array<T>::value;


### PR DESCRIPTION
## Summary
- Relax LocatedVar static_assert for non-64-bit platforms
- Rename template params to avoid Arduino binary.h macro collisions
- Add explicit initializer_list include for minimal stdlib environments
- Guard ostream usage for platforms without I/O streams

All 1505 tests pass. Non-AVR platforms unchanged.