### PR TITLE
fix(vscode-extension): align LibraryArchiveInfo with chunked StlibArchive

### DIFF
--- a/vscode-extension/client/src/stlib-explorer.ts
+++ b/vscode-extension/client/src/stlib-explorer.ts
@@ -215,8 +215,15 @@ export class StlibExplorer
     }
 
     if (parsed.category === "cpp") {
-      if (parsed.fileName.endsWith(".hpp")) return info.archive.headerCode;
-      if (parsed.fileName.endsWith(".cpp")) return info.archive.cppCode;
+      // Chunks concatenated in array order reproduce the legacy library-wide
+      // headerCode / cppCode blobs byte-for-byte. The library system overhaul
+      // (PR #105) replaced the blob fields with per-symbol chunk slices.
+      if (parsed.fileName.endsWith(".hpp")) {
+        return info.archive.chunks.map((c) => c.header).join("");
+      }
+      if (parsed.fileName.endsWith(".cpp")) {
+        return info.archive.chunks.map((c) => c.cpp).join("");
+      }
     }
 
     return undefined;

--- a/vscode-extension/shared/protocol.ts
+++ b/vscode-extension/shared/protocol.ts
@@ -137,9 +137,14 @@ export interface LibraryArchiveInfo {
         baseType?: string;
       }>;
     };
-    headerCode: string;
-    cppCode: string;
-    sources?: Array<{ fileName: string; source: string }>;
+    chunks: Array<{
+      name: string;
+      kind: "function" | "functionBlock" | "type" | "inlineGlobal";
+      header: string;
+      cpp: string;
+      deps: Array<{ library: string; name: string }>;
+    }>;
+    sources?: Array<{ fileName: string; source: string; category?: string }>;
     dependencies: Array<{ name: string; version: string }>;
   };
 }


### PR DESCRIPTION
## Summary

Hotfix for the v0.4.8 release build that failed in `build-vsix` with:

```
server/src/server.ts(967,3): error TS2322:
  Type '{ filePath: string; archive: StlibArchive; }[]' is not
  assignable to type 'LibraryArchiveInfo[]'.
```

PR #105 retired the legacy `StlibArchive.headerCode` / `cppCode` blob
fields in favor of per-symbol `chunks[]`, but the VSCode extension's
shared protocol type still mirrored the old shape.

## Changes

- `shared/protocol.ts`: replace `headerCode` / `cppCode` on `LibraryArchiveInfo.archive` with `chunks[]`, add optional `category` on source entries.
- `client/src/stlib-explorer.ts`: concatenate chunks in array order when serving `.hpp` / `.cpp` synthetic file content (reproduces the legacy blobs byte-for-byte).

## Test plan

- [x] `tsc -b` clean
- [x] 238 extension unit tests pass
- [ ] CI green (especially `build-vsix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)