### PR TITLE
Release: vscode-extension build fix (v0.4.9)

### DIFF
--- a/vscode-extension/client/src/stlib-explorer.ts
+++ b/vscode-extension/client/src/stlib-explorer.ts
@@ -215,8 +215,15 @@ export class StlibExplorer
     }
 
     if (parsed.category === "cpp") {
-      if (parsed.fileName.endsWith(".hpp")) return info.archive.headerCode;
-      if (parsed.fileName.endsWith(".cpp")) return info.archive.cppCode;
+      // Chunks concatenated in array order reproduce the legacy library-wide
+      // headerCode / cppCode blobs byte-for-byte. The library system overhaul
+      // (PR #105) replaced the blob fields with per-symbol chunk slices.
+      if (parsed.fileName.endsWith(".hpp")) {
+        return info.archive.chunks.map((c) => c.header).join("");
+      }
+      if (parsed.fileName.endsWith(".cpp")) {
+        return info.archive.chunks.map((c) => c.cpp).join("");
+      }
     }
 
     return undefined;

--- a/vscode-extension/shared/protocol.ts
+++ b/vscode-extension/shared/protocol.ts
@@ -137,9 +137,14 @@ export interface LibraryArchiveInfo {
         baseType?: string;
       }>;
     };
-    headerCode: string;
-    cppCode: string;
-    sources?: Array<{ fileName: string; source: string }>;
+    chunks: Array<{
+      name: string;
+      kind: "function" | "functionBlock" | "type" | "inlineGlobal";
+      header: string;
+      cpp: string;
+      deps: Array<{ library: string; name: string }>;
+    }>;
+    sources?: Array<{ fileName: string; source: string; category?: string }>;
     dependencies: Array<{ name: string; version: string }>;
   };
 }


### PR DESCRIPTION
## Summary

Promotes `development` → `main` to ship the v0.4.8 build hotfix as v0.4.9.

## What's included

- **vscode-extension: align LibraryArchiveInfo with chunked StlibArchive** (#107) — the v0.4.8 release build failed in `build-vsix` because the extension's shared protocol type still declared the retired `headerCode` / `cppCode` blob fields. Updated to mirror the new `chunks[]` shape.

## Why v0.4.9 instead of retag v0.4.8

The v0.4.8 tag exists but no GitHub Release was published (the `create-release` job was skipped after `build-vsix` failed). Cutting a fresh v0.4.9 avoids force-tag operations.

## Test plan

- [ ] CI green (especially `build-vsix`)
- [ ] v0.4.9 release artifacts uploaded
- [ ] GitHub Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)