### PR TITLE
fix(ci): compare snippet labels case-insensitively in test-completions-hover

### DIFF
--- a/vscode-extension/tests/unit/test-completions-hover.test.ts
+++ b/vscode-extension/tests/unit/test-completions-hover.test.ts
@@ -80,7 +80,7 @@ describe("test-aware completions", () => {
         1,
         TEST_SOURCE,
       );
-      const labels = items.map((i) => i.label);
+      const labels = items.map((i) => i.label.toUpperCase());
       expect(labels).toContain("TEST");
       expect(labels).toContain("SETUP");
       expect(labels).toContain("TEARDOWN");
@@ -102,7 +102,7 @@ describe("test-aware completions", () => {
         1,
         NORMAL_SOURCE,
       );
-      const labels = items.map((i) => i.label);
+      const labels = items.map((i) => i.label.toUpperCase());
       expect(labels).toContain("PROGRAM");
       expect(labels).not.toContain("SETUP");
       expect(labels).not.toContain("TEARDOWN");


### PR DESCRIPTION
## Summary
- Two assertions in `vscode-extension/tests/unit/test-completions-hover.test.ts` still expected uppercase `TEST` / `PROGRAM` labels after snippet labels were lowercased in 1085afd, which broke CI on `development` and `main`.
- Map labels through `.toUpperCase()` before comparing, matching the `upperLabels` pattern already used in `completion.test.ts`.

## Test plan
- [x] `cd vscode-extension && npx vitest run tests/unit/test-completions-hover.test.ts` — 20/20 pass
- [x] `cd vscode-extension && npx vitest run` — 243/243 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)