### PR TITLE
Merge branch 'development' into main: STruC++ v0.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strucpp",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "IEC 61131-3 Structured Text to C++ Compiler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/vscode-extension/tests/unit/test-completions-hover.test.ts
+++ b/vscode-extension/tests/unit/test-completions-hover.test.ts
@@ -80,7 +80,7 @@ describe("test-aware completions", () => {
         1,
         TEST_SOURCE,
       );
-      const labels = items.map((i) => i.label);
+      const labels = items.map((i) => i.label.toUpperCase());
       expect(labels).toContain("TEST");
       expect(labels).toContain("SETUP");
       expect(labels).toContain("TEARDOWN");
@@ -102,7 +102,7 @@ describe("test-aware completions", () => {
         1,
         NORMAL_SOURCE,
       );
-      const labels = items.map((i) => i.label);
+      const labels = items.map((i) => i.label.toUpperCase());
       expect(labels).toContain("PROGRAM");
       expect(labels).not.toContain("SETUP");
       expect(labels).not.toContain("TEARDOWN");


### PR DESCRIPTION
## Summary
- v0.4.14: CI test snippet case-sensitivity fix
- Picks up #111 (lowercased snippet labels broke `test-completions-hover.test.ts`)

## Test plan
- [x] vscode-extension test suite: 243/243 pass on `development`