### PR TITLE
fix(debug-table): split debug_dispatch.hpp so AVR macros never reach user code

### DIFF
--- a/src/backend/debug-table-gen.ts
+++ b/src/backend/debug-table-gen.ts
@@ -562,7 +562,13 @@ function renderCpp(
   lines.push("// strucpp::debug::handle_*() in debug_dispatch.hpp.");
   lines.push("");
   lines.push('#include "generated.hpp"');
-  lines.push('#include "debug_dispatch.hpp"');
+  // `debug_table.hpp` carries the AVR-clean subset (Entry, TypeTag,
+  // STRUCPP_DEBUG_FLASH).  Including `debug_dispatch.hpp` here would
+  // pull `<avr/pgmspace.h>` → `<avr/io.h>` into the only TU that
+  // names user variables — AVR register macros (`SP`, `SREG`, …)
+  // would then mangle identifiers like PID's `SP` setpoint.  See
+  // runtime/include/debug_table.hpp.
+  lines.push('#include "debug_table.hpp"');
   lines.push("");
   lines.push(
     `// The sketch/runtime must define this global with external linkage:`,

--- a/src/runtime/include/debug_dispatch.hpp
+++ b/src/runtime/include/debug_dispatch.hpp
@@ -19,6 +19,15 @@
 
 #pragma once
 
+// `debug_table.hpp` is the AVR-clean header generated_debug.cpp also
+// includes — it carries the Entry / TypeTag / STRUCPP_DEBUG_FLASH bits
+// shared between the table emitter and the dispatch helpers.  Importing
+// it here (rather than redefining) keeps the ABI definitions in exactly
+// one place.  See debug_table.hpp's preamble for why
+// `<avr/pgmspace.h>` no longer lives in the same TU as user variable
+// references.
+#include "debug_table.hpp"
+
 #include "iec_types.hpp"
 #include "iec_traits.hpp"
 #include "iec_var.hpp"
@@ -26,58 +35,17 @@
 #include <cstddef>
 #include <cstring>
 
-// ---------------------------------------------------------------------------
-// Flash-placement macro for per-project pointer tables.
-// Defined here so generated_debug.cpp stays target-neutral — the runtime
-// header decides the placement attribute.
-// ---------------------------------------------------------------------------
 #ifdef __AVR__
+// `read_entry` and friends use `pgm_read_word_far` / `pgm_read_byte` /
+// `pgm_get_far_address`, which live here.  Only the runtime translation
+// unit (arduino_runtime_glue.cpp / runtime_v4_entry.cpp) ever needs
+// this dispatch header; `generated_debug.cpp` consumes only
+// `debug_table.hpp` so it never sees the AVR register-macro contamination
+// `<avr/io.h>` brings in transitively.
 #include <avr/pgmspace.h>
-#define STRUCPP_DEBUG_FLASH PROGMEM
-#else
-#define STRUCPP_DEBUG_FLASH
 #endif
 
 namespace strucpp { namespace debug {
-
-// ---------------------------------------------------------------------------
-// Type tags. Order is ABI — matches the indices generated into
-// generated_debug.cpp's Entry{.tag} fields, and must match type_ops[] below.
-// ---------------------------------------------------------------------------
-enum TypeTag : uint8_t {
-    TAG_BOOL    = 0,
-    TAG_SINT    = 1,
-    TAG_USINT   = 2,
-    TAG_INT     = 3,
-    TAG_UINT    = 4,
-    TAG_DINT    = 5,
-    TAG_UDINT   = 6,
-    TAG_LINT    = 7,
-    TAG_ULINT   = 8,
-    TAG_REAL    = 9,
-    TAG_LREAL   = 10,
-    TAG_BYTE    = 11,
-    TAG_WORD    = 12,
-    TAG_DWORD   = 13,
-    TAG_LWORD   = 14,
-    TAG_TIME    = 15,
-    TAG_DATE    = 16,
-    TAG_TOD     = 17,
-    TAG_DT      = 18,
-    TAG_STRING  = 19,
-    TAG_WSTRING = 20,
-    TAG__COUNT
-};
-
-// ---------------------------------------------------------------------------
-// Debug entry: one per leaf variable. 4 bytes on 16-bit-pointer AVR,
-// 16 bytes on 64-bit platforms (pad absorbs alignment).
-// ---------------------------------------------------------------------------
-struct Entry {
-    void* ptr;
-    uint8_t tag;
-    uint8_t _pad;
-};
 
 // ---------------------------------------------------------------------------
 // Status codes used by the protocol helpers below.

--- a/src/runtime/include/debug_table.hpp
+++ b/src/runtime/include/debug_table.hpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later WITH STruCpp-runtime-exception
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+// This file is part of the STruC++ Runtime Library and is covered by the
+// STruC++ Runtime Library Exception. See COPYING.RUNTIME for details.
+/**
+ * STruC++ Runtime - Debug Table Types
+ *
+ * Minimal header included by the per-project `generated_debug.cpp` to declare
+ * the debug Entry table.  Carries exactly three things:
+ *
+ *   1. `STRUCPP_DEBUG_FLASH` — placement attribute applied to the table
+ *      arrays (`PROGMEM` on AVR, no-op elsewhere).
+ *   2. `TypeTag` enum — the ABI between strucpp's code generator and the
+ *      runtime's per-type dispatch.
+ *   3. `Entry` struct — the per-leaf record shape.
+ *
+ * Crucially, this header does NOT include `<avr/pgmspace.h>` — and that's the
+ * entire reason it exists.  On AVR targets, `<pgmspace.h>` transitively pulls
+ * `<avr/io.h>` which defines `SP`, `SREG`, `OCR0A`, `TCNT0`, `DDRA`, etc. as
+ * preprocessor macros expanding to register-pointer casts.  IEC 61131-3
+ * function blocks routinely use those identifiers as field names (PID's
+ * `SP` setpoint, for example), so the moment a TU that names a user variable
+ * sees `<avr/io.h>` the preprocessor mangles `g_config.INSTANCE0.SP` into
+ * `g_config.INSTANCE0.(*(volatile uint16_t *)(0x3D))` and the C++ parser
+ * dies at the `(`.
+ *
+ * The dispatch helpers (`read_entry`, `handle_set`, …) genuinely need the
+ * AVR-specific accessors `pgm_read_word_far` / `pgm_read_byte` / etc., so
+ * they stay in `debug_dispatch.hpp`.  But the runtime translation unit
+ * that #includes that header doesn't name user variables — `generated_debug.cpp`
+ * is the only TU that does, and it doesn't need the dispatch helpers.  By
+ * having `generated_debug.cpp` include THIS file instead of
+ * `debug_dispatch.hpp`, AVR's register macros never enter the user-variable
+ * TU and identifier collisions become structurally impossible.
+ *
+ * `debug_dispatch.hpp` includes this file too, so the `TypeTag` enum and
+ * `Entry` struct stay defined exactly once — the dispatch side and the
+ * table-emit side cannot drift.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// Flash-placement attribute for per-project pointer tables.
+//
+// `PROGMEM` (avr-libc) ultimately expands to `__attribute__((__progmem__))`,
+// which is a plain GCC section attribute that the avr-gcc driver understands
+// natively — `<avr/pgmspace.h>` is not required to USE the attribute, only
+// to call the `pgm_read_*` accessors.  Defining it directly here keeps this
+// header AVR-clean.
+// ---------------------------------------------------------------------------
+#ifdef __AVR__
+#define STRUCPP_DEBUG_FLASH __attribute__((__progmem__))
+#else
+#define STRUCPP_DEBUG_FLASH
+#endif
+
+namespace strucpp { namespace debug {
+
+// ---------------------------------------------------------------------------
+// Type tags.  Order is ABI — matches the indices generated into
+// `generated_debug.cpp`'s `Entry{.tag}` fields, and must match `type_ops[]`
+// in `debug_dispatch.hpp`.  When extending: append only, never reorder.
+// ---------------------------------------------------------------------------
+enum TypeTag : uint8_t {
+    TAG_BOOL    = 0,
+    TAG_SINT    = 1,
+    TAG_USINT   = 2,
+    TAG_INT     = 3,
+    TAG_UINT    = 4,
+    TAG_DINT    = 5,
+    TAG_UDINT   = 6,
+    TAG_LINT    = 7,
+    TAG_ULINT   = 8,
+    TAG_REAL    = 9,
+    TAG_LREAL   = 10,
+    TAG_BYTE    = 11,
+    TAG_WORD    = 12,
+    TAG_DWORD   = 13,
+    TAG_LWORD   = 14,
+    TAG_TIME    = 15,
+    TAG_DATE    = 16,
+    TAG_TOD     = 17,
+    TAG_DT      = 18,
+    TAG_STRING  = 19,
+    TAG_WSTRING = 20,
+    TAG__COUNT
+};
+
+// ---------------------------------------------------------------------------
+// Debug entry: one per leaf variable.  Layout is ABI; see notes in
+// debug_dispatch.hpp's runtime dispatch for the per-platform size:
+// 4 bytes on 16-bit-pointer AVR, 16 bytes on 64-bit platforms (pad absorbs
+// alignment).
+// ---------------------------------------------------------------------------
+struct Entry {
+    void* ptr;
+    uint8_t tag;
+    uint8_t _pad;
+};
+
+} } // namespace strucpp::debug

--- a/tests/backend/debug-table-gen.test.ts
+++ b/tests/backend/debug-table-gen.test.ts
@@ -82,7 +82,13 @@ END_CONFIGURATION
   it("emits valid C++ source with the expected pointer expressions", () => {
     const result = compile(simpleBlinkSource);
     const cpp = result.debugTableCpp!;
-    expect(cpp).toContain("#include \"debug_dispatch.hpp\"");
+    // Emitted file includes the AVR-clean `debug_table.hpp` subset, NOT
+    // `debug_dispatch.hpp` — pulling the dispatch header here would
+    // drag in `<avr/pgmspace.h>` → `<avr/io.h>` and AVR's register
+    // macros (e.g. `SP`) would mangle user variable references like
+    // PID's `SP` setpoint.  See runtime/include/debug_table.hpp.
+    expect(cpp).toContain("#include \"debug_table.hpp\"");
+    expect(cpp).not.toContain("#include \"debug_dispatch.hpp\"");
     expect(cpp).toContain("extern ::strucpp::Configuration_CONFIG0 g_config;");
     expect(cpp).toContain("namespace strucpp { namespace debug {");
     expect(cpp).toContain("const Entry debug_arr_0[");


### PR DESCRIPTION
## Summary
- New `runtime/include/debug_table.hpp` carries the AVR-clean subset `generated_debug.cpp` needs (Entry, TypeTag, STRUCPP_DEBUG_FLASH); defines PROGMEM placement directly so `<avr/pgmspace.h>` stays out.
- `debug_dispatch.hpp` keeps its `<avr/pgmspace.h>` include for the inline `read_entry` / dispatch helpers but now consumes `debug_table.hpp` for the shared ABI types. Only the runtime TU includes it.
- `debug-table-gen.ts` emits `#include "debug_table.hpp"` at the top of `generated_debug.cpp`.

## The bug
rc1 strucpp 0.4.11 fails to compile any project with a PID block on AVR. `generated_debug.cpp` includes `debug_dispatch.hpp` → `<avr/pgmspace.h>` → `<avr/io.h>`. `<avr/io.h>` defines `SP` as `_SFR_IO16(0x3D)` → `(*(volatile uint16_t *)(0x3D))`. PID's `SP : REAL` setpoint field then triggers preprocessor expansion: `g_config.INSTANCE0.PID1.SP` becomes `g_config.INSTANCE0.PID1.(*(volatile uint16_t *)(0x3D))` and avr-g++ fails with `error: expected unqualified-id before '(' token`.

## Test plan
- [x] `npx vitest run` — 1965 passed (was 1964 + the updated debug-table-gen fixture asserting the new include).
- [x] End-to-end on atmega2560 with PID program:
  - new `debug_table.hpp`: `generated_debug.cpp` compiles ✓
  - old `debug_dispatch.hpp` (regression check): fails on `.SP` with the original error ✓
- [ ] Downstream: bump openplc-editor + openplc-web `binary-versions.json` to v0.4.15, run shared compiler suite on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)