### PR TITLE
fix(debug-table): move extern decls into debug_table.hpp so const definitions get external linkage

### DIFF
--- a/src/runtime/include/debug_dispatch.hpp
+++ b/src/runtime/include/debug_dispatch.hpp
@@ -177,16 +177,17 @@ inline constexpr TypeOps type_ops[TAG__COUNT] = {
 };
 
 // ---------------------------------------------------------------------------
-// Per-project tables — DECLARED here, DEFINED by generated_debug.cpp.
-// Using `extern` so the linker ties them together without the runtime header
-// needing to know the array counts at compile time.
+// Per-project tables are declared in `debug_table.hpp` (which we
+// include above).  They live there — not here — because the table-emit
+// translation unit (`generated_debug.cpp`) needs the `extern`
+// declarations to force external linkage on its `const` definitions,
+// and pulling `debug_dispatch.hpp` into generated_debug.cpp drags
+// `<avr/pgmspace.h>` → `<avr/io.h>` into a TU that names user
+// variables.  See debug_table.hpp's preamble for the rationale.
 //
-// On AVR these are in PROGMEM; the accessors below use pgm_read_*_far() to
-// work regardless of flash location.
+// On AVR these tables are in PROGMEM; the accessors below use
+// pgm_read_*_far() to work regardless of flash location.
 // ---------------------------------------------------------------------------
-extern const Entry* const debug_arrays[]     STRUCPP_DEBUG_FLASH;
-extern const uint16_t     debug_array_counts[] STRUCPP_DEBUG_FLASH;
-extern const uint8_t      debug_array_count;
 
 // ---------------------------------------------------------------------------
 // read_entry(): fetches Entry for (array_idx, elem_idx).

--- a/src/runtime/include/debug_table.hpp
+++ b/src/runtime/include/debug_table.hpp
@@ -101,4 +101,32 @@ struct Entry {
     uint8_t _pad;
 };
 
+// ---------------------------------------------------------------------------
+// Per-project tables — DECLARED here, DEFINED by generated_debug.cpp.
+//
+// These MUST be declared `extern` here even though generated_debug.cpp's
+// definitions are themselves `const`.  C++ rule: a namespace-scope `const`
+// variable gets INTERNAL linkage by default — which would hide the
+// definitions from every other translation unit (debug_dispatch.hpp's
+// `read_entry` / `handle_*` accessors, the runtime entry, the simulator's
+// ModbusSlave) and the linker would fail with `undefined reference to
+// strucpp::debug::debug_arrays`.  Putting the `extern` declaration
+// FIRST in the TU forces external linkage for the subsequent `const`
+// definitions.
+//
+// The decls live here (not in debug_dispatch.hpp) because
+// `generated_debug.cpp` includes only this header — pulling in
+// `debug_dispatch.hpp` from the table-emit TU drags `<avr/pgmspace.h>`
+// → `<avr/io.h>` into user-variable land, which is the whole reason
+// this header exists.  Consumers that need the accessors (read_entry,
+// handle_set, …) include `debug_dispatch.hpp` separately and get the
+// extern declarations transitively through this header.
+//
+// `STRUCPP_DEBUG_FLASH` placement is part of the declared signature so
+// the linker sees matching `__attribute__((__progmem__))` on both sides.
+// ---------------------------------------------------------------------------
+extern const Entry* const debug_arrays[]       STRUCPP_DEBUG_FLASH;
+extern const uint16_t     debug_array_counts[] STRUCPP_DEBUG_FLASH;
+extern const uint8_t      debug_array_count;
+
 } } // namespace strucpp::debug


### PR DESCRIPTION
## Summary
v0.4.15 split the runtime debug header but left the `extern` forward declarations behind in `debug_dispatch.hpp`. `generated_debug.cpp` (which now includes only `debug_table.hpp`) defines `const Entry* const debug_arrays[N] = {…}` at namespace scope — C++ default linkage for a `const` namespace variable is INTERNAL, so the definitions stopped being externally visible. Linker then bailed in every consumer translation unit (the simulator's ModbusSlave, runtime v4 entry shim, etc.):

```
/work/src/debug_dispatch.hpp:198: undefined reference to `strucpp::debug::debug_array_count'
/work/src/debug_dispatch.hpp:202: undefined reference to `strucpp::debug::debug_array_counts'
/work/src/debug_dispatch.hpp:207: undefined reference to `strucpp::debug::debug_arrays'
```

Fix: move the `extern` declarations into `debug_table.hpp`. Forward-declaring with `extern` before the `const` definitions forces external linkage, and consumers that include `debug_dispatch.hpp` get the decls transitively through it.

## Test plan
- [x] strucpp test suite: 1965 passed (unchanged)
- [x] End-to-end PID compile **with link** (the regression that escaped v0.4.15):
  - Local strucpp source → strucpp.compile() on a PID-bearing program
  - Assemble firmware skeleton (editor's `resources/sources/Baremetal/` + `arduino/`)
  - arduino-cli compile for `arduino:avr:mega` with editor's exact flags
  - **Sketch uses 8914 bytes (3%) program storage / 682 bytes RAM** — links cleanly
- [ ] Downstream: bump openplc-editor + openplc-web `binary-versions.json` to v0.4.16.

## Why this escaped v0.4.15
The previous verifier `-c`-compiled `generated_debug.cpp` to an object file but never linked. C++ linkage rules around `const` namespace-scope are exactly the kind of bug that only surfaces at link time. The new harness runs the full arduino-cli compile (which includes the link step) on a PID-using project — this class of regression now gets caught locally before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)