### PR TITLE
release: v0.4.16 — fix debug-table extern linkage

### DIFF
--- a/src/runtime/include/debug_dispatch.hpp
+++ b/src/runtime/include/debug_dispatch.hpp
@@ -177,16 +177,17 @@ inline constexpr TypeOps type_ops[TAG__COUNT] = {
 };
 
 // ---------------------------------------------------------------------------
-// Per-project tables — DECLARED here, DEFINED by generated_debug.cpp.
-// Using `extern` so the linker ties them together without the runtime header
-// needing to know the array counts at compile time.
+// Per-project tables are declared in `debug_table.hpp` (which we
+// include above).  They live there — not here — because the table-emit
+// translation unit (`generated_debug.cpp`) needs the `extern`
+// declarations to force external linkage on its `const` definitions,
+// and pulling `debug_dispatch.hpp` into generated_debug.cpp drags
+// `<avr/pgmspace.h>` → `<avr/io.h>` into a TU that names user
+// variables.  See debug_table.hpp's preamble for the rationale.
 //
-// On AVR these are in PROGMEM; the accessors below use pgm_read_*_far() to
-// work regardless of flash location.
+// On AVR these tables are in PROGMEM; the accessors below use
+// pgm_read_*_far() to work regardless of flash location.
 // ---------------------------------------------------------------------------
-extern const Entry* const debug_arrays[]     STRUCPP_DEBUG_FLASH;
-extern const uint16_t     debug_array_counts[] STRUCPP_DEBUG_FLASH;
-extern const uint8_t      debug_array_count;
 
 // ---------------------------------------------------------------------------
 // read_entry(): fetches Entry for (array_idx, elem_idx).

--- a/src/runtime/include/debug_table.hpp
+++ b/src/runtime/include/debug_table.hpp
@@ -101,4 +101,32 @@ struct Entry {
     uint8_t _pad;
 };
 
+// ---------------------------------------------------------------------------
+// Per-project tables — DECLARED here, DEFINED by generated_debug.cpp.
+//
+// These MUST be declared `extern` here even though generated_debug.cpp's
+// definitions are themselves `const`.  C++ rule: a namespace-scope `const`
+// variable gets INTERNAL linkage by default — which would hide the
+// definitions from every other translation unit (debug_dispatch.hpp's
+// `read_entry` / `handle_*` accessors, the runtime entry, the simulator's
+// ModbusSlave) and the linker would fail with `undefined reference to
+// strucpp::debug::debug_arrays`.  Putting the `extern` declaration
+// FIRST in the TU forces external linkage for the subsequent `const`
+// definitions.
+//
+// The decls live here (not in debug_dispatch.hpp) because
+// `generated_debug.cpp` includes only this header — pulling in
+// `debug_dispatch.hpp` from the table-emit TU drags `<avr/pgmspace.h>`
+// → `<avr/io.h>` into user-variable land, which is the whole reason
+// this header exists.  Consumers that need the accessors (read_entry,
+// handle_set, …) include `debug_dispatch.hpp` separately and get the
+// extern declarations transitively through this header.
+//
+// `STRUCPP_DEBUG_FLASH` placement is part of the declared signature so
+// the linker sees matching `__attribute__((__progmem__))` on both sides.
+// ---------------------------------------------------------------------------
+extern const Entry* const debug_arrays[]       STRUCPP_DEBUG_FLASH;
+extern const uint16_t     debug_array_counts[] STRUCPP_DEBUG_FLASH;
+extern const uint8_t      debug_array_count;
+
 } } // namespace strucpp::debug


### PR DESCRIPTION
Promotes #116. v0.4.15 silently turned the per-project debug tables into internal-linkage symbols; this restores external linkage by moving the extern decls into debug_table.hpp.  Verified end-to-end with arduino-cli link step on a PID-using program.