### PR TITLE
fix(parser): replace chevrotain's 1,400-line NoViableAlt dump with rule-aware messages

### DIFF
--- a/src/frontend/parser-error-message-provider.ts
+++ b/src/frontend/parser-error-message-provider.ts
@@ -1,0 +1,294 @@
+/**
+ * Custom chevrotain {@link IParserErrorMessageProvider} for the
+ * Structured Text grammar.
+ *
+ * The default provider on chevrotain's `NoViableAltException` enumerates
+ * every valid token path through every alternative of the failed `OR()`.
+ * For statement-level alternations in this grammar that's ~1,400 paths;
+ * the message that lands in front of the user is unreadable.
+ *
+ * This module replaces those messages with concise, rule-aware
+ * sentences that name the actual unexpected token and describe what
+ * rule was being parsed.  The full path enumeration is preserved only
+ * for grammar-debugging purposes — set `STRUCPP_VERBOSE_PARSER_ERRORS=1`
+ * to bypass this provider and fall back to chevrotain's default.
+ *
+ * The {@link RULE_DESCRIPTIONS} table grows organically.  When a user
+ * reports a confusing message, add a friendly description for the rule
+ * name that surfaced.  Anything unmapped falls back to
+ * `parsing rule \`<ruleName>\`` — degraded but never broken.
+ */
+
+import type {
+  IParserErrorMessageProvider,
+  IToken,
+  TokenType,
+} from "chevrotain";
+
+/**
+ * Friendly descriptions for the rules that fail in front of users
+ * most often.  Phrased to slot into "Unexpected <token> while
+ * `<description>`." — keep the wording consistent so the rendered
+ * sentence reads naturally.
+ */
+const RULE_DESCRIPTIONS: Record<string, string> = {
+  // Top-level
+  compilationUnit: "parsing the program",
+  programDeclaration: "parsing a PROGRAM declaration",
+  functionDeclaration: "parsing a FUNCTION declaration",
+  functionBlockDeclaration: "parsing a FUNCTION_BLOCK declaration",
+  interfaceDeclaration: "parsing an INTERFACE declaration",
+  methodDeclaration: "parsing a METHOD declaration",
+  propertyDeclaration: "parsing a PROPERTY declaration",
+  configurationDeclaration: "parsing a CONFIGURATION block",
+  resourceDeclaration: "parsing a RESOURCE block",
+  taskDeclaration: "parsing a TASK declaration",
+  programInstance: "parsing a program instance",
+
+  // Statements
+  statementList: "parsing a statement block",
+  statement: "parsing a statement",
+  assignmentStatement: "parsing an assignment",
+  refAssignStatement: "parsing a reference assignment",
+  functionCallStatement: "parsing a function call",
+  methodCallStatement: "parsing a method call",
+  ifStatement: "parsing an IF statement",
+  caseStatement: "parsing a CASE statement",
+  caseStatementList: "parsing a CASE statement",
+  caseElement: "parsing a CASE branch",
+  caseLabel: "parsing a CASE label",
+  forStatement: "parsing a FOR loop",
+  whileStatement: "parsing a WHILE loop",
+  repeatStatement: "parsing a REPEAT loop",
+  exitStatement: "parsing an EXIT statement",
+  returnStatement: "parsing a RETURN statement",
+  deleteStatement: "parsing a __DELETE statement",
+  advanceTimeStatement: "parsing an __advance_time call",
+  mockStatement: "parsing a mock declaration",
+  mockVerifyStatement: "parsing a mock verification",
+
+  // Expressions
+  expression: "parsing an expression",
+  orExpression: "parsing an expression",
+  andExpression: "parsing an expression",
+  comparisonExpression: "parsing a comparison",
+  addExpression: "parsing an arithmetic expression",
+  mulExpression: "parsing an arithmetic expression",
+  powerExpression: "parsing an arithmetic expression",
+  primaryExpression: "parsing an expression",
+  literal: "parsing a literal value",
+  functionCall: "parsing a function call",
+  methodCall: "parsing a method call",
+  chainedMethodCall: "parsing a method call",
+  argumentList: "parsing a function-call argument list",
+  argument: "parsing a function-call argument",
+  qualifiedIdentifier: "parsing an identifier",
+  refExpression: "parsing a REF() expression",
+  drefExpression: "parsing a DREF^ expression",
+  newExpression: "parsing a __NEW expression",
+
+  // Declarations
+  varBlock: "parsing a VAR block",
+  methodVarBlock: "parsing a method VAR block",
+  varDeclaration: "parsing a variable declaration",
+  initializerExpression: "parsing a variable initializer",
+  arrayLiteral: "parsing an array literal",
+  dataType: "parsing a data type",
+  singleTypeDeclaration: "parsing a type declaration",
+  structType: "parsing a STRUCT type",
+  simpleEnumType: "parsing an enum type",
+  enumMember: "parsing an enum member",
+  arrayType: "parsing an ARRAY type",
+  arrayDimension: "parsing an ARRAY dimension",
+  subrangeBounds: "parsing a subrange",
+  typedEnumOrSubrangeOrAlias: "parsing a type declaration",
+
+  // Misc
+  assertCall: "parsing an ASSERT_* call",
+  externalCodePragma: "parsing an external-code pragma",
+  setupBlock: "parsing a __setup block",
+  identifierOrKeyword: "parsing an identifier",
+  interfaceMethodDeclaration: "parsing an interface method signature",
+  propertyGetter: "parsing a property GET accessor",
+  propertySetter: "parsing a property SET accessor",
+};
+
+/**
+ * Render a token in a way that's useful to a human reader.  Keywords
+ * and punctuation are reported by their token type name (e.g.
+ * `END_FUNCTION_BLOCK`, `Semicolon`); identifiers and literals
+ * surface their actual image (`sdfasdfa`, `42`).  Falls back to the
+ * token type name when the image is missing.
+ */
+function formatToken(token: IToken | undefined): string {
+  if (!token) return "end of input";
+  const typeName = token.tokenType?.name ?? "<unknown>";
+  const image = token.image;
+  // Keyword tokens have image === typeName-ish — favor the image when
+  // it differs (covers user-typed identifiers and literals) and the
+  // type name when they coincide (covers keywords like `END_VAR`).
+  if (typeName === "Identifier" && image) return `identifier \`${image}\``;
+  if (typeName === "IntegerLiteral" && image)
+    return `integer literal \`${image}\``;
+  if (typeName === "RealLiteral" && image) return `real literal \`${image}\``;
+  if (typeName === "StringLiteral" && image)
+    return `string literal \`${image}\``;
+  if (typeName === "WideStringLiteral" && image)
+    return `string literal \`${image}\``;
+  if (typeName === "TimeLiteral" && image) return `time literal \`${image}\``;
+  if (typeName === "DateLiteral" && image) return `date literal \`${image}\``;
+  if (typeName === "TimeOfDayLiteral" && image)
+    return `time-of-day literal \`${image}\``;
+  if (typeName === "DateTimeLiteral" && image)
+    return `date-time literal \`${image}\``;
+  if (typeName === "TypedLiteral" && image) return `typed literal \`${image}\``;
+  return `\`${image || typeName}\``;
+}
+
+function describeRule(ruleName: string): string {
+  return RULE_DESCRIPTIONS[ruleName] ?? `parsing rule \`${ruleName}\``;
+}
+
+/**
+ * The provider chevrotain consults whenever it has to format a parse
+ * error.  Each method below mirrors the corresponding method on
+ * {@link IParserErrorMessageProvider}; signatures must match the
+ * chevrotain contract exactly.
+ */
+export const stParserErrorMessageProvider: IParserErrorMessageProvider = {
+  /**
+   * A {@link BaseParser.CONSUME} call failed: the parser expected
+   * exactly one specific token type at this position and got
+   * something else.  The default chevrotain message
+   * (`Expecting token of type --> X <-- but found --> 'Y' <--`)
+   * is already concise — just rewrap it to match the house style.
+   */
+  buildMismatchTokenMessage({ expected, actual }) {
+    return `Expected \`${expected.name}\`, found ${formatToken(actual)}.`;
+  },
+
+  /**
+   * Parsing finished successfully but there were tokens left over.
+   * Usually means an unbalanced END_* keyword or an extra semicolon
+   * after the last block.
+   */
+  buildNotAllInputParsedMessage({ firstRedundant, ruleName }) {
+    return (
+      `Unexpected extra input after ${describeRule(ruleName)}: ` +
+      `${formatToken(firstRedundant)}.`
+    );
+  },
+
+  /**
+   * The headline case.  A {@link BaseParser.OR} alternation failed
+   * because none of its branches matched the upcoming token stream.
+   * Chevrotain's default lists every expected token path; that's the
+   * 1,400-line dump the user complained about.  We DROP
+   * `expectedPathsPerAlt` and produce a sentence built from `ruleName`
+   * + the unexpected token.
+   *
+   * The unused params are kept on the signature so the contract
+   * stays satisfied; eslint/prettier won't complain about underscore
+   * names.
+   */
+  buildNoViableAltMessage({ actual, previous, ruleName }) {
+    const after =
+      previous && previous !== actual[0]
+        ? ` after ${formatToken(previous)}`
+        : "";
+    return `Unexpected ${formatToken(actual[0])}${after} while ${describeRule(ruleName)}.`;
+  },
+
+  /**
+   * A {@link BaseParser.AT_LEAST_ONE} / `AT_LEAST_ONE_SEP` saw zero
+   * iterations.  Same shape as `NoViableAlt` but the rule is one of
+   * the few that demands a non-empty body (statement list inside a
+   * non-empty IF / FOR body, etc.).
+   */
+  buildEarlyExitMessage({ actual, ruleName }) {
+    return (
+      `Expected at least one entry while ${describeRule(ruleName)}; ` +
+      `found ${formatToken(actual[0])}.`
+    );
+  },
+};
+
+/**
+ * Internal helper exported for the suggestion layer.  Given a parser
+ * rule name and the actual unexpected token, return a short
+ * remediation hint or `undefined` when the case isn't covered.
+ *
+ * Kept in this file (rather than in `index.ts`) so the rule-name
+ * → suggestion mapping lives next to the rule-name → description
+ * mapping it builds on.  Add an entry whenever a real-world error
+ * makes the simple-format message insufficient.
+ */
+export function suggestionForParseError(
+  ruleName: string,
+  actual: IToken | undefined,
+): string | undefined {
+  if (!actual) return undefined;
+  const tokenName = actual.tokenType?.name;
+  if (ruleName === "statement" && tokenName === "Identifier") {
+    return (
+      "Statements start with an assignment (`:=`), a function call, " +
+      "or a block keyword (IF / CASE / FOR / WHILE / REPEAT / " +
+      "RETURN / EXIT).  Did you forget `:=` after the identifier?"
+    );
+  }
+  if (ruleName === "varDeclaration" || ruleName === "varBlock") {
+    return (
+      "Variable declarations look like `name : TYPE := initialValue;` " +
+      "inside a VAR / VAR_INPUT / VAR_OUTPUT block."
+    );
+  }
+  if (ruleName === "dataType") {
+    return (
+      "Expected a type name (BOOL / INT / REAL / STRING / TIME / a " +
+      "user-defined TYPE / an ARRAY[...] OF ...)."
+    );
+  }
+  if (ruleName === "ifStatement") {
+    return (
+      "IF blocks need `IF <cond> THEN <stmt>; <stmt>; END_IF;`.  " +
+      "ELSIF / ELSE branches are optional."
+    );
+  }
+  if (ruleName === "argumentList" && tokenName === "Semicolon") {
+    return "Function-call arguments are separated by `,` and end with `)`, not `;`.";
+  }
+  return undefined;
+}
+
+/**
+ * Whether to use the custom provider (default) or fall back to
+ * chevrotain's verbose path-listing provider.  Set
+ * `STRUCPP_VERBOSE_PARSER_ERRORS=1` in the environment to see the
+ * full alternation paths — useful when *debugging the grammar
+ * itself*, never in front of end users.
+ *
+ * Resolved at parser-construction time, so flipping the env var
+ * mid-process won't have any effect (which is the right behaviour —
+ * chevrotain caches the provider into its initialised parser).
+ */
+export function shouldUseVerboseErrors(): boolean {
+  // The browser bundle ships without a `process` global; fall back to
+  // "no, use the friendly provider" in that case.
+  if (typeof process === "undefined") return false;
+  return process.env?.STRUCPP_VERBOSE_PARSER_ERRORS === "1";
+}
+
+/**
+ * The provider to install on the parser.  Returns `undefined` (so
+ * chevrotain uses its default) when the verbose escape hatch is on.
+ */
+export function resolveErrorMessageProvider():
+  | IParserErrorMessageProvider
+  | undefined {
+  return shouldUseVerboseErrors() ? undefined : stParserErrorMessageProvider;
+}
+
+// Re-export the TokenType type from chevrotain so consumers that want
+// to add custom RULE_DESCRIPTIONS at runtime don't have to import it
+// separately.  Not used by this module directly but cheap to expose.
+export type { TokenType };

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -9,6 +9,7 @@
 
 import { CstParser, CstNode, type TokenType } from "chevrotain";
 import * as tokens from "./lexer.js";
+import { resolveErrorMessageProvider } from "./parser-error-message-provider.js";
 
 /**
  * STruC++ Parser for IEC 61131-3 Structured Text.
@@ -18,9 +19,17 @@ import * as tokens from "./lexer.js";
  */
 export class STParser extends CstParser {
   constructor(tokenVocabulary?: import("chevrotain").TokenType[]) {
+    // `errorMessageProvider` swaps chevrotain's default
+    // alternation-path dump (1,400+ lines for a top-level statement
+    // failure) for a rule-aware sentence.  `resolveErrorMessageProvider`
+    // returns `undefined` when `STRUCPP_VERBOSE_PARSER_ERRORS=1` is set
+    // in the env, falling back to chevrotain's default for
+    // grammar-debugging.  See parser-error-message-provider.ts.
+    const errorMessageProvider = resolveErrorMessageProvider();
     super(tokenVocabulary ?? tokens.allTokens, {
       recoveryEnabled: true,
       maxLookahead: 3,
+      ...(errorMessageProvider ? { errorMessageProvider } : {}),
     });
 
     this.performSelfAnalysis();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   AnalysisResult,
 } from "./types.js";
 import { parse as parseSource } from "./frontend/parser.js";
+import { suggestionForParseError } from "./frontend/parser-error-message-provider.js";
 import { buildAST } from "./frontend/ast-builder.js";
 import { transpileILSource } from "./il/il-transpiler.js";
 import { buildProjectModel } from "./project-model.js";
@@ -311,10 +312,25 @@ function runPipeline(
   const parseResult = parseSource(effectiveSource);
   if (parseResult.errors.length > 0) {
     for (const err of parseResult.errors) {
+      // Chevrotain's IRecognitionException — only the fields we
+      // actually read are typed here.  `context.ruleStack` is the
+      // chain of rules being parsed at the failure point; the
+      // innermost rule (last entry) drives the suggestion lookup.
       const errObj = err as {
         message?: string;
-        token?: { startLine?: number; startColumn?: number };
+        token?: {
+          startLine?: number;
+          startColumn?: number;
+          tokenType?: { name?: string };
+        };
+        context?: { ruleStack?: string[] };
       };
+      const ruleStack = errObj.context?.ruleStack ?? [];
+      const ruleName = ruleStack[ruleStack.length - 1] ?? "";
+      const suggestion = suggestionForParseError(
+        ruleName,
+        errObj.token as Parameters<typeof suggestionForParseError>[1],
+      );
       const entry: CompileError = {
         message: errObj.message ?? "Parse error",
         line: errObj.token?.startLine ?? 0,
@@ -322,6 +338,7 @@ function runPipeline(
         severity: "error",
       };
       if (mergedOptions.fileName) entry.file = mergedOptions.fileName;
+      if (suggestion) entry.suggestion = suggestion;
       errors.push(entry);
     }
     // In analyze mode, continue with partial CST from Chevrotain recovery.

--- a/tests/frontend/parser-error-messages.test.ts
+++ b/tests/frontend/parser-error-messages.test.ts
@@ -1,0 +1,170 @@
+/**
+ * STruC++ parser error-message shape tests.
+ *
+ * The provider in `src/frontend/parser-error-message-provider.ts`
+ * replaces chevrotain's default verbose alternation dump.  These tests
+ * pin the *shape* of the new messages (length cap + presence of key
+ * substrings) so future wording tweaks don't fail the suite.
+ *
+ * What gets asserted:
+ *   - Messages stay short (< 500 chars) — the original chevrotain
+ *     output for these inputs ran several thousand characters.
+ *   - The unexpected token's actual image is in the message.
+ *   - For `NoViableAlt` / `EarlyExit`, the rule description gives the
+ *     user a hint about what was being parsed.
+ *   - For `Mismatched`, the expected token type is named.
+ *   - For "redundant input", the message identifies the extra token.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../src/frontend/parser.js";
+
+interface ParseError {
+  message?: string;
+  context?: { ruleStack?: string[] };
+}
+
+function firstErrorMessage(source: string): string {
+  const result = parse(source);
+  expect(result.errors.length).toBeGreaterThan(0);
+  const first = result.errors[0] as ParseError;
+  return first.message ?? "";
+}
+
+const MAX_MESSAGE_CHARS = 500;
+
+describe("parser error messages (custom provider)", () => {
+  describe("bare identifier in a statement (NoViableAlt at top level)", () => {
+    // The headline case from the user's report: a function-block
+    // body that contains just `sdfasdfa`.  Chevrotain's default
+    // dumps every alternative of the `statement` rule.
+    const source = `
+      FUNCTION_BLOCK cvavava
+        sdfasdfa
+      END_FUNCTION_BLOCK
+    `;
+
+    it("does not enumerate every token path", () => {
+      const message = firstErrorMessage(source);
+      expect(message.length).toBeLessThan(MAX_MESSAGE_CHARS);
+      // The default provider's format starts with this phrase before
+      // listing alternatives — its absence is the signal that we
+      // intercepted the message.
+      expect(message).not.toContain("possible Token sequences");
+      expect(message).not.toMatch(/\[Identifier,\s*RefAssign\]/);
+    });
+
+    it("names the unexpected identifier", () => {
+      const message = firstErrorMessage(source);
+      expect(message.toLowerCase()).toContain("sdfasdfa");
+    });
+
+    it("identifies the rule that failed (statement)", () => {
+      const message = firstErrorMessage(source);
+      expect(message.toLowerCase()).toContain("statement");
+    });
+  });
+
+  describe("missing END_FUNCTION_BLOCK (MismatchedToken)", () => {
+    const source = `
+      FUNCTION_BLOCK widget
+        VAR a : INT; END_VAR
+        a := a + 1;
+    `;
+
+    it("names the expected END_* token and the actual one", () => {
+      const message = firstErrorMessage(source);
+      expect(message.length).toBeLessThan(MAX_MESSAGE_CHARS);
+      // Either the END_FUNCTION_BLOCK type is named, or the message
+      // calls out the unexpected EOF / next token.  Both are useful.
+      expect(message).toMatch(/END_FUNCTION_BLOCK|end of input/i);
+    });
+  });
+
+  describe("extra input after end of program (NotAllInputParsed)", () => {
+    const source = `
+      PROGRAM main
+        VAR a : INT; END_VAR
+        a := 1;
+      END_PROGRAM
+      garbage
+    `;
+
+    it("calls out the extra token", () => {
+      const message = firstErrorMessage(source);
+      expect(message.length).toBeLessThan(MAX_MESSAGE_CHARS);
+      expect(message.toLowerCase()).toMatch(/extra input|unexpected/);
+    });
+  });
+
+  describe("rule-stack-based suggestion", () => {
+    it("attaches a suggestion when the first error is a bare statement identifier", async () => {
+      // We can't access CompileError.suggestion through `parse()`
+      // directly — that's only built in src/index.ts.  Import the
+      // suggestion helper and exercise it standalone instead.  Same
+      // mapping the production path uses.
+      const { suggestionForParseError } = await import(
+        "../../src/frontend/parser-error-message-provider.js"
+      );
+      const fakeToken = {
+        tokenType: { name: "Identifier" },
+        image: "sdfasdfa",
+      };
+      const suggestion = suggestionForParseError(
+        "statement",
+        fakeToken as Parameters<typeof suggestionForParseError>[1],
+      );
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.toLowerCase()).toMatch(/assignment|:=/);
+    });
+
+    it("returns undefined when the rule has no curated suggestion", async () => {
+      const { suggestionForParseError } = await import(
+        "../../src/frontend/parser-error-message-provider.js"
+      );
+      const fakeToken = {
+        tokenType: { name: "Identifier" },
+        image: "x",
+      };
+      const suggestion = suggestionForParseError(
+        "compilationUnit",
+        fakeToken as Parameters<typeof suggestionForParseError>[1],
+      );
+      expect(suggestion).toBeUndefined();
+    });
+  });
+
+  describe("escape hatch — STRUCPP_VERBOSE_PARSER_ERRORS", () => {
+    it("returns the custom provider by default", async () => {
+      const { resolveErrorMessageProvider } = await import(
+        "../../src/frontend/parser-error-message-provider.js"
+      );
+      const original = process.env.STRUCPP_VERBOSE_PARSER_ERRORS;
+      delete process.env.STRUCPP_VERBOSE_PARSER_ERRORS;
+      try {
+        expect(resolveErrorMessageProvider()).toBeDefined();
+      } finally {
+        if (original !== undefined) {
+          process.env.STRUCPP_VERBOSE_PARSER_ERRORS = original;
+        }
+      }
+    });
+
+    it("returns undefined when STRUCPP_VERBOSE_PARSER_ERRORS=1", async () => {
+      const { resolveErrorMessageProvider } = await import(
+        "../../src/frontend/parser-error-message-provider.js"
+      );
+      const original = process.env.STRUCPP_VERBOSE_PARSER_ERRORS;
+      process.env.STRUCPP_VERBOSE_PARSER_ERRORS = "1";
+      try {
+        expect(resolveErrorMessageProvider()).toBeUndefined();
+      } finally {
+        if (original === undefined) {
+          delete process.env.STRUCPP_VERBOSE_PARSER_ERRORS;
+        } else {
+          process.env.STRUCPP_VERBOSE_PARSER_ERRORS = original;
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Why

User report: compiling a project with a malformed POU body (the canonical case is a bare identifier where a statement should be) produces a 1,409-line error message:

```
Expecting: one of these possible Token sequences:
  1.   [Identifier, RefAssign]
  2.   [SET, RefAssign]
  ...
  1401. [Semicolon]
but found: 'SDFASDFA'
```

Root cause: strucpp uses chevrotain ^11.0.0 and never installs a custom `IParserErrorMessageProvider`, so chevrotain's default `buildNoViableAltMessage` enumerates every valid token path through every alternative of a failed `OR()` rule. For the statement rule, that's ~1,400 paths. `src/index.ts:312` then passes the message through verbatim.

## What changed

`src/frontend/parser-error-message-provider.ts` (new, ~290 LOC) implements all four `IParserErrorMessageProvider` methods. The big win is `buildNoViableAltMessage`, which now produces:

```
Unexpected identifier `SDFASDFA` after identifier `CVAVAVA` while parsing a statement.
```

Plus a suggestion populated on `CompileError.suggestion`:

```
Statements start with an assignment (`:=`), a function call, or a block keyword
(IF / CASE / FOR / WHILE / REPEAT / RETURN / EXIT).  Did you forget `:=` after
the identifier?
```

Architecture (in priority order):

| Layer | File | Role |
|---|---|---|
| **Provider** | `parser-error-message-provider.ts` | Rule-aware messages via `RULE_DESCRIPTIONS` table. Discards `expectedPathsPerAlt`. |
| **Wiring** | `parser.ts` STParser constructor | Passes `errorMessageProvider` via `resolveErrorMessageProvider()`. |
| **Suggestions** | `index.ts` parse-error mapping | Populates `CompileError.suggestion` from `suggestionForParseError(ruleName, token)`. |
| **Escape hatch** | `STRUCPP_VERBOSE_PARSER_ERRORS=1` | Falls back to chevrotain's default for grammar-debugging. |

### `RULE_DESCRIPTIONS` is a living table

~60 rule names mapped to friendly descriptions (`statement` → `parsing a statement`, `varDeclaration` → `parsing a variable declaration`, etc.). When a user reports a confusing message, add an entry — anything unmapped falls back to `` parsing rule `<ruleName>` ``, which is degraded but never broken. Same pattern for the suggestion table.

## Verification

| | Before | After |
|---|---|---|
| **Line count for `FUNCTION_BLOCK cvavava { sdfasdfa END_FUNCTION_BLOCK }`** | 1,409 lines per error | 2 lines + 1 suggestion |
| **End-to-end smoke** | dump readable in `STRUCPP_VERBOSE_PARSER_ERRORS=1` | full message preserved for grammar debugging |
| **Existing test suite** | — | 1974/1974 pass (7 pre-existing skips) |
| **New tests** | — | 9/9 pass (`parser-error-messages.test.ts`) |

The new test suite pins the *shape* of the message (length cap, presence of key substrings, escape-hatch behavior) without locking exact wording, so future tweaks won't fail tests.

## Trade-offs called out in the plan

- `RULE_DESCRIPTIONS` needs maintenance when rules are renamed (graceful fallback).
- `suggestionForParseError` table starts with the most common 5 cases; grows on user feedback.
- `STRUCPP_VERBOSE_PARSER_ERRORS=1` preserves the old behaviour for anyone debugging the grammar itself.

## Release path

After merge:
1. Tag strucpp v0.4.17
2. Bump `binary-versions.json` on `openplc-editor` + `openplc-web` so the next install pulls it
3. Smoke-test the user's exact bug shape on both editor and web

🤖 Generated with [Claude Code](https://claude.com/claude-code)