### PR TITLE
fix(types): refine overloaded std-function return type at call sites

### DIFF
--- a/src/semantic/type-checker.ts
+++ b/src/semantic/type-checker.ts
@@ -38,6 +38,7 @@ import {
   resolveFieldType,
   resolveArrayElementType,
   typeName as typeNameUtil,
+  isGenericGroupType,
 } from "./type-utils.js";
 import { stripEnEno } from "../ast-utils.js";
 
@@ -569,8 +570,23 @@ export class TypeChecker {
     // Check user-defined functions in symbol tables
     const funcSymbol = this.symbolTables.lookupFunction(expr.functionName);
     if (funcSymbol !== undefined) {
-      expr.resolvedType = funcSymbol.returnType;
-      return funcSymbol.returnType;
+      let returnType = funcSymbol.returnType;
+      // Overloaded standard functions are published in the builtin stdlib
+      // manifest with their generic return *constraint* (e.g. NOT -> ANY_BIT,
+      // ADD -> ANY_NUM). When the IEC signature says the result type matches
+      // the first argument, refine that generic to the concrete operand type
+      // so downstream checks see a real type — e.g. NOT(BOOL) -> BOOL, which
+      // the EN-input check (and bit/num operand rules) require.
+      if (returnType && isGenericGroupType(returnType) && this.stdRegistry) {
+        const desc = this.stdRegistry.lookup(nameUpper);
+        if (desc?.returnMatchesFirstParam) {
+          const userArgs = stripEnEno(expr.arguments);
+          const firstArgType = userArgs[0]?.value.resolvedType;
+          if (firstArgType) returnType = firstArgType;
+        }
+      }
+      expr.resolvedType = returnType;
+      return returnType;
     }
 
     // Validate standard function argument types (after resolving args)

--- a/src/semantic/type-utils.ts
+++ b/src/semantic/type-utils.ts
@@ -204,6 +204,33 @@ export function isTypeInCategory(
   return categories?.includes(category) ?? false;
 }
 
+/** The IEC generic type-group names (ANY, ANY_BIT, ANY_NUM, ...). */
+const GENERIC_TYPE_NAMES: ReadonlySet<string> = new Set([
+  "ANY",
+  "ANY_DERIVED",
+  "ANY_ELEMENTARY",
+  "ANY_MAGNITUDE",
+  "ANY_NUM",
+  "ANY_REAL",
+  "ANY_INT",
+  "ANY_BIT",
+  "ANY_STRING",
+  "ANY_DATE",
+]);
+
+/**
+ * Whether a resolved type is one of the IEC generic type groups rather than a
+ * concrete type. Overloaded standard functions are published with one of these
+ * as their declared return type (e.g. NOT -> ANY_BIT); such a result must be
+ * refined to a concrete type at the call site before it can be used.
+ */
+export function isGenericGroupType(type: IECType): boolean {
+  return (
+    type.typeKind === "elementary" &&
+    GENERIC_TYPE_NAMES.has((type as ElementaryType).name.toUpperCase())
+  );
+}
+
 /**
  * Check if a type name matches a StdFunctionRegistry TypeConstraint.
  */

--- a/tests/semantic/expression-validation.test.ts
+++ b/tests/semantic/expression-validation.test.ts
@@ -292,4 +292,21 @@ describe("Semantic Analyzer - EN/ENO Argument Counting", () => {
     );
     expect(enoErrors.length).toBeGreaterThan(0);
   });
+
+  it("accepts NOT(BOOL) as an EN input — overloaded std result refines to BOOL", () => {
+    // Regression: ladder-generated `MOVE(EN := NOT(led), ...)`. NOT is an
+    // overloaded standard function published with a generic ANY_BIT return;
+    // it must refine to the concrete operand type (BOOL) so the EN check
+    // (which requires BOOL) passes instead of erroring with "got ANY_BIT".
+    const result = analyzeSource(`
+      PROGRAM Main
+        VAR led : BOOL; q : UINT; eno : BOOL; END_VAR
+        q := MOVE(EN := NOT(led), IN := UINT#0, ENO => eno);
+      END_PROGRAM
+    `);
+    const enErrors = result.errors.filter((e) =>
+      e.message.includes("'EN' input must be a BOOL"),
+    );
+    expect(enErrors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Problem

Ladder-generated code such as `MOVE(EN := NOT(led), ...)` failed to compile with:

```
error: 'EN' input must be a BOOL expression, got ANY_BIT
```

`NOT` is an overloaded standard function published in the builtin stdlib manifest with its generic return **constraint** (`ANY_BIT`). In `inferFunctionCallType`, the symbol-table lookup resolved the call first and returned that generic group type, never reaching the std-registry logic that applies `returnMatchesFirstParam`. So `NOT(BOOL)` resolved to `ANY_BIT` instead of `BOOL`, and the EN-input check (which requires `BOOL`) rejected it.

This affects every overloaded std function used in function-call form (NOT, AND, OR, XOR, ADD, SUB, ...), which is exactly the shape the ladder→ST generator emits for EN/ENO wrappers.

## Fix

When a function resolved from the symbol table has a **generic group** return type and the std signature declares `returnMatchesFirstParam`, refine the result to the concrete first-argument type (`NOT(BOOL) -> BOOL`, `ADD(INT, INT) -> INT`, ...), per IEC 61131-3 overloaded-function typing.

- `src/semantic/type-utils.ts`: new `isGenericGroupType` predicate (next to the other type predicates and the `TypeCategory` enumeration), backed by a precise set of the generic group names.
- `src/semantic/type-checker.ts`: `inferFunctionCallType` refines a generic return via `returnMatchesFirstParam`.

## Testing

- `tsc --noEmit`: clean.
- Repro via CLI before/after: `MOVE(EN := NOT(led), ...)` errored on the base and now compiles.
- Added a regression test: `EN := NOT(BOOL)` produces no EN error (`tests/semantic/expression-validation.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)