### PR TITLE
fix(codegen): lower IEC numeric literals in VAR initializers (#133)

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -5058,6 +5058,18 @@ export class CodeGenerator {
         const escaped = this.translateIECString(inner);
         return `u"${escaped}"`;
       }
+      // Lower IEC numeric literals (based 16#FF/8#17/2#1010, decimals
+      // with underscore separators, typed prefixes like INT#5, optional
+      // sign). PROGRAM/GLOBAL VAR initialisers arrive here as raw IEC
+      // strings; without this they're emitted verbatim (`X(16#FF)`,
+      // `X(1_000)`, `X(INT#5)`) and the C++ build fails. Mirrors the
+      // expression-statement path (formatIntegerLiteral). Returns null
+      // for non-numeric initialisers (enum names, constants), which then
+      // pass through unchanged.
+      const numeric = this.lowerNumericInitializer(initialValue);
+      if (numeric !== null) {
+        return numeric;
+      }
       return initialValue;
     }
 
@@ -5099,6 +5111,45 @@ export class CodeGenerator {
     // User-defined types (structs, enums, arrays, subranges, type aliases)
     // use default initialization - return empty string to skip in initializer list
     return "";
+  }
+
+  /**
+   * Lower an IEC numeric literal initializer string to a C++ literal.
+   *
+   * Handles based literals (16#FF, 8#17, 2#1010), decimals/reals with
+   * IEC underscore separators (1_000, 16#FF_FF), an optional leading
+   * sign (-5, +3), and an optional IEC type prefix (INT#5, BYTE#16#AB,
+   * REAL#1.5). Reuses {@link iecBaseToCppLiteral}, the same helper the
+   * expression path uses, so declaration initialisers and statement
+   * bodies lower identically.
+   *
+   * Returns `null` when `raw` is not a recognised numeric literal, so
+   * non-numeric initialisers (enum names, named constants) pass through
+   * unchanged at the call site.
+   */
+  private lowerNumericInitializer(raw: string): string | null {
+    let s = raw.trim();
+    let sign = "";
+    if (s.startsWith("-") || s.startsWith("+")) {
+      sign = s[0]!;
+      s = s.slice(1).trimStart();
+    }
+    // Strip an optional IEC type prefix (TYPE#...). The leading
+    // identifier must start with a letter/underscore, which excludes
+    // radix markers like `16#` whose left side is numeric.
+    const typePrefix = /^[A-Za-z_][A-Za-z0-9_]*#(.+)$/.exec(s);
+    if (typePrefix) {
+      s = typePrefix[1]!;
+    }
+    const isNumeric =
+      /^16#[0-9A-Fa-f][0-9A-Fa-f_]*$/.test(s) ||
+      /^8#[0-7][0-7_]*$/.test(s) ||
+      /^2#[01][01_]*$/.test(s) ||
+      /^[0-9][0-9_]*(\.[0-9][0-9_]*)?([eE][+-]?[0-9]+)?$/.test(s);
+    if (!isNumeric) {
+      return null;
+    }
+    return sign + iecBaseToCppLiteral(s);
   }
 
   /**

--- a/src/project-model.ts
+++ b/src/project-model.ts
@@ -831,6 +831,16 @@ export class ProjectModelBuilder {
       const lit = expr;
       return lit.rawValue;
     }
+    if (
+      expr.kind === "UnaryExpression" &&
+      (expr.operator === "-" || expr.operator === "+")
+    ) {
+      // Preserve the sign on numeric literal initialisers (e.g. -5).
+      // Without this the operand is dropped and the initialiser silently
+      // falls back to the type's default (0). Codegen lowers the result.
+      const inner = this.expressionToString(expr.operand);
+      return inner === "" ? "" : `${expr.operator}${inner}`;
+    }
     if (expr.kind === "VariableExpression") {
       if (expr.fieldAccess.length > 0) {
         return `${expr.name}.${expr.fieldAccess.join(".")}`;

--- a/tests/backend/codegen-literal-body.test.ts
+++ b/tests/backend/codegen-literal-body.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Companion to codegen-var-initializers.test.ts (issue #133).
+ *
+ * The initializer fix lowers numeric literals on the declaration path so
+ * it matches the statement-body path. These tests pin down the body path
+ * itself — based literals, IEC underscore separators, typed-literal
+ * prefixes, signs, and reals must lower to valid C++ wherever a literal
+ * can appear (assignment RHS, conditions, arithmetic, array indices),
+ * so the two paths can't drift apart later.
+ */
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../../dist/index.js";
+
+/** Compile a program body and return just the `run()` method text. */
+function runBody(statements: string, vars: string): string {
+  const result = compile(`
+    PROGRAM P
+      VAR ${vars} END_VAR
+      ${statements}
+    END_PROGRAM
+  `);
+  expect(result.success).toBe(true);
+  const lines = result.cppCode.split("\n");
+  const start = lines.findIndex((l) => l.includes("void Program_P::run"));
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = lines.findIndex((l, idx) => idx > start && l.trimEnd() === "}");
+  return lines.slice(start, end + 1).join("\n");
+}
+
+describe("issue #133: statement-body literal lowering", () => {
+  it("lowers based integer/bitstring literals", () => {
+    const body = runBody("u := 16#FF; u := 8#17; u := 2#1010;", "u : UDINT;");
+    expect(body).toContain("U = 0xFF;");
+    expect(body).toContain("U = 017;");
+    expect(body).toContain("U = 0b1010;");
+  });
+
+  it("strips IEC underscore separators", () => {
+    const body = runBody("u := 16#FF_FF; u := 1_000;", "u : UDINT;");
+    expect(body).toContain("U = 0xFFFF;");
+    expect(body).toContain("U = 1000;");
+  });
+
+  it("lowers typed-literal prefixes to static_cast", () => {
+    const body = runBody(
+      "i := INT#5; i := INT#16#10; bt := BYTE#16#AB; wd := WORD#16#1234;",
+      "i : INT; bt : BYTE; wd : WORD;",
+    );
+    expect(body).toContain("static_cast<IEC_INT>(5)");
+    expect(body).toContain("static_cast<IEC_INT>(0x10)");
+    expect(body).toContain("static_cast<IEC_BYTE>(0xAB)");
+    expect(body).toContain("static_cast<IEC_WORD>(0x1234)");
+  });
+
+  it("preserves signs, including on based literals", () => {
+    const body = runBody("i := -5; i := +3; li := -16#FF;", "i : INT; li : LINT;");
+    expect(body).toContain("I = -5;");
+    expect(body).toContain("I = +3;");
+    expect(body).toContain("LI = -0xFF;");
+  });
+
+  it("lowers based literals inside conditions, arithmetic and indices", () => {
+    const body = runBody(
+      "IF u > 16#10 THEN u := u + 16#01; END_IF; arr[2#11] := 16#AA;",
+      "u : UDINT; arr : ARRAY[0..15] OF INT;",
+    );
+    expect(body).toContain("U > 0x10");
+    expect(body).toContain("U + 0x01");
+    expect(body).toContain("ARR[0b11] = 0xAA;");
+  });
+
+  it("emits valid reals (decimal point or exponent)", () => {
+    const body = runBody(
+      "r := 1.5; r := 1.5E3; lr := 1.5E-10;",
+      "r : REAL; lr : LREAL;",
+    );
+    expect(body).toContain("R = 1.5;");
+    expect(body).toContain("R = 1500.0;");
+    expect(body).toContain("LR = 1.5e-10;");
+  });
+});

--- a/tests/backend/codegen-var-initializers.test.ts
+++ b/tests/backend/codegen-var-initializers.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for issue #133 — numeric literal lowering in VAR
+ * initializers.
+ *
+ * IEC numeric literals used as VAR initial values reach the program /
+ * global codegen path as raw IEC strings (project-model stringifies the
+ * initializer expression). They must be lowered to valid C++ the same
+ * way the expression-statement path lowers them — otherwise the
+ * constructor initializer list emits e.g. `X(16#FF)` / `X(INT#5)` /
+ * `X(1_000)` verbatim and the generated C++ fails to compile
+ * (`stray '#' in program`, bad digit separators), or a signed literal
+ * like `-5` is silently dropped to the type default.
+ */
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../../dist/index.js";
+
+function compileST(source: string): {
+  cppCode: string;
+  headerCode: string;
+  success: boolean;
+  errors: unknown[];
+} {
+  const result = compile(source);
+  return {
+    cppCode: result.cppCode,
+    headerCode: result.headerCode,
+    success: result.success,
+    errors: result.errors,
+  };
+}
+
+/** Extract the constructor initializer-list line for a program. */
+function initList(cpp: string): string {
+  const line = cpp.split("\n").find((l) => l.trimStart().startsWith(": "));
+  return line ?? "";
+}
+
+describe("issue #133: VAR initializer literal lowering", () => {
+  it("lowers based integer/bitstring literals (16#, 8#, 2#)", () => {
+    const { cppCode, success } = compileST(`
+      PROGRAM P
+        VAR
+          h : UDINT := 16#FF;
+          o : UDINT := 8#17;
+          b : UDINT := 2#1010;
+        END_VAR
+        h := h;
+      END_PROGRAM
+    `);
+    expect(success).toBe(true);
+    const inits = initList(cppCode);
+    expect(inits).toContain("H(0xFF)");
+    expect(inits).toContain("O(017)");
+    expect(inits).toContain("B(0b1010)");
+    // No raw IEC based-literal marker must survive in the init list.
+    expect(inits).not.toContain("#");
+  });
+
+  it("strips IEC underscore separators from initializers", () => {
+    const { cppCode, success } = compileST(`
+      PROGRAM P
+        VAR
+          x : UDINT := 16#FF_FF;
+          y : UDINT := 1_000;
+        END_VAR
+        x := x;
+      END_PROGRAM
+    `);
+    expect(success).toBe(true);
+    const inits = initList(cppCode);
+    expect(inits).toContain("X(0xFFFF)");
+    expect(inits).toContain("Y(1000)");
+    // The IEC underscore separators must be gone from the init list.
+    expect(inits).not.toContain("_");
+  });
+
+  it("strips IEC typed-literal prefixes (INT#, BYTE#, REAL#)", () => {
+    const { cppCode, success } = compileST(`
+      PROGRAM P
+        VAR
+          a : INT  := INT#5;
+          b : INT  := INT#16#10;
+          c : BYTE := BYTE#16#AB;
+          d : REAL := REAL#1.5;
+        END_VAR
+        a := a;
+      END_PROGRAM
+    `);
+    expect(success).toBe(true);
+    const inits = initList(cppCode);
+    expect(inits).toContain("A(5)");
+    expect(inits).toContain("B(0x10)");
+    expect(inits).toContain("C(0xAB)");
+    expect(inits).toContain("D(1.5)");
+    expect(inits).not.toContain("#");
+  });
+
+  it("preserves the sign on negative/positive literal initializers", () => {
+    const { cppCode, success } = compileST(`
+      PROGRAM P
+        VAR
+          n : INT := -5;
+          p : INT := +3;
+        END_VAR
+        n := n;
+      END_PROGRAM
+    `);
+    expect(success).toBe(true);
+    const inits = initList(cppCode);
+    expect(inits).toContain("N(-5)");
+    // A dropped sign would regress to the default 0.
+    expect(inits).not.toContain("N(0)");
+  });
+
+  it("leaves decimals, reals and non-numeric initializers unchanged", () => {
+    const { cppCode, success } = compileST(`
+      PROGRAM P
+        VAR
+          d : UDINT := 255;
+          r : REAL  := 1.5;
+          e : REAL  := 1.5E3;
+          t : BOOL  := TRUE;
+        END_VAR
+        d := d;
+      END_PROGRAM
+    `);
+    expect(success).toBe(true);
+    const inits = initList(cppCode);
+    expect(inits).toContain("D(255)");
+    expect(inits).toContain("R(1.5)");
+    expect(inits).toContain("E(1.5E3)");
+    expect(inits).toContain("T(true)");
+  });
+
+  it("lowers based literals in VAR_GLOBAL initializers too", () => {
+    const { cppCode, success } = compileST(`
+      CONFIGURATION Cfg
+        VAR_GLOBAL
+          g : UDINT := 16#CAFE;
+        END_VAR
+      END_CONFIGURATION
+    `);
+    expect(success).toBe(true);
+    expect(cppCode).toContain("0xCAFE");
+    expect(cppCode).not.toContain("16#");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #133 — a hex literal used as a `VAR` initial value was copied verbatim into the generated C++ constructor initializer list (`X(16#FF)`), so the output failed to compile (`error: stray '#' in program`). The same literal in a statement body lowered correctly, so only the initializer codegen path was affected.

## Root cause

PROGRAM/GLOBAL `VAR` initialisers reach codegen as **raw IEC strings** — `project-model.expressionToString()` returns the literal's `rawValue`, and `codegen.getDefaultValue()` never lowered numeric strings (it only special-cased TIME/DATE/BOOL/STRING). `expressionToString()` also returned `""` for any non-literal/non-variable node, so a unary expression like `-5` was dropped and the initialiser silently fell back to the type default `0`.

## Scope — checked every literal form in the initializer position and fixed them together

| Form | Before | After |
|------|--------|-------|
| based int/bitstring | `X(16#FF)`, `X(8#17)`, `X(2#1010)` ❌ | `0xFF`, `017`, `0b1010` ✅ |
| underscore separators | `X(16#FF_FF)`, `X(1_000)` ❌ | `0xFFFF`, `1000` ✅ |
| typed prefixes | `X(INT#5)`, `X(BYTE#16#AB)`, `X(REAL#1.5)` ❌ | `5`, `0xAB`, `1.5` ✅ |
| signed literal | `X(-5)` → `X(0)` (lost) ❌ | `-5`, `+3` ✅ |
| decimal/real/bool/string | already valid ✅ | unchanged ✅ |
| enum names / named constants | passed through ✅ | unchanged ✅ |

FB initialisers already routed through the expression path and were unaffected; struct fields emit valid decimal. The fix also covers the `VAR_GLOBAL` path (`getDefaultValue` is shared).

## Implementation
- `project-model.ts`: `expressionToString` now preserves the sign of unary `+`/`-` literal initialisers.
- `codegen.ts`: new `lowerNumericInitializer` helper (reuses the existing `iecBaseToCppLiteral`, so declaration initialisers and statement bodies lower identically); `getDefaultValue` calls it before the verbatim fall-through.

## Verification
- New `tests/backend/codegen-var-initializers.test.ts` (6 cases) covers all forms above incl. `VAR_GLOBAL`.
- Full suite green (1992 passed), typecheck + lint clean.
- g++ `-std=c++17 -fsyntax-only` on the issue's repro and a combined PROGRAM/FB/struct sample: compiles (exit 0); the original `repro.st` now emits `: X(0xFF)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)