### PR TITLE
test: fix fragile/vacuous assertions (#75)

### DIFF
--- a/tests/integration/oscat-gpp-compile.test.ts
+++ b/tests/integration/oscat-gpp-compile.test.ts
@@ -124,10 +124,14 @@ describe.skipIf(!hasGpp || !oscatStlibAvailable)(
         const cppPath = path.join(tempDir, "oscat_all.cpp");
 
         if (!fs.existsSync(hppPath) || !fs.existsSync(cppPath)) {
-          console.warn(
-            "Skipping — no transpiled output available from previous step",
+          // The suite is already gated on g++/stlib availability
+          // (describe.skipIf above), so reaching here means the preceding
+          // transpile test failed to emit output. That is a real failure —
+          // fail loudly rather than returning and passing vacuously.
+          expect.fail(
+            "No transpiled OSCAT output (oscat_all.hpp/.cpp) from the " +
+              "previous step — the transpile test must have failed.",
           );
-          return;
         }
 
         // Generate test .st that instantiates every FB from the archive manifest
@@ -209,7 +213,6 @@ describe.skipIf(!hasGpp || !oscatStlibAvailable)(
           expect.fail(
             `g++ full compile+link failed with ${errorLines.length} errors`,
           );
-          return;
         }
 
         // Run the binary

--- a/tests/semantic/located-variables.test.ts
+++ b/tests/semantic/located-variables.test.ts
@@ -203,7 +203,14 @@ describe('Phase 2.3 - Located Variables', () => {
       `;
       const result = compile(source);
       expect(result.success).toBe(false);
-      expect(result.errors.some(e => e.message.includes('FUNCTION_BLOCK'))).toBe(true);
+      // Anchor on the distinctive rule text rather than the generic token
+      // 'FUNCTION_BLOCK' (which any unrelated FB error would satisfy), so the
+      // test fails if a *different* error fires or the located-var check stops.
+      expect(
+        result.errors.some(e =>
+          e.message.includes('Located variables can only be declared'),
+        ),
+      ).toBe(true);
     });
 
     it('should allow located variable in program', () => {


### PR DESCRIPTION
Closes #75.

## Summary

Addresses #75. Of its three sub-items, **two are still valid** and fixed here; **one was already resolved**.

### 1. `oscat-gpp-compile.test.ts` — vacuous pass (fixed)
The "compiles and runs full OSCAT" test silently `return`ed when no transpiled output existed, so it could **pass without testing anything**. The suite is already gated by `describe.skipIf(!hasGpp || !oscatStlibAvailable)`, so a missing artifact means the preceding transpile test failed — a real failure. Replaced the silent return with `expect.fail(...)`, and removed a dead `return` after an existing `expect.fail`.

### 2. `located-variables.test.ts` — fragile string-contains (fixed)
`should error on located variable in function block` asserted `message.includes('FUNCTION_BLOCK')` — a generic token that **any unrelated FB error would satisfy** (vacuous match). Anchored it to the distinctive rule text `"Located variables can only be declared …"` so the test fails if a different error fires or the located-var check regresses.

> Note: the issue suggested "assert on error code/type instead", but `CompileError.code` is **not populated** anywhere in `src/semantic/` — introducing an error-code taxonomy across the analyzer is a much larger, separate change. Anchoring on distinctive message text removes the actual fragility (vacuous matching) without that scope.

### 3. `codesys-import.test.ts` — already fixed
The "V3 vs V2.3 counts comparable" test already uses `toBeGreaterThan(...)` tolerance checks, not the brittle exact `toBe(v23fn)` equality the issue described. No change needed.

## Verification
Affected files pass (76 tests); the OSCAT test genuinely ran (172 FB instantiation tests), confirming it's no longer vacuous.

Supersedes the stale, conflicting PR #83 (it touched `src/index.ts`/`analyzer.ts` and the already-fixed codesys test, and conflicts against current `development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)