### PR TITLE
feat(vscode): hover docs for built-in IEC data types (#55)

### DIFF
--- a/vscode-extension/server/src/hover.ts
+++ b/vscode-extension/server/src/hover.ts
@@ -25,6 +25,7 @@ import { typeName } from "strucpp";
 import { resolveSymbolAtPosition, lookupSymbolByName } from "./resolve-symbol.js";
 import { sourceSpanToRange, restoreCase } from "./lsp-utils.js";
 import { isTestFile, getWordAt } from "../../shared/test-utils.js";
+import { getIecTypeDoc } from "./iec-type-docs.js";
 
 /** Shorthand: restore casing via the case map. */
 type CaseMap = ReadonlyMap<string, string>;
@@ -44,6 +45,18 @@ export function getHover(
   if (source && isTestFile(source)) {
     const testHover = getTestKeywordHover(source, line, column);
     if (testHover) return testHover;
+  }
+
+  // Built-in IEC data type hover (INT, TIME, LREAL, …). Type names are
+  // reserved keywords, so the word under the cursor can never also be a
+  // user symbol — resolve this directly from the source text, independent
+  // of AST symbol resolution (type references often have no symbol node).
+  if (source !== undefined) {
+    const w = getWordAt(source, line, column);
+    if (w !== undefined) {
+      const typeDoc = getIecTypeDoc(w.word);
+      if (typeDoc !== null) return makeHover(typeDoc);
+    }
   }
 
   const resolved = resolveSymbolAtPosition(analysis, fileName, line, column);

--- a/vscode-extension/server/src/iec-type-docs.ts
+++ b/vscode-extension/server/src/iec-type-docs.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Hover documentation for the built-in IEC 61131-3 elementary data types.
+ *
+ * Sizes/representations describe how STruC++ actually lowers each type (see
+ * `src/runtime/include/iec_types.hpp`), not a generic PLC assumption — in
+ * particular every temporal type (TIME/LTIME/DATE/TOD/DT) is a signed 64-bit
+ * integer here, not the 32-bit milliseconds some controllers use.
+ */
+
+/** Built-in IEC type name (upper-case) → markdown hover text. */
+export const IEC_TYPE_DOCS: Readonly<Record<string, string>> = {
+  // --- Boolean / bit strings ---
+  BOOL: "**BOOL** (*Boolean*)\n\nSingle-bit boolean. Values: `TRUE` or `FALSE`.\n\n**Size:** 1 bit (1 byte in memory)",
+  BYTE: "**BYTE** (*Bit String 8*)\n\nUnsigned 8-bit value. Range: `0` … `255` (`16#00` … `16#FF`).\n\n**Size:** 8 bits",
+  WORD: "**WORD** (*Bit String 16*)\n\nUnsigned 16-bit value. Range: `0` … `65535`.\n\n**Size:** 16 bits",
+  DWORD:
+    "**DWORD** (*Bit String 32*)\n\nUnsigned 32-bit value. Range: `0` … `4294967295`.\n\n**Size:** 32 bits",
+  LWORD:
+    "**LWORD** (*Bit String 64*)\n\nUnsigned 64-bit value. Range: `0` … `2⁶⁴-1`.\n\n**Size:** 64 bits",
+
+  // --- Signed integers ---
+  SINT: "**SINT** (*Short Integer*)\n\nSigned 8-bit integer. Range: `-128` … `127`.\n\n**Size:** 8 bits",
+  INT: "**INT** (*Integer*)\n\nSigned 16-bit integer. Range: `-32768` … `32767`.\n\n**Size:** 16 bits",
+  DINT: "**DINT** (*Double Integer*)\n\nSigned 32-bit integer. Range: `-2147483648` … `2147483647`.\n\n**Size:** 32 bits",
+  LINT: "**LINT** (*Long Integer*)\n\nSigned 64-bit integer. Range: `-2⁶³` … `2⁶³-1`.\n\n**Size:** 64 bits",
+
+  // --- Unsigned integers ---
+  USINT:
+    "**USINT** (*Unsigned Short Integer*)\n\nUnsigned 8-bit integer. Range: `0` … `255`.\n\n**Size:** 8 bits",
+  UINT: "**UINT** (*Unsigned Integer*)\n\nUnsigned 16-bit integer. Range: `0` … `65535`.\n\n**Size:** 16 bits",
+  UDINT:
+    "**UDINT** (*Unsigned Double Integer*)\n\nUnsigned 32-bit integer. Range: `0` … `4294967295`.\n\n**Size:** 32 bits",
+  ULINT:
+    "**ULINT** (*Unsigned Long Integer*)\n\nUnsigned 64-bit integer. Range: `0` … `2⁶⁴-1`.\n\n**Size:** 64 bits",
+
+  // --- Floating point ---
+  REAL: "**REAL** (*Real*)\n\nSingle-precision IEEE-754 float. Range: ±3.4×10³⁸ (~7 significant digits).\n\n**Size:** 32 bits",
+  LREAL:
+    "**LREAL** (*Long Real*)\n\nDouble-precision IEEE-754 float. Range: ±1.8×10³⁰⁸ (~15 significant digits).\n\n**Size:** 64 bits",
+
+  // --- Time / date (STruC++ represents all of these as signed int64) ---
+  TIME: "**TIME** (*Duration*)\n\nSigned 64-bit duration counted in **nanoseconds**. Literal: `T#1h30m` or `TIME#500ms`.\n\n**Size:** 64 bits (nanoseconds)",
+  LTIME:
+    "**LTIME** (*Long Duration*)\n\nHigh-resolution duration, signed 64-bit **nanoseconds**. Literal: `LTIME#1h30m0s500ms`.\n\n**Size:** 64 bits (nanoseconds)",
+  DATE: "**DATE** (*Date*)\n\nCalendar date as signed 64-bit **days** since the Unix epoch (UTC). Literal: `D#2024-01-31` or `DATE#2024-01-31`.\n\n**Size:** 64 bits (days)",
+  TIME_OF_DAY:
+    "**TIME_OF_DAY** (*Time of Day*)\n\nTime within a day as signed 64-bit **nanoseconds** since midnight. Literal: `TOD#12:30:00` or `TIME_OF_DAY#08:00:00.500`.\n\n**Size:** 64 bits (nanoseconds)",
+  TOD: "**TOD** (*Time of Day*)\n\nShort alias for `TIME_OF_DAY` — signed 64-bit nanoseconds since midnight. Literal: `TOD#12:30:00`.\n\n**Size:** 64 bits (nanoseconds)",
+  DATE_AND_TIME:
+    "**DATE_AND_TIME** (*Date and Time*)\n\nCombined timestamp as signed 64-bit **nanoseconds** since the Unix epoch (UTC). Literal: `DT#2024-01-31-12:30:00`.\n\n**Size:** 64 bits (nanoseconds)",
+  DT: "**DT** (*Date and Time*)\n\nShort alias for `DATE_AND_TIME` — signed 64-bit nanoseconds since the Unix epoch (UTC). Literal: `DT#2024-01-31-12:30:00`.\n\n**Size:** 64 bits (nanoseconds)",
+
+  // --- Character strings ---
+  STRING:
+    "**STRING** (*String*)\n\nSingle-byte character string. Default capacity 80; declare a length with `STRING[255]`.",
+  WSTRING:
+    "**WSTRING** (*Wide String*)\n\nWide (UTF-16 / `char16_t`) character string. Declare a length with `WSTRING[255]`.",
+  CHAR: "**CHAR** (*Character*)\n\nSingle single-byte character.\n\n**Size:** 8 bits",
+  WCHAR:
+    "**WCHAR** (*Wide Character*)\n\nSingle wide (UTF-16 / `char16_t`) character.\n\n**Size:** 16 bits",
+};
+
+/**
+ * Markdown hover text for a word if it names a built-in IEC data type.
+ * Case-insensitive (IEC identifiers are). Returns `null` otherwise.
+ */
+export function getIecTypeDoc(word: string): string | null {
+  return IEC_TYPE_DOCS[word.toUpperCase()] ?? null;
+}

--- a/vscode-extension/tests/unit/hover.test.ts
+++ b/vscode-extension/tests/unit/hover.test.ts
@@ -169,3 +169,44 @@ END_PROGRAM
     }
   });
 });
+
+describe("getHover — built-in IEC data type docs (#55)", () => {
+  it("shows type documentation when hovering a built-in type name", () => {
+    const source = [
+      "PROGRAM P",
+      "  VAR",
+      "    n : INT;",
+      "    t : TIME;",
+      "  END_VAR",
+      "  n := n;",
+      "END_PROGRAM",
+      "",
+    ].join("\n");
+    const analysis = analyze(source, { fileName: "types.st" });
+    const lines = source.split("\n");
+
+    const intLine = lines.findIndex((l) => l.includes(": INT")) + 1;
+    const intCol = lines[intLine - 1].indexOf("INT") + 1;
+    const intHover = getHover(analysis, "types.st", intLine, intCol, undefined, source);
+    expect(intHover).not.toBeNull();
+    const intValue = (intHover!.contents as { value: string }).value;
+    expect(intValue).toContain("**INT**");
+    expect(intValue).toContain("16 bits");
+
+    const timeLine = lines.findIndex((l) => l.includes(": TIME")) + 1;
+    const timeCol = lines[timeLine - 1].indexOf("TIME") + 1;
+    const timeHover = getHover(analysis, "types.st", timeLine, timeCol, undefined, source);
+    expect((timeHover!.contents as { value: string }).value).toContain("nanoseconds");
+  });
+
+  it("does not hijack hover on a variable name", () => {
+    const source = "PROGRAM P\n  VAR n : INT; END_VAR\n  n := n;\nEND_PROGRAM\n";
+    const analysis = analyze(source, { fileName: "v.st" });
+    const col = source.split("\n")[2].indexOf("n") + 1; // the 'n' in 'n := n'
+    const hover = getHover(analysis, "v.st", 3, col, undefined, source);
+    if (hover) {
+      const value = (hover.contents as { value: string }).value;
+      expect(value).not.toContain("Signed 16-bit integer");
+    }
+  });
+});

--- a/vscode-extension/tests/unit/iec-type-docs.test.ts
+++ b/vscode-extension/tests/unit/iec-type-docs.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+import { describe, it, expect } from "vitest";
+import {
+  getIecTypeDoc,
+  IEC_TYPE_DOCS,
+} from "../../server/src/iec-type-docs.js";
+
+const ALL_TYPES = [
+  "BOOL", "BYTE", "WORD", "DWORD", "LWORD",
+  "SINT", "INT", "DINT", "LINT",
+  "USINT", "UINT", "UDINT", "ULINT",
+  "REAL", "LREAL",
+  "TIME", "LTIME", "DATE", "TIME_OF_DAY", "TOD", "DATE_AND_TIME", "DT",
+  "STRING", "WSTRING", "CHAR", "WCHAR",
+];
+
+describe("getIecTypeDoc", () => {
+  it("returns markdown for every built-in IEC type", () => {
+    for (const t of ALL_TYPES) {
+      const doc = getIecTypeDoc(t);
+      expect(doc, t).not.toBeNull();
+      expect(doc, t).toContain(`**${t}**`); // bold type name header
+    }
+  });
+
+  it("covers exactly the documented type set (no orphans)", () => {
+    expect(Object.keys(IEC_TYPE_DOCS).sort()).toEqual([...ALL_TYPES].sort());
+  });
+
+  it("is case-insensitive", () => {
+    expect(getIecTypeDoc("int")).toBe(getIecTypeDoc("INT"));
+    expect(getIecTypeDoc("Lreal")).toBe(getIecTypeDoc("LREAL"));
+  });
+
+  it("returns null for non-type words", () => {
+    expect(getIecTypeDoc("PROGRAM")).toBeNull();
+    expect(getIecTypeDoc("myVar")).toBeNull();
+    expect(getIecTypeDoc("INT_TO_REAL")).toBeNull();
+    expect(getIecTypeDoc("")).toBeNull();
+  });
+
+  it("documents the temporal types as STruC++ implements them (int64)", () => {
+    // Regression guard: these are NOT 32-bit ms in STruC++ — all 64-bit.
+    for (const t of ["TIME", "LTIME", "TOD", "TIME_OF_DAY", "DATE_AND_TIME", "DT"]) {
+      expect(getIecTypeDoc(t), t).toContain("64 bits (nanoseconds)");
+    }
+    expect(getIecTypeDoc("DATE")).toContain("64 bits (days)");
+  });
+
+  it("documents signed/unsigned integer widths correctly", () => {
+    expect(getIecTypeDoc("INT")).toContain("16 bits");
+    expect(getIecTypeDoc("DINT")).toContain("32 bits");
+    expect(getIecTypeDoc("LINT")).toContain("64 bits");
+    expect(getIecTypeDoc("USINT")).toContain("8 bits");
+  });
+});


### PR DESCRIPTION
Closes #55.

## Summary

Hovering a built-in IEC 61131-3 type name (`INT`, `TIME`, `LREAL`, …) in a `.st` file now shows a markdown tooltip with the full name, category, value range, bit size, and literal syntax. Hovering a non-type word returns nothing (or the normal symbol hover).

- **New `server/src/iec-type-docs.ts`** — `IEC_TYPE_DOCS` map (26 elementary types) + `getIecTypeDoc(word)`.
- **`hover.ts` `getHover`** — resolves a built-in type name from the source word at the cursor. Type names are reserved keywords, so they never collide with user symbols and often have no AST symbol node; doing a direct text lookup is the reliable approach. The server already advertises `hoverProvider: true` and routes `onHover → getHover` (both `server.ts` and `server-browser.ts`), so **no wiring change was needed**.

## Does PR #56 address this on the current codebase? No.

PR #56 was the right idea but doesn't fit today's code:
- It's **closed/unmerged**, based on the stale `feature/vscode-extension` branch.
- It adds a standalone `hover-provider.ts` + direct `server.ts` `onHover` wiring — but hover has since been **consolidated into `hover.ts`/`getHover`** (called from `register-analysis-handlers.ts`). Its integration would conflict/duplicate.
- **Its data is wrong for STruC++**: it documents `TIME`/`DATE`/`TOD`/`DT` as *32-bit*, but `src/runtime/include/iec_types.hpp` defines all of them as **signed int64** (TIME/LTIME/TOD/DT in nanoseconds, DATE in days). The new docs are corrected to match the actual implementation.

So I implemented it fresh against the current architecture and salvaged only the accurate parts of #56's type table.

## Tests
- `iec-type-docs.test.ts` — all 26 types return docs, case-insensitivity, null cases, and a regression guard that the temporal types are documented as int64 (not 32-bit ms).
- `hover.test.ts` — integration: hovering `INT`/`TIME` shows the docs; hovering a variable name does not get hijacked.
- Full extension suite green (**252 tests**); `tsc -b` build clean; additions are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)