### PR TITLE
test: import src/ not dist/ in tests + dist guard & package smoke (#71)

### DIFF
--- a/tests/backend/build-utils.test.ts
+++ b/tests/backend/build-utils.test.ts
@@ -3,11 +3,11 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
-import { splitCxxFlags } from "../../dist/cxx-flags.js";
+import { splitCxxFlags } from "../../src/cxx-flags.js";
 import {
   findRuntimeIncludeDir,
   isCompilerAvailable,
-} from "../../dist/node/build-utils.js";
+} from "../../src/node/build-utils.js";
 
 describe("splitCxxFlags", () => {
   it("splits simple flags", () => {

--- a/tests/backend/codegen-composite.test.ts
+++ b/tests/backend/codegen-composite.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): { cppCode: string; headerCode: string; success: boolean; errors: unknown[] } {
   const result = compile(source);

--- a/tests/backend/codegen-control-flow.test.ts
+++ b/tests/backend/codegen-control-flow.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): { cppCode: string; headerCode: string; success: boolean; errors: unknown[]; warnings: unknown[] } {
   const result = compile(source);

--- a/tests/backend/codegen-dynamic-memory.test.ts
+++ b/tests/backend/codegen-dynamic-memory.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): {
   cppCode: string;

--- a/tests/backend/codegen-fb.test.ts
+++ b/tests/backend/codegen-fb.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileAndCheck(source: string) {
   const result = compile(source);

--- a/tests/backend/codegen-literal-body.test.ts
+++ b/tests/backend/codegen-literal-body.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 /** Compile a program body and return just the `run()` method text. */
 function runBody(statements: string, vars: string): string {

--- a/tests/backend/codegen-oop.test.ts
+++ b/tests/backend/codegen-oop.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileAndCheck(source: string) {
   const result = compile(source);

--- a/tests/backend/codegen-var-initializers.test.ts
+++ b/tests/backend/codegen-var-initializers.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): {
   cppCode: string;

--- a/tests/backend/codegen-vla.test.ts
+++ b/tests/backend/codegen-vla.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 function compileST(source: string): {
   cppCode: string;

--- a/tests/backend/codegen-wstring-literals.test.ts
+++ b/tests/backend/codegen-wstring-literals.test.ts
@@ -31,7 +31,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile, parse } from "../../dist/index.js";
+import { compile, parse } from "../../src/index.js";
 
 describe("WSTRING literal handling", () => {
   describe("parser", () => {

--- a/tests/backend/test-main-gen.test.ts
+++ b/tests/backend/test-main-gen.test.ts
@@ -5,9 +5,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { generateTestMain } from "../../dist/backend/test-main-gen.js";
-import type { POUInfo } from "../../dist/backend/test-main-gen.js";
-import type { TestFile } from "../../dist/testing/test-model.js";
+import { generateTestMain } from "../../src/backend/test-main-gen.js";
+import type { POUInfo } from "../../src/backend/test-main-gen.js";
+import type { TestFile } from "../../src/testing/test-model.js";
 
 /** Helper to create a basic POUInfo for a program */
 function programPOU(name: string, vars: Record<string, string> = {}): POUInfo {

--- a/tests/diagnostic-pou-context.test.ts
+++ b/tests/diagnostic-pou-context.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../dist/index.js";
+import { compile } from "../src/index.js";
 
 describe("CompileError POU annotation", () => {
   describe("var-block errors", () => {

--- a/tests/il/il-additional-sources.test.ts
+++ b/tests/il/il-additional-sources.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { compile } from "../../dist/index.js";
+import { compile } from "../../src/index.js";
 
 describe("IL transpilation across additionalSources", () => {
   it("compiles an IL POU passed via additionalSources alongside an ST primary", () => {

--- a/tests/integration/package-smoke.test.ts
+++ b/tests/integration/package-smoke.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Package smoke test — exercises the COMPILED artifact in `dist/`.
+ *
+ * Every other test imports `../../src/...` so it runs the TypeScript source
+ * (transpiled on the fly by Vite) and counts toward `src/**` coverage. This
+ * file is the one deliberate exception: it imports the built `dist/index.js`
+ * — the exact entry point the npm package ships (`package.json` "main" /
+ * "exports") and that consumers like the OpenPLC Editor import.
+ *
+ * It guards what `src/` tests cannot: that `tsc` actually emits a working
+ * public API (correct export surface, ESM resolution, no type-only import
+ * that vanishes at runtime). The `no-dist-imports` guard test explicitly
+ * allows this file.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as pkg from "../../dist/index.js";
+
+const EXPECTED_EXPORTS = [
+  "compile",
+  "parse",
+  "analyze",
+  "getVersion",
+  "compileStlib",
+] as const;
+
+describe("package smoke (compiled dist/ artifact)", () => {
+  it("exposes the documented public API as functions", () => {
+    for (const name of EXPECTED_EXPORTS) {
+      expect(typeof (pkg as Record<string, unknown>)[name], name).toBe(
+        "function",
+      );
+    }
+    // defaultOptions is a value export, not a function
+    expect(pkg.defaultOptions).toBeDefined();
+  });
+
+  it("compiles a trivial program end-to-end through the built output", () => {
+    const result = pkg.compile(
+      "PROGRAM P\nVAR n : INT; END_VAR\nn := n + 1;\nEND_PROGRAM\n",
+    );
+    expect(result.success).toBe(true);
+    expect(result.cppCode).toContain("Program_P");
+    expect(result.headerCode.length).toBeGreaterThan(0);
+  });
+
+  it("reports a semver version string", () => {
+    expect(pkg.getVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/tests/library/codesys-import.test.ts
+++ b/tests/library/codesys-import.test.ts
@@ -16,11 +16,11 @@ import {
   readLEB128,
   formatPOU,
   pouToSources,
-} from "../../dist/library/codesys-import/index.js";
+} from "../../src/library/codesys-import/index.js";
 import type {
   CodesysImportResult,
   ExtractedPOU,
-} from "../../dist/library/codesys-import/index.js";
+} from "../../src/library/codesys-import/index.js";
 
 // Tests previously called `await importCodesysLibrary(path)`; the public
 // API is now bytes-first so the file read sits in the test harness.

--- a/tests/no-dist-imports.test.ts
+++ b/tests/no-dist-imports.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Guard: test files must import the TypeScript source (`../../src/…`), not
+ * the compiled `dist/…` output.
+ *
+ * Why a test and not an ESLint rule: `npm run lint` only lints `src/`, and
+ * test files are excluded from `tsconfig.json`, so the type-aware ESLint
+ * config can't lint them without a separate project. This test enforces the
+ * rule reliably in CI instead.
+ *
+ * Why it matters: coverage is collected on `src/**` (`vitest.config.ts`),
+ * with `dist/` excluded and not remapped. A test that imports `dist/` runs
+ * the compiled output and contributes *nothing* to `src/` coverage — so the
+ * code it exercises looks untested. Import `src/` for behavior tests; the
+ * one deliberate exception (validating the shipped artifact) is the package
+ * smoke test, allow-listed below.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TESTS_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+/** Test files permitted to import the compiled `dist/` artifact on purpose. */
+const ALLOWLIST = new Set<string>([
+  "integration/package-smoke.test.ts",
+  "no-dist-imports.test.ts",
+]);
+
+/** A `from "<…>/dist/…"` import/export specifier. */
+const DIST_IMPORT = /\bfrom\s+["'][^"']*\/dist\//;
+
+function allTestFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...allTestFiles(full));
+    else if (entry.name.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+describe("test suite hygiene", () => {
+  it("no test imports the compiled dist/ output (behavior tests must use src/)", () => {
+    const offenders: string[] = [];
+    for (const file of allTestFiles(TESTS_DIR)) {
+      const rel = relative(TESTS_DIR, file).split("\\").join("/");
+      if (ALLOWLIST.has(rel)) continue;
+      if (DIST_IMPORT.test(readFileSync(file, "utf8"))) offenders.push(rel);
+    }
+    expect(
+      offenders,
+      "These tests import dist/ instead of src/ — they run the compiled " +
+        "output and are lost to src/ coverage. Switch to ../../src/…, or " +
+        "add to the allowlist if intentionally testing the shipped artifact:\n  " +
+        offenders.join("\n  "),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #71.

## Summary

Behavior tests were importing the compiled `dist/` output. Since coverage is collected on `src/**` (`dist/` excluded, not remapped), those tests contributed **zero** to `src/` coverage — proven: `codegen-composite.test.ts` now attributes **~46%** to `src/backend/codegen.ts`, where importing `dist/` it counted **0%**. (The issue's "fails without a build" rationale is moot — the vitest `globalSetup` runs `tsc` first — but the **coverage-attribution** problem is real, which is the actual justification.)

- **Converted all 14 dist-importing test files** to `../…/src/…` (vite resolves the `.js` specifiers to `.ts`, as the rest of the suite already does). My grep pass found 13; the new guard caught a **14th** at the `tests/` root (`diagnostic-pou-context.test.ts`, one `../` deep) — the issue had listed 9.
- **Added `tests/no-dist-imports.test.ts`** — a guard that fails if any test imports `dist/`. Implemented as a *test* rather than ESLint because `npm run lint` only covers `src/` and tests are excluded from `tsconfig.json`, so type-aware ESLint can't lint them without a separate project. The guard is allow-listed for the smoke test.
- **Added `tests/integration/package-smoke.test.ts`** — the one deliberate `dist/` consumer: imports the shipped `dist/index.js`, asserts the public API surface + a trivial end-to-end compile. Validates `tsc` emit / exports / ESM resolution that `src/` (vite-transpiled) tests can't.

Full suite: **74 files, 1913 passed / 7 skipped**.

## Re: PR #77
Supersedes the stale **#77** — it converted only 8 of the (then 9, now 14) files and conflicts against current `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)