### PR TITLE
feat(runtime): add read-through proxies on IECStringVar / IECWStringVar

### DIFF
--- a/src/runtime/include/iec_string.hpp
+++ b/src/runtime/include/iec_string.hpp
@@ -417,6 +417,34 @@ public:
         return *this;
     }
 
+    // Read-through proxies into the inner IECString.  Without these,
+    // user code in C/C++ POU bodies has to write `name.get().c_str()`
+    // / `name.get().length()` for every read — `IECStringVar` would
+    // otherwise expose nothing but `get()` / `set()` / `operator=` to
+    // its consumers.  Routed through the force-aware value (forced
+    // value when forcing is active, underlying value otherwise) so
+    // every read respects force semantics the same way `IECVar<T>`'s
+    // `operator T()` already does for numeric pins.  Returning the
+    // pointer to the persistent member (not to `get()`'s temporary)
+    // keeps `c_str()`'s buffer stable for the lifetime of `*this`.
+    //
+    // NOTE: only methods that didn't previously exist on
+    // `IECStringVar` are added here.  Comparison (`operator==` etc.)
+    // is intentionally NOT proxied — the free-function overloads at
+    // the bottom of this file (`operator==(IECStringVar, IECString)`
+    // and converse) already handle every cross-class compare path,
+    // and adding member operators would risk overload ambiguity at
+    // ST call sites that previously bound to the free functions.
+    constexpr size_t length() const noexcept {
+        return (forced_ ? forced_value_ : value_).length();
+    }
+    const char* c_str() const noexcept {
+        return (forced_ ? forced_value_ : value_).c_str();
+    }
+    char operator[](size_t index) const noexcept {
+        return (forced_ ? forced_value_ : value_)[index];
+    }
+
 private:
     value_type value_;
     bool forced_;

--- a/src/runtime/include/iec_wstring.hpp
+++ b/src/runtime/include/iec_wstring.hpp
@@ -433,6 +433,22 @@ public:
         return *this;
     }
 
+    // Read-through proxies into the inner IECWString.  Mirror of the
+    // IECStringVar proxy set — see `iec_string.hpp` for the design
+    // rationale, including why comparison operators are intentionally
+    // NOT proxied (free-function `==` / `!=` overloads already cover
+    // every cross-class compare path, and adding member operators
+    // would risk overload ambiguity at ST call sites).
+    constexpr size_t length() const noexcept {
+        return (forced_ ? forced_value_ : value_).length();
+    }
+    const char16_t* c_str() const noexcept {
+        return (forced_ ? forced_value_ : value_).c_str();
+    }
+    char16_t operator[](size_t index) const noexcept {
+        return (forced_ ? forced_value_ : value_)[index];
+    }
+
 private:
     value_type value_;
     bool forced_;


### PR DESCRIPTION
## Summary

Without these proxies, user code reading a STRING / WSTRING pin has to write `name.get().c_str()` / `name.get().length()` / `name.get()[i]` for every read — `IECStringVar` would otherwise expose nothing but `get()` / `set()` / `operator=` to its consumers.

Add `length()`, `c_str()`, and `operator[]` (read-only — returns `char` / `char16_t` by value) on both `IECStringVar<MaxLen>` and `IECWStringVar<MaxLen>`, routed through the force-aware value (`forced_value_` when forcing is active, `value_` otherwise). This mirrors how `IECVar<T>::operator T()` already exposes the underlying numeric for force-respecting reads on numeric pins.

## Why comparison operators are NOT proxied

`operator==` / `operator!=` are intentionally left off the wrapper. The free-function overloads at the bottom of each header already cover every cross-class compare path:

```cpp
inline bool operator==(const IECString<L1>& a, const IECStringVar<L2>& b)
inline bool operator==(const IECStringVar<L1>& a, const IECString<L2>& b)
inline bool operator==(const IECStringVar<L1>& a, const IECStringVar<L2>& b)
inline bool operator==(const IECStringVar<L1>& a, const char* b)
// + converse / IECVar wrappers
```

Adding member operators on `IECStringVar` would risk overload ambiguity at ST call sites that currently bind to the free functions.

## Unlocks

- openplc-editor PR #831 (c_blocks STRING/WSTRING standardization) — user C/C++ POU bodies can now read pins via plain `name.length()` / `name.c_str()` / `name[i]`.
- The matching openplc-web mirror PR will follow once this is released as v0.5.1.

## Test plan

- [x] `npm run build` succeeds.
- [x] Integration tests pass: `npx vitest run tests/integration/st-validation.test.ts` → 64/64 green.
- [ ] Reviewer: verify the integration test suite still passes in CI.
- [ ] Reviewer: confirm no diagnostic on `iec_string.hpp` / `iec_wstring.hpp` introduces an unintended overload (the design rationale for omitting `==`/`!=` proxies is documented in the source comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)