### PR TITLE
Release v0.5.1: IECStringVar / IECWStringVar read-through proxies

### DIFF
--- a/src/runtime/include/iec_string.hpp
+++ b/src/runtime/include/iec_string.hpp
@@ -417,6 +417,34 @@ public:
         return *this;
     }
 
+    // Read-through proxies into the inner IECString.  Without these,
+    // user code in C/C++ POU bodies has to write `name.get().c_str()`
+    // / `name.get().length()` for every read — `IECStringVar` would
+    // otherwise expose nothing but `get()` / `set()` / `operator=` to
+    // its consumers.  Routed through the force-aware value (forced
+    // value when forcing is active, underlying value otherwise) so
+    // every read respects force semantics the same way `IECVar<T>`'s
+    // `operator T()` already does for numeric pins.  Returning the
+    // pointer to the persistent member (not to `get()`'s temporary)
+    // keeps `c_str()`'s buffer stable for the lifetime of `*this`.
+    //
+    // NOTE: only methods that didn't previously exist on
+    // `IECStringVar` are added here.  Comparison (`operator==` etc.)
+    // is intentionally NOT proxied — the free-function overloads at
+    // the bottom of this file (`operator==(IECStringVar, IECString)`
+    // and converse) already handle every cross-class compare path,
+    // and adding member operators would risk overload ambiguity at
+    // ST call sites that previously bound to the free functions.
+    constexpr size_t length() const noexcept {
+        return (forced_ ? forced_value_ : value_).length();
+    }
+    const char* c_str() const noexcept {
+        return (forced_ ? forced_value_ : value_).c_str();
+    }
+    char operator[](size_t index) const noexcept {
+        return (forced_ ? forced_value_ : value_)[index];
+    }
+
 private:
     value_type value_;
     bool forced_;

--- a/src/runtime/include/iec_wstring.hpp
+++ b/src/runtime/include/iec_wstring.hpp
@@ -433,6 +433,22 @@ public:
         return *this;
     }
 
+    // Read-through proxies into the inner IECWString.  Mirror of the
+    // IECStringVar proxy set — see `iec_string.hpp` for the design
+    // rationale, including why comparison operators are intentionally
+    // NOT proxied (free-function `==` / `!=` overloads already cover
+    // every cross-class compare path, and adding member operators
+    // would risk overload ambiguity at ST call sites).
+    constexpr size_t length() const noexcept {
+        return (forced_ ? forced_value_ : value_).length();
+    }
+    const char16_t* c_str() const noexcept {
+        return (forced_ ? forced_value_ : value_).c_str();
+    }
+    char16_t operator[](size_t index) const noexcept {
+        return (forced_ ? forced_value_ : value_)[index];
+    }
+
 private:
     value_type value_;
     bool forced_;


### PR DESCRIPTION
## Summary

Release v0.5.1 with the read-through proxy methods added to `IECStringVar` / `IECWStringVar` (from #156).

### What's new since v0.5.0

- **`length()`, `c_str()`, `operator[]`** proxies on `IECStringVar<MaxLen>` and `IECWStringVar<MaxLen>`, force-aware (route through `forced_value_` when forcing is active, `value_` otherwise).
- Lets user C/C++ POU code in openplc-editor / openplc-web read STRING / WSTRING pins with plain `name.length()` / `name.c_str()` / `name[i]` syntax instead of `name.get().length()` etc.
- Comparison operators intentionally NOT proxied (free-function overloads already cover every cross-class compare path; adding member ops would risk ST overload ambiguity).

### Unlocks downstream

- **openplc-editor PR #831** (c_blocks STRING/WSTRING standardization)
- **openplc-web mirror PR** (to follow)

### Test plan

- [x] Full local CI-equivalent gates passed on the dev tip: lint (0 errors), prettier clean, typecheck clean, **1913/1920 tests pass** (7 pre-existing skips).
- [ ] CI (which fires on this PR — unlike dev-targeted PRs) reports green.
- [ ] After merge: tag v0.5.1 from main to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)