### PR TITLE
fix(ci): plumb expected version through env so smoke-windows passes reliably

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-linux-x64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -117,6 +119,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-linux-arm64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -167,6 +171,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-macos-x64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp arch -x86_64
@@ -217,6 +223,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-macos-arm64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -293,7 +301,7 @@ jobs:
   # start (guards against the issue #132 class of bug on Windows).
   # ---------------------------------------------------------------------------
   smoke-windows:
-    needs: build-windows-x64
+    needs: [prepare, build-windows-x64]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -313,6 +321,14 @@ jobs:
 
       - name: Smoke-test binary
         shell: bash
+        env:
+          # Job runs on a fresh runner with a clean source checkout — the
+          # `npm version` bump done by `build-windows-x64` only lived in
+          # that build job's filesystem.  Pass the canonical version from
+          # `prepare.outputs.version` so the smoke-test asserts against
+          # what we ASKED the pipeline to build, not whatever happens to
+          # be committed in `package.json` at the tagged commit.
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: node scripts/smoke-test.mjs unpacked/strucpp/strucpp.exe
 
   # ---------------------------------------------------------------------------

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -12,14 +12,30 @@
  *
  * This script actually executes the binary and FAILS (non-zero exit) if it
  * can't run:
- *   1. `--version` exits 0 and prints the package.json version
+ *   1. `--version` exits 0 and prints the expected version
  *      (proves the module-load path — the thing that crashes today — works).
  *   2. `--help` exits 0.
  *   3. A tiny ST program compiles to a non-empty .cpp.
  *
+ * Expected-version resolution (highest precedence first):
+ *
+ *   1. `STRUCPP_EXPECTED_VERSION` env var.  This is the source of truth
+ *      used by `release.yml` — every smoke step exports
+ *      `${{ needs.prepare.outputs.version }}`, the same value all build
+ *      jobs feed into `npm version` when bumping `package.json` for the
+ *      bundle/pkg pipeline.  Critically, this also lets the cross-runner
+ *      `smoke-windows` job assert correctly: it checks out fresh source
+ *      at the tag commit, where `package.json` may not have been bumped
+ *      by a `chore(release): vX.Y.Z` commit yet, so the version-from-disk
+ *      fallback would mismatch the binary built upstream with an
+ *      injected version.
+ *
+ *   2. `package.json` on disk.  Fallback for local invocations.
+ *
  * Usage:  node scripts/smoke-test.mjs <path-to-binary> [runner-prefix...]
  *   e.g.  node scripts/smoke-test.mjs dist/bin/strucpp
  *         node scripts/smoke-test.mjs dist/bin/strucpp arch -x86_64
+ *         STRUCPP_EXPECTED_VERSION=0.5.2 node scripts/smoke-test.mjs dist/bin/strucpp
  *
  * Any extra args after the binary path are a command prefix used to launch
  * it (for running a cross-arch binary under an emulator, e.g. `arch -x86_64`
@@ -38,8 +54,11 @@ if (!binArg) {
   process.exit(2);
 }
 
-const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url)));
-const expectedVersion = pkg.version;
+const expectedVersion =
+  process.env.STRUCPP_EXPECTED_VERSION ??
+  JSON.parse(readFileSync(new URL("../package.json", import.meta.url))).version;
+console.log(`  Expected version: ${expectedVersion}` +
+  (process.env.STRUCPP_EXPECTED_VERSION ? " (from STRUCPP_EXPECTED_VERSION)" : " (from package.json)"));
 
 /** Run the binary (optionally under a runner prefix) and return the result. */
 function run(args) {


### PR DESCRIPTION
## Summary

The smoke-test reads its expected version from `package.json` on disk. This works in the `build-*` jobs (the `Inject version` step bumps package.json on the same runner before smoke runs) but **breaks in `smoke-windows`**: that job is on a separate Windows runner because the Windows binary is cross-built on Linux and can't execute there. It does a fresh `actions/checkout@v4` at the tag ref with no `Inject version` step, so its `package.json` still holds whatever was committed at the tagged commit. If the tag's commit didn't pre-bump package.json (no `chore(release): vX.Y.Z` PR), the binary correctly reports the injected version while `smoke-windows` compares against the stale committed string and fails.

This is exactly what happened on the first attempt at v0.5.1 — binary reported `0.5.1`, package.json on Windows runner still said `0.5.0`, smoke failed, release aborted.

### Fix

- **`scripts/smoke-test.mjs`** — prefer `STRUCPP_EXPECTED_VERSION` env var over the `package.json` fallback. Logs which source the version came from for traceability.
- **`.github/workflows/release.yml`** — every smoke step exports `STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}`. The `prepare` job derives this value once from `github.ref_name` (stripping `v`), so it's the same source of truth all build jobs feed into `npm version`. `smoke-windows` now also lists `prepare` in its `needs:` array to access the output.

The `Inject version` steps in the build jobs **stay** — they're still load-bearing for baking the version into the bundle/binary itself. They're just no longer the only way smoke-test learns what version to expect.

### Validation plan

Once merged to development and main, **v0.5.2 will be tagged WITHOUT a preceding `chore(release): v0.5.2` bump**. That's the explicit test: with package.json still saying `0.5.1` at the tag commit, the build jobs will inject `0.5.2` into their package.json copies and bake `0.5.2` into the binary, and `smoke-windows` will compare its fresh-checkout binary against `STRUCPP_EXPECTED_VERSION=0.5.2` rather than the stale `0.5.1` from disk. If that passes, the fix is verified end-to-end.

### Side benefit

The assertion now actually tests what it claims to test ("the binary reports the version we asked the pipeline to build"), not "the binary version matches whatever `npm version` happened to mutate package.json to in the same runner" (which was a tautology in every build-job smoke step).

### Test plan

- [x] Local sanity: env override path passes; package.json fallback correctly fails when binary disagrees.
- [x] Local CI-equivalent: lint (0 errors), prettier, typecheck, **1913/1920 tests pass** (7 pre-existing skips).
- [ ] CI on this PR green.
- [ ] After merge: v0.5.2 release runs end-to-end without a chore(release) bump — proves the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)