### PR TITLE
Release v0.5.2: smoke-windows fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-linux-x64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -117,6 +119,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-linux-arm64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -167,6 +171,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-macos-x64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp arch -x86_64
@@ -217,6 +223,8 @@ jobs:
         run: npx pkg dist/strucpp-bundle.cjs --no-bytecode --public-packages "*" --public --target node22-macos-arm64 --output dist/bin/strucpp --compress GZip
 
       - name: Smoke-test binary
+        env:
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           file dist/bin/strucpp
           node scripts/smoke-test.mjs dist/bin/strucpp
@@ -293,7 +301,7 @@ jobs:
   # start (guards against the issue #132 class of bug on Windows).
   # ---------------------------------------------------------------------------
   smoke-windows:
-    needs: build-windows-x64
+    needs: [prepare, build-windows-x64]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -313,6 +321,14 @@ jobs:
 
       - name: Smoke-test binary
         shell: bash
+        env:
+          # Job runs on a fresh runner with a clean source checkout — the
+          # `npm version` bump done by `build-windows-x64` only lived in
+          # that build job's filesystem.  Pass the canonical version from
+          # `prepare.outputs.version` so the smoke-test asserts against
+          # what we ASKED the pipeline to build, not whatever happens to
+          # be committed in `package.json` at the tagged commit.
+          STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
         run: node scripts/smoke-test.mjs unpacked/strucpp/strucpp.exe
 
   # ---------------------------------------------------------------------------

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -12,14 +12,30 @@
  *
  * This script actually executes the binary and FAILS (non-zero exit) if it
  * can't run:
- *   1. `--version` exits 0 and prints the package.json version
+ *   1. `--version` exits 0 and prints the expected version
  *      (proves the module-load path — the thing that crashes today — works).
  *   2. `--help` exits 0.
  *   3. A tiny ST program compiles to a non-empty .cpp.
  *
+ * Expected-version resolution (highest precedence first):
+ *
+ *   1. `STRUCPP_EXPECTED_VERSION` env var.  This is the source of truth
+ *      used by `release.yml` — every smoke step exports
+ *      `${{ needs.prepare.outputs.version }}`, the same value all build
+ *      jobs feed into `npm version` when bumping `package.json` for the
+ *      bundle/pkg pipeline.  Critically, this also lets the cross-runner
+ *      `smoke-windows` job assert correctly: it checks out fresh source
+ *      at the tag commit, where `package.json` may not have been bumped
+ *      by a `chore(release): vX.Y.Z` commit yet, so the version-from-disk
+ *      fallback would mismatch the binary built upstream with an
+ *      injected version.
+ *
+ *   2. `package.json` on disk.  Fallback for local invocations.
+ *
  * Usage:  node scripts/smoke-test.mjs <path-to-binary> [runner-prefix...]
  *   e.g.  node scripts/smoke-test.mjs dist/bin/strucpp
  *         node scripts/smoke-test.mjs dist/bin/strucpp arch -x86_64
+ *         STRUCPP_EXPECTED_VERSION=0.5.2 node scripts/smoke-test.mjs dist/bin/strucpp
  *
  * Any extra args after the binary path are a command prefix used to launch
  * it (for running a cross-arch binary under an emulator, e.g. `arch -x86_64`
@@ -38,8 +54,11 @@ if (!binArg) {
   process.exit(2);
 }
 
-const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url)));
-const expectedVersion = pkg.version;
+const expectedVersion =
+  process.env.STRUCPP_EXPECTED_VERSION ??
+  JSON.parse(readFileSync(new URL("../package.json", import.meta.url))).version;
+console.log(`  Expected version: ${expectedVersion}` +
+  (process.env.STRUCPP_EXPECTED_VERSION ? " (from STRUCPP_EXPECTED_VERSION)" : " (from package.json)"));
 
 /** Run the binary (optionally under a runner prefix) and return the result. */
 function run(args) {


### PR DESCRIPTION
## Summary

Roll the `STRUCPP_EXPECTED_VERSION` env-based smoke-test fix (#160) from development into main so v0.5.2 can be tagged here.

### What lands

- `scripts/smoke-test.mjs` reads expected version from env first, falls back to `package.json`.
- `release.yml` exports `STRUCPP_EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}` in every smoke step. `smoke-windows` lists `prepare` in its `needs:` array.

### Validation: deliberate test of the fix

After this merges, **v0.5.2 will be tagged WITHOUT a preceding `chore(release): v0.5.2` bump**. With `package.json` still saying `0.5.1` at the tag commit:
- Build jobs inject `0.5.2` via `npm version`, bake it into the binary.
- `smoke-windows` checks out fresh source (package.json says `0.5.1`), but receives `STRUCPP_EXPECTED_VERSION=0.5.2` via env, so it compares correctly.

If smoke-windows passes, the asymmetry is fixed. If it doesn't, we iterate.

### Test plan

- [ ] CI on this PR green (lint, typecheck, test matrix, extension build, build, smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)