### PR TITLE
fix(debug): emit STRING / WSTRING entries into the debug table

### DIFF
--- a/src/backend/debug-table-gen.ts
+++ b/src/backend/debug-table-gen.ts
@@ -121,8 +121,16 @@ const IEC_NAME_TO_SIZE: Record<string, number> = {
   DT: 8,
   DATE_AND_TIME: 8,
   LDT: 8,
-  STRING: 0, // variable-length — Phase 4b
-  WSTRING: 0, // variable-length — Phase 4b
+  // STRING / WSTRING wire widths match `DEBUG_STRING_WIDTH` /
+  // `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`.
+  // The runtime always writes a full fixed-width window
+  // (1 byte length + 126 bytes UTF-8 / 252 bytes UTF-16LE); the
+  // editor decoder reads `min(length, 126)` from the prefix and
+  // skips the remainder.  Pinning the same constants here keeps the
+  // editor's batch-byte arithmetic aligned with what the runtime
+  // actually sends per entry.
+  STRING: 127,
+  WSTRING: 253,
 };
 
 // ---------------------------------------------------------------------------
@@ -227,12 +235,6 @@ export function generateDebugTable(
       return;
     }
     const size = IEC_NAME_TO_SIZE[iecName.toUpperCase()] ?? 0;
-    // Phase 4a: skip STRING/WSTRING because variable-length encoding isn't
-    // defined yet.
-    if (tagName === "STRING" || tagName === "WSTRING") {
-      skipped.push({ path, reason: `string types deferred to Phase 4b` });
-      return;
-    }
     ensureRoom();
     const bucket = tail();
     const arrIdx = arrays.length - 1;

--- a/tests/backend/debug-table-gen.test.ts
+++ b/tests/backend/debug-table-gen.test.ts
@@ -27,6 +27,12 @@ describe("debug-table-gen helpers", () => {
     expect(sizeForTypeName("LINT")).toBe(8);
     expect(sizeForTypeName("REAL")).toBe(4);
     expect(sizeForTypeName("LREAL")).toBe(8);
+    // STRING / WSTRING use the fixed debug-protocol window width:
+    // 1 byte length prefix + 126 bytes of UTF-8 (STRING) or
+    // 126 * 2 bytes of UTF-16LE (WSTRING).  Mirrors `DEBUG_STRING_WIDTH` /
+    // `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`.
+    expect(sizeForTypeName("STRING")).toBe(127);
+    expect(sizeForTypeName("WSTRING")).toBe(253);
   });
 
   it("TAG values are sequential from 0", () => {
@@ -77,6 +83,41 @@ END_CONFIGURATION
     const blink = map.leaves.find((l) => l.path === "INSTANCE0.BLINK")!;
     expect(blink.type).toBe("BOOL");
     expect(blink.size).toBe(1);
+  });
+
+  it("emits Entry rows for STRING and WSTRING leaves with the wire-width sizes", () => {
+    const source = `
+PROGRAM main
+  VAR
+    label : STRING := 'hello';
+    note  : WSTRING := "hi";
+  END_VAR
+END_PROGRAM
+
+CONFIGURATION Config0
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 1);
+    PROGRAM instance0 WITH task0 : main;
+  END_RESOURCE
+END_CONFIGURATION
+`;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    const map = result.debugMap!;
+    const labelLeaf = map.leaves.find((l) => l.path === "INSTANCE0.LABEL");
+    const noteLeaf = map.leaves.find((l) => l.path === "INSTANCE0.NOTE");
+    expect(labelLeaf, "STRING leaf must be emitted into the debug table").toBeDefined();
+    expect(noteLeaf, "WSTRING leaf must be emitted into the debug table").toBeDefined();
+    expect(labelLeaf!.type).toBe("STRING");
+    expect(labelLeaf!.size).toBe(127); // 1 + DEBUG_STRING_CAP
+    expect(noteLeaf!.type).toBe("WSTRING");
+    expect(noteLeaf!.size).toBe(253); // 1 + DEBUG_STRING_CAP * 2
+
+    const cpp = result.debugTableCpp!;
+    expect(cpp).toContain("TAG_STRING");
+    expect(cpp).toContain("TAG_WSTRING");
+    expect(cpp).toContain("&g_config.INSTANCE0.LABEL");
+    expect(cpp).toContain("&g_config.INSTANCE0.NOTE");
   });
 
   it("emits valid C++ source with the expected pointer expressions", () => {


### PR DESCRIPTION
## Summary

**The other half** of the debugger STRING / WSTRING fix.

v0.5.3 shipped the runtime side — real `read_string` / `read_wstring` / `write_*` / `force_*` implementations against `IECStringVar<254>` / `IECWStringVar<254>`. C++ smoke test verified all four ops round-trip correctly.

End-to-end against the simulator **still showed `-`** in the editor's debug watch panel. Live-tracing the wire bytes by instrumenting `decodeWireValue` (`openplc-web/src/frontend/utils/variable-sizes.ts`) to log every poll revealed the actual remaining culprit was on the **EMITTER** side, not the runtime:

```typescript
// src/backend/debug-table-gen.ts (BEFORE)
if (tagName === "STRING" || tagName === "WSTRING") {
  skipped.push({ path, reason: `string types deferred to Phase 4b` });
  return;
}
```

`addLeaf` explicitly early-returned for STRING / WSTRING. **No Entry row was ever placed into the generated debug table**, so `handle_read()` never had a STRING entry to dispatch and silently returned 0 bytes. The runtime fix was correct but unreachable.

## Fix

- Remove the skip in `addLeaf`.
- Update `IEC_NAME_TO_SIZE` for STRING / WSTRING to the actual wire widths (127 / 253 bytes — `1 + DEBUG_STRING_CAP` and `1 + DEBUG_STRING_CAP * 2`), matching `DEBUG_STRING_WIDTH` / `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`. These sizes flow into both the per-Entry `size` field (for the editor's batch-byte arithmetic) and the debug-map manifest the editor consumes.
- Extend `debug-table-gen.test.ts` with a regression guard that asserts STRING / WSTRING leaves emit with the correct type/size and that the generated C++ source carries the matching `TAG_STRING` / `TAG_WSTRING` rows.

## Verification

- **Unit test added**: `tests/backend/debug-table-gen.test.ts` — "emits Entry rows for STRING and WSTRING leaves with the wire-width sizes". 15/15 tests pass.
- **Full local suite**: 1913/1920 tests pass (7 pre-existing skips).
- **End-to-end live**: simulator running the dev project with `test_string : STRING := 'hello world'` in `Manual_Override`. Editor's polling loop receives `[11, 'h','e','l','l','o',' ','w','o','r','l','d']` (length=11 prefix + correct UTF-8 bytes) and decodes as `"hello world"`. The previous "Debug map: 162 leaves" becomes "163 leaves" with the codegen fix — confirming the STRING entry is now emitted.

## Process note

This bug taught me to not declare victory on a unit-test pass when the user's report is a UX-level "still shows `-`". The runtime impl in v0.5.3 was correct in isolation but unreachable in the pipeline. I should have done the live wire-trace **before** committing v0.5.3.

## Test plan

- [ ] CI green.
- [ ] After v0.5.4 release: bump editor + web; STRING / WSTRING values render in production debug watch panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)