### PR TITLE
chore(release): v0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strucpp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strucpp",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "chevrotain": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strucpp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "IEC 61131-3 Structured Text to C++ Compiler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release bundling #168 (C++14 backport of user-facing runtime headers).

Fixes c_blocks_code.cpp compile under mbed-based Arduino cores.