### PR TITLE
release: v0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strucpp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strucpp",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "chevrotain": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strucpp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "IEC 61131-3 Structured Text to C++ Compiler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/runtime/include/iec_string.hpp
+++ b/src/runtime/include/iec_string.hpp
@@ -892,21 +892,33 @@ inline bool NE_STRING(const IECString<MaxLen1>& s1, const IECString<MaxLen2>& s2
 // =============================================================================
 
 // Numeric → STRING (uses snprintf for real-time safety, no std::to_string)
+//
+// Split into two SFINAE'd overloads (signed vs unsigned) rather than a single
+// function with `if constexpr`, because user C/C++ POU code in
+// `c_blocks_code.cpp` compiles under whatever -std= the platform's Arduino
+// core picked (gnu++14 on mbed cores).  `if constexpr` is C++17-only and
+// would make this header unusable from those compilation units.  Tag
+// dispatch via `enable_if_t` works back to C++11.
 template<typename T,
-    std::enable_if_t<std::is_integral_v<decltype(iec_unwrap(std::declval<T>()))>, int> = 0>
+    std::enable_if_t<std::is_integral<decltype(iec_unwrap(std::declval<T>()))>::value
+                  && std::is_unsigned<decltype(iec_unwrap(std::declval<T>()))>::value, int> = 0>
 inline IECString<254> TO_STRING(T v) noexcept {
     char buf[32];
-    auto raw = iec_unwrap(v);
-    if constexpr (std::is_unsigned_v<decltype(raw)>) {
-        std::snprintf(buf, sizeof(buf), "%llu", static_cast<unsigned long long>(raw));
-    } else {
-        std::snprintf(buf, sizeof(buf), "%lld", static_cast<long long>(raw));
-    }
+    std::snprintf(buf, sizeof(buf), "%llu", static_cast<unsigned long long>(iec_unwrap(v)));
     return IECString<254>(buf);
 }
 
 template<typename T,
-    std::enable_if_t<std::is_floating_point_v<decltype(iec_unwrap(std::declval<T>()))>, int> = 0>
+    std::enable_if_t<std::is_integral<decltype(iec_unwrap(std::declval<T>()))>::value
+                  && !std::is_unsigned<decltype(iec_unwrap(std::declval<T>()))>::value, int> = 0>
+inline IECString<254> TO_STRING(T v) noexcept {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%lld", static_cast<long long>(iec_unwrap(v)));
+    return IECString<254>(buf);
+}
+
+template<typename T,
+    std::enable_if_t<std::is_floating_point<decltype(iec_unwrap(std::declval<T>()))>::value, int> = 0>
 inline IECString<254> TO_STRING(T v) noexcept {
     char buf[64];
     std::snprintf(buf, sizeof(buf), "%g", static_cast<double>(iec_unwrap(v)));

--- a/src/runtime/include/iec_subrange.hpp
+++ b/src/runtime/include/iec_subrange.hpp
@@ -25,12 +25,12 @@ namespace strucpp {
  * @tparam Lower The minimum allowed value (inclusive)
  * @tparam Upper The maximum allowed value (inclusive)
  */
-template<typename BaseType, auto Lower, auto Upper>
+template<typename BaseType, BaseType Lower, BaseType Upper>
 class IEC_SUBRANGE_Value {
 public:
     using base_type = BaseType;
-    static constexpr auto lower_bound = Lower;
-    static constexpr auto upper_bound = Upper;
+    static constexpr BaseType lower_bound = Lower;
+    static constexpr BaseType upper_bound = Upper;
     
 private:
     BaseType value_;
@@ -208,13 +208,13 @@ public:
  * @tparam Lower The minimum allowed value
  * @tparam Upper The maximum allowed value
  */
-template<typename BaseType, auto Lower, auto Upper>
+template<typename BaseType, BaseType Lower, BaseType Upper>
 class IEC_SUBRANGE_Var {
 public:
     using value_type = IEC_SUBRANGE_Value<BaseType, Lower, Upper>;
     using base_type = BaseType;
-    static constexpr auto lower_bound = Lower;
-    static constexpr auto upper_bound = Upper;
+    static constexpr BaseType lower_bound = Lower;
+    static constexpr BaseType upper_bound = Upper;
     
 private:
     value_type value_;
@@ -323,7 +323,7 @@ public:
  * Convenience alias for subrange with forcing support.
  * Usage: IEC_SUBRANGE<int16_t, 0, 100> percentage;
  */
-template<typename BaseType, auto Lower, auto Upper>
+template<typename BaseType, BaseType Lower, BaseType Upper>
 using IEC_SUBRANGE = IEC_SUBRANGE_Var<BaseType, Lower, Upper>;
 
 /*

--- a/src/runtime/include/iec_traits.hpp
+++ b/src/runtime/include/iec_traits.hpp
@@ -30,8 +30,13 @@ template<typename T, typename Bounds1, typename Bounds2, typename Bounds3> class
 class IEC_STRUCT_Base;
 template<typename EnumType> class IEC_ENUM_Value;
 template<typename EnumType> class IEC_ENUM_Var;
-template<typename BaseType, auto Lower, auto Upper> class IEC_SUBRANGE_Value;
-template<typename BaseType, auto Lower, auto Upper> class IEC_SUBRANGE_Var;
+// Forward declarations.  `auto` template parameters are C++17; we declare
+// these subrange templates with `BaseType`-typed bounds so they remain
+// compilable under the platform's gnu++14 default (mbed Arduino cores).
+// Numeric bounds in IEC subrange types are always the same type as the
+// base, so requiring `Lower`/`Upper` to be `BaseType` is no semantic loss.
+template<typename BaseType, BaseType Lower, BaseType Upper> class IEC_SUBRANGE_Value;
+template<typename BaseType, BaseType Lower, BaseType Upper> class IEC_SUBRANGE_Var;
 template<typename T> class IEC_REF_TO;
 
 // =============================================================================
@@ -232,43 +237,43 @@ struct is_any_elementary<IECVar<T>> : is_any_elementary<T> {};
 // =============================================================================
 
 template<typename T>
-inline constexpr bool is_iec_type_v = is_iec_type<T>::value;
+constexpr bool is_iec_type_v = is_iec_type<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_bool_v = is_any_bool<T>::value;
+constexpr bool is_any_bool_v = is_any_bool<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_sint_v = is_any_sint<T>::value;
+constexpr bool is_any_sint_v = is_any_sint<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_uint_v = is_any_uint<T>::value;
+constexpr bool is_any_uint_v = is_any_uint<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_int_v = is_any_int<T>::value;
+constexpr bool is_any_int_v = is_any_int<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_real_v = is_any_real<T>::value;
+constexpr bool is_any_real_v = is_any_real<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_num_v = is_any_num<T>::value;
+constexpr bool is_any_num_v = is_any_num<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_bit_v = is_any_bit<T>::value;
+constexpr bool is_any_bit_v = is_any_bit<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_string_v = is_any_string<T>::value;
+constexpr bool is_any_string_v = is_any_string<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_date_v = is_any_date<T>::value;
+constexpr bool is_any_date_v = is_any_date<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_time_v = is_any_time<T>::value;
+constexpr bool is_any_time_v = is_any_time<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_magnitude_v = is_any_magnitude<T>::value;
+constexpr bool is_any_magnitude_v = is_any_magnitude<T>::value;
 
 template<typename T>
-inline constexpr bool is_any_elementary_v = is_any_elementary<T>::value;
+constexpr bool is_any_elementary_v = is_any_elementary<T>::value;
 
 // =============================================================================
 // Type Size Traits
@@ -297,7 +302,7 @@ template<typename T>
 struct iec_bit_size<IECVar<T>> : iec_bit_size<T> {};
 
 template<typename T>
-inline constexpr size_t iec_bit_size_v = iec_bit_size<T>::value;
+constexpr size_t iec_bit_size_v = iec_bit_size<T>::value;
 
 // =============================================================================
 // Underlying Type Traits
@@ -315,10 +320,10 @@ using iec_underlying_type_t = typename iec_underlying_type<T>::type;
 
 /** Extract the raw value from an IECVar or pass through a raw value unchanged */
 template<typename T>
-inline constexpr T iec_unwrap(T v) noexcept { return v; }
+constexpr T iec_unwrap(T v) noexcept { return v; }
 
 template<typename T>
-inline constexpr T iec_unwrap(const IECVar<T>& v) noexcept { return v.get(); }
+constexpr T iec_unwrap(const IECVar<T>& v) noexcept { return v.get(); }
 
 // =============================================================================
 // Type Limits
@@ -389,16 +394,16 @@ template<typename T, typename Bnd1, typename Bnd2, typename Bnd3>
 struct is_iec_array<IEC_ARRAY_3D<T, Bnd1, Bnd2, Bnd3>> : std::true_type {};
 
 template<typename T>
-inline constexpr bool is_iec_array_v = is_iec_array<T>::value;
+constexpr bool is_iec_array_v = is_iec_array<T>::value;
 
 /** Check if T is an IEC struct type */
 // Uses std::is_base_of to detect types derived from IEC_STRUCT_Base
 // Note: Generated structs inherit from IEC_STRUCT_Base
 template<typename T>
-struct is_iec_struct : std::bool_constant<std::is_base_of_v<IEC_STRUCT_Base, T>> {};
+struct is_iec_struct : std::integral_constant<bool,std::is_base_of<IEC_STRUCT_Base, T>::value> {};
 
 template<typename T>
-inline constexpr bool is_iec_struct_v = is_iec_struct<T>::value;
+constexpr bool is_iec_struct_v = is_iec_struct<T>::value;
 
 /** Check if T is an IEC enumeration type */
 template<typename T> struct is_iec_enum : std::false_type {};
@@ -410,19 +415,19 @@ template<typename E>
 struct is_iec_enum<IEC_ENUM_Var<E>> : std::true_type {};
 
 template<typename T>
-inline constexpr bool is_iec_enum_v = is_iec_enum<T>::value;
+constexpr bool is_iec_enum_v = is_iec_enum<T>::value;
 
 /** Check if T is an IEC subrange type */
 template<typename T> struct is_iec_subrange : std::false_type {};
 
-template<typename B, auto L, auto U>
+template<typename B, B L, B U>
 struct is_iec_subrange<IEC_SUBRANGE_Value<B, L, U>> : std::true_type {};
 
-template<typename B, auto L, auto U>
+template<typename B, B L, B U>
 struct is_iec_subrange<IEC_SUBRANGE_Var<B, L, U>> : std::true_type {};
 
 template<typename T>
-inline constexpr bool is_iec_subrange_v = is_iec_subrange<T>::value;
+constexpr bool is_iec_subrange_v = is_iec_subrange<T>::value;
 
 /** Check if T is an IEC pointer type (REF_TO) */
 template<typename T> struct is_iec_pointer : std::false_type {};
@@ -431,11 +436,11 @@ template<typename T>
 struct is_iec_pointer<IEC_REF_TO<T>> : std::true_type {};
 
 template<typename T>
-inline constexpr bool is_iec_pointer_v = is_iec_pointer<T>::value;
+constexpr bool is_iec_pointer_v = is_iec_pointer<T>::value;
 
 /** Check if T is ANY_DERIVED (composite types: arrays, structs, enums, subranges, pointers) */
 template<typename T>
-struct is_any_derived : std::bool_constant<
+struct is_any_derived : std::integral_constant<bool,
     is_iec_array<T>::value ||
     is_iec_struct<T>::value ||
     is_iec_enum<T>::value ||
@@ -444,7 +449,7 @@ struct is_any_derived : std::bool_constant<
 > {};
 
 template<typename T>
-inline constexpr bool is_any_derived_v = is_any_derived<T>::value;
+constexpr bool is_any_derived_v = is_any_derived<T>::value;
 
 // =============================================================================
 // C++17 SFINAE Helpers

--- a/src/runtime/include/iec_var.hpp
+++ b/src/runtime/include/iec_var.hpp
@@ -59,7 +59,7 @@ public:
      *  to functions expecting a wider IECVar type. Without this, C++ would need
      *  two user-defined conversions (IECVar<U>→U→T→IECVar<T>) which is disallowed. */
     template<typename U, std::enable_if_t<
-        std::is_convertible_v<U, T> && !std::is_same_v<U, T>, int> = 0>
+        std::is_convertible<U, T>::value && !std::is_same<U, T>::value, int> = 0>
     IECVar(const IECVar<U>& other) noexcept
         : value_{static_cast<T>(other.get())}, forced_{false}, forced_value_{} {}
 
@@ -197,7 +197,7 @@ public:
      *  by providing a direct match (template is preferred over two indirect paths
      *  that each require one user-defined conversion). */
     template<typename U, std::enable_if_t<
-        std::is_convertible_v<U, T> && !std::is_same_v<U, T>, int> = 0>
+        std::is_convertible<U, T>::value && !std::is_same<U, T>::value, int> = 0>
     IECVar& operator=(const IECVar<U>& other) noexcept {
         set(static_cast<T>(other.get()));
         return *this;
@@ -207,7 +207,7 @@ public:
      *  WARNING: On 64-bit platforms, assigning to types narrower than pointer width
      *  (e.g., DWORD) truncates the address. Use ULINT, LWORD, or PTR_INT_t for
      *  portable pointer-to-integer storage. */
-    template<typename U, typename V = T, std::enable_if_t<std::is_integral_v<V>, int> = 0>
+    template<typename U, typename V = T, std::enable_if_t<std::is_integral<V>::value, int> = 0>
     IECVar& operator=(const IEC_Ptr<U>& ptr) noexcept {
         set(static_cast<T>(ptr.to_addr()));
         return *this;
@@ -218,10 +218,10 @@ public:
     // =========================================================================
 
     /** Forward operator-> to underlying type (struct/FB member access) */
-    template<typename U = T, std::enable_if_t<std::is_class_v<U>, int> = 0>
+    template<typename U = T, std::enable_if_t<std::is_class<U>::value, int> = 0>
     T* operator->() noexcept { return &value_; }
 
-    template<typename U = T, std::enable_if_t<std::is_class_v<U>, int> = 0>
+    template<typename U = T, std::enable_if_t<std::is_class<U>::value, int> = 0>
     const T* operator->() const noexcept { return &value_; }
 
     /** Forward operator[] to underlying type (1D array access) */
@@ -350,7 +350,7 @@ inline IECVar<T> operator/(const IECVar<T>& a, const IECVar<T>& b) noexcept {
     return IECVar<T>(a.get() / b.get());
 }
 
-template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+template<typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 inline IECVar<T> operator%(const IECVar<T>& a, const IECVar<T>& b) noexcept {
     return IECVar<T>(a.get() % b.get());
 }
@@ -364,8 +364,8 @@ template<typename T> inline IECVar<T> operator*(const IECVar<T>& a, T b) noexcep
 template<typename T> inline IECVar<T> operator*(T a, const IECVar<T>& b) noexcept { return IECVar<T>(a * b.get()); }
 template<typename T> inline IECVar<T> operator/(const IECVar<T>& a, T b) noexcept { return IECVar<T>(a.get() / b); }
 template<typename T> inline IECVar<T> operator/(T a, const IECVar<T>& b) noexcept { return IECVar<T>(a / b.get()); }
-template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>> inline IECVar<T> operator%(const IECVar<T>& a, T b) noexcept { return IECVar<T>(a.get() % b); }
-template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>> inline IECVar<T> operator%(T a, const IECVar<T>& b) noexcept { return IECVar<T>(a % b.get()); }
+template<typename T, typename = std::enable_if_t<std::is_integral<T>::value>> inline IECVar<T> operator%(const IECVar<T>& a, T b) noexcept { return IECVar<T>(a.get() % b); }
+template<typename T, typename = std::enable_if_t<std::is_integral<T>::value>> inline IECVar<T> operator%(T a, const IECVar<T>& b) noexcept { return IECVar<T>(a % b.get()); }
 
 // =============================================================================
 // Comparison Operators


### PR DESCRIPTION
## Summary

- Backport user-facing runtime headers to C++14 for mbed-cored Arduino targets (#168)
- Release commit (#169)

## Test plan

- [x] CMake-based runtime test suite still compiles + passes under C++17
- [x] User-facing headers (`iec_var.hpp`, `iec_string.hpp`, `iec_traits.hpp`, `iec_subrange.hpp`) verified to compile under both gnu++14 and gnu++17, byte-identical .o output
- [x] End-to-end: openplc-editor compiles a Nano RP2040 Connect project with a C/C++ Function Block (user-verified)