### PR TITLE
feat(references): implement REF_TO / REFERENCE TO codegen + REF_LINK block

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -4175,6 +4175,16 @@ export class CodeGenerator {
       return `&(${args[0] ?? ""})`;
     }
 
+    // 0a. REF_LINK(x) → REF(x) — callable form of the REF() reference operator
+    // (REF is a reserved token and can't take the graphical EN/IN/ENO call
+    // form). Assigning the result to a REF_TO variable binds it.
+    if (nameUpper === "REF_LINK") {
+      const args = expr.arguments.map((arg) =>
+        this.generateExpression(arg.value),
+      );
+      return `REF(${args[0] ?? ""})`;
+    }
+
     // 0b. LOWER_BOUND/UPPER_BOUND(arr, dim) → arr.lower_bound() / arr.upper_bound()
     if (nameUpper === "LOWER_BOUND" || nameUpper === "UPPER_BOUND") {
       const method =

--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -364,6 +364,11 @@ export class CodeGenerator {
   /** Map of variable name (upper case) → type name (original case) for current scope */
   protected currentScopeVarTypes: Map<string, string> = new Map();
 
+  /** Map of variable name (upper case) → referenceKind ("ref_to" | "reference_to"
+   *  | "pointer_to") for current scope. Only reference/pointer vars are present;
+   *  used e.g. to pick the correct lowering for a REF= rebind. */
+  protected currentScopeVarRefKinds: Map<string, string> = new Map();
+
   /** Parent class name of current FB (for SUPER resolution) */
   private currentFBExtends: string | undefined;
 
@@ -599,13 +604,17 @@ export class CodeGenerator {
       );
     }
 
-    if (typeRef.referenceKind === "pointer_to") {
-      // Use IEC_Ptr<T> for pointer types — handles cross-type assignment,
-      // pointer arithmetic, and pointer-to-integer conversion seamlessly.
-      // IEC_Ptr needs the raw element type (not IECVar-wrapped).
+    if (
+      typeRef.referenceKind === "pointer_to" ||
+      typeRef.referenceKind === "ref_to" ||
+      typeRef.referenceKind === "reference_to"
+    ) {
+      // Pointer (IEC_Ptr<T>) and reference (IEC_REF_TO<T> / IEC_REFERENCE_TO<T>)
+      // wrappers all take the raw element type (not IECVar-wrapped); they wrap
+      // an IECVar<T> internally.
       let elemType: string;
       if (typeRef.arrayDimensions && typeRef.elementTypeName) {
-        // Array pointer: baseType is already raw (Array1D<...>)
+        // Array pointer/reference: baseType is already raw (Array1D<...>)
         elemType = baseType;
       } else if (this.isUserDefinedType(typeRef.name)) {
         // UDT: use raw struct/FB/program name
@@ -616,7 +625,19 @@ export class CodeGenerator {
         // Primitive type: use raw type mapping (BYTE_t, INT_t, etc.)
         elemType = this.typeCodeGen.mapTypeToCpp(typeRef.name);
       }
-      return `IEC_Ptr<${elemType}>`;
+      switch (typeRef.referenceKind) {
+        case "pointer_to":
+          // IEC_Ptr<T> — cross-type assignment, pointer arithmetic,
+          // pointer-to-integer conversion.
+          return `IEC_Ptr<${elemType}>`;
+        case "ref_to":
+          // REF_TO — explicit dereference (^), nullable, rebind via
+          // `:= REF(x)` / `:= ADR(x)`.
+          return `IEC_REF_TO<${elemType}>`;
+        case "reference_to":
+          // REFERENCE TO — implicit dereference, rebind via `REF=`.
+          return `IEC_REFERENCE_TO<${elemType}>`;
+      }
     }
     // For STRING(CONSTANT_NAME), emit template with the constant name
     if (typeof typeRef.maxLength === "string") {
@@ -1004,6 +1025,7 @@ export class CodeGenerator {
     this.emitHeader('#include "iec_std_lib.hpp"');
     this.emitHeader('#include "iec_enum.hpp"');
     this.emitHeader('#include "iec_memory.hpp"');
+    this.emitHeader('#include "iec_pointer.hpp"');
     this.emitHeader('#include "iec_string.hpp"');
     this.emitHeader('#include "iec_wstring.hpp"');
     this.emitHeader("#include <array>");
@@ -2313,6 +2335,16 @@ export class CodeGenerator {
       // Initializer list
       const inits: string[] = [];
       for (const decl of prog.varDeclarations) {
+        // References (REF_TO / REFERENCE TO) wrap a pointer internally and
+        // must be default-constructed (unbound) — `name(0)` is ambiguous for
+        // IEC_REF_TO. They are bound later via REF= / := REF(). (An
+        // initialized `REFERENCE TO X := target` is a separate enhancement.)
+        if (
+          decl.referenceKind === "ref_to" ||
+          decl.referenceKind === "reference_to"
+        ) {
+          continue;
+        }
         const initVal = this.getDefaultValue(decl.typeName, decl.initialValue);
         // Skip user-defined types (empty initVal) - they use default constructors
         if (initVal) {
@@ -2336,6 +2368,16 @@ export class CodeGenerator {
       // Initializer list for local variables
       const inits: string[] = [];
       for (const decl of prog.varDeclarations) {
+        // References (REF_TO / REFERENCE TO) wrap a pointer internally and
+        // must be default-constructed (unbound) — `name(0)` is ambiguous for
+        // IEC_REF_TO. They are bound later via REF= / := REF(). (An
+        // initialized `REFERENCE TO X := target` is a separate enhancement.)
+        if (
+          decl.referenceKind === "ref_to" ||
+          decl.referenceKind === "reference_to"
+        ) {
+          continue;
+        }
         const initVal = this.getDefaultValue(decl.typeName, decl.initialValue);
         // Skip user-defined types (empty initVal) - they use default constructors
         if (initVal) {
@@ -2857,8 +2899,15 @@ export class CodeGenerator {
   }
 
   /**
-   * Generate code for a REF= assignment (rebind REFERENCE_TO).
-   * ST: target REF= source;  →  C++: target.bind(source);
+   * Generate code for a REF= rebind. The lowering depends on the target's
+   * reference kind, because the two runtime wrappers expose different APIs:
+   *
+   *   REFERENCE TO (IEC_REFERENCE_TO)  →  target.bind(source);
+   *   REF_TO       (IEC_REF_TO)        →  target = REF(source);
+   *
+   * IEC_REF_TO has no bind() — it rebinds via assignment from REF()/ADR() —
+   * so emitting bind() unconditionally (the old behaviour) failed to compile
+   * for REF_TO targets.
    */
   private generateRefAssignStatement(
     stmt: RefAssignStatement,
@@ -2866,7 +2915,16 @@ export class CodeGenerator {
   ): void {
     const target = this.generateExpression(stmt.target);
     const source = this.generateExpression(stmt.source);
-    this.emit(`${indent}${target}.bind(${source});`);
+    const targetKind =
+      stmt.target.kind === "VariableExpression"
+        ? this.currentScopeVarRefKinds.get(stmt.target.name.toUpperCase())
+        : undefined;
+    if (targetKind === "ref_to") {
+      this.emit(`${indent}${target} = REF(${source});`);
+    } else {
+      // REFERENCE_TO (and the default) rebind via bind().
+      this.emit(`${indent}${target}.bind(${source});`);
+    }
   }
 
   /**
@@ -4608,6 +4666,7 @@ export class CodeGenerator {
     varBlocks: CompilationUnit["programs"][0]["varBlocks"],
   ): void {
     this.currentScopeVarTypes.clear();
+    this.currentScopeVarRefKinds.clear();
     this.memberMangledNames.clear();
     for (const block of varBlocks) {
       for (const decl of block.declarations) {
@@ -4616,6 +4675,15 @@ export class CodeGenerator {
           : `IEC_${decl.type.name}`;
         for (const name of decl.names) {
           this.currentScopeVarTypes.set(name.toUpperCase(), decl.type.name);
+          if (
+            decl.type.referenceKind !== undefined &&
+            decl.type.referenceKind !== "none"
+          ) {
+            this.currentScopeVarRefKinds.set(
+              name.toUpperCase(),
+              decl.type.referenceKind,
+            );
+          }
           // Detect member name collisions with type name (GCC -Wchanges-meaning)
           if (
             this.isUserDefinedType(decl.type.name) &&

--- a/src/runtime/include/iec_pointer.hpp
+++ b/src/runtime/include/iec_pointer.hpp
@@ -292,8 +292,10 @@ public:
  * REFERENCE_TO type with implicit dereferencing (CODESYS compatibility).
  * Unlike REF_TO, this type automatically dereferences on value access.
  *
- * Cannot be NULL - must always be bound to a valid variable.
- * Uses REF= operator (implemented as bind() method) for rebinding.
+ * Conceptually always bound; default-constructs unbound (nullptr) only so
+ * the variable can be declared before being bound. Must be bound (via the
+ * REF= operator / bind()) before any read or write — accessing it unbound
+ * is undefined behaviour, mirroring CODESYS.
  *
  * @tparam T The underlying value type (e.g., INT_t, REAL_t)
  */
@@ -308,12 +310,24 @@ private:
 
 public:
     /**
-     * Constructor - must be initialized with a valid reference
+     * Default constructor - unbound (ptr_ == nullptr).
+     *
+     * IEC 61131-3 REFERENCE TO is conceptually "always bound", but a
+     * variable of this type must still be *declarable* before it is bound
+     * (e.g. an uninitialized FB member or local that is bound later via the
+     * REF= operator inside the POU body). The generated code default-
+     * constructs such members, so a usable default ctor is required.
+     *
+     * As with CODESYS, reading or writing an unbound REFERENCE TO is
+     * undefined behaviour — generated code is expected to bind it (REF=)
+     * before first access. (Use REF_TO if you need explicit NULL checks.)
+     */
+    IEC_REFERENCE_TO() noexcept : ptr_(nullptr) {}
+
+    /**
+     * Constructor - initialize bound to a variable (REFERENCE TO X := target)
      */
     explicit IEC_REFERENCE_TO(IECVar<T>& var) noexcept : ptr_(&var) {}
-
-    // No default constructor - must be bound
-    IEC_REFERENCE_TO() = delete;
 
     // Copy/move - default is fine
     IEC_REFERENCE_TO(const IEC_REFERENCE_TO&) = default;

--- a/src/semantic/analyzer.ts
+++ b/src/semantic/analyzer.ts
@@ -1592,12 +1592,13 @@ export class SemanticAnalyzer {
       }
     }
 
-    // Additional ADR constraint: argument must be an l-value
-    if (nameUpper === "ADR" && argCount > 0) {
+    // Additional ADR / REF_LINK constraint: argument must be an l-value
+    // (you can only take the address of / a reference to a variable).
+    if ((nameUpper === "ADR" || nameUpper === "REF_LINK") && argCount > 0) {
       const arg = userArgs[0]!.value;
       if (!this.isLValue(arg)) {
         this.addError(
-          "ADR() requires a variable reference, not an expression",
+          `${nameUpper}() requires a variable reference, not an expression`,
           expr.sourceSpan.startLine,
           expr.sourceSpan.startCol,
           expr.sourceSpan.file,

--- a/src/semantic/std-function-registry.ts
+++ b/src/semantic/std-function-registry.ts
@@ -879,6 +879,24 @@ export class StdFunctionRegistry {
       category: "system",
     });
 
+    // REF_LINK(variable) -> reference to the variable (CODESYS REF() exposed
+    // as a callable block, since the bare REF() is a reserved operator token
+    // and cannot be invoked with the graphical EN/IN/ENO call form). Codegen
+    // lowers REF_LINK(x) to the runtime REF(x); wire its output to a REF_TO
+    // variable to bind it (myref := REF_LINK(target)). Replaces hand-written
+    // "link a reference" function blocks.
+    this.register({
+      name: "REF_LINK",
+      cppName: "REF",
+      returnConstraint: "specific",
+      returnMatchesFirstParam: false,
+      specificReturnType: "ANY",
+      params: [{ name: "IN", constraint: "ANY", isByRef: true }],
+      isVariadic: false,
+      isConversion: false,
+      category: "system",
+    });
+
     // SIZEOF(variable) -> UDINT (size in bytes)
     this.register({
       name: "SIZEOF",

--- a/src/semantic/type-checker.ts
+++ b/src/semantic/type-checker.ts
@@ -768,6 +768,24 @@ export class TypeChecker {
       case "RefAssignStatement": {
         this.resolveExprType(stmt.target, scope);
         this.resolveExprType(stmt.source, scope);
+        // REF= rebinds a reference, so the target must be declared
+        // REF_TO / REFERENCE TO. Catch `plainVar REF= x` here with a clear
+        // message rather than letting it fall through to a confusing C++
+        // error (e.g. `IEC_INT` has no member `bind`).
+        if (stmt.target.kind === "VariableExpression") {
+          const sym = scope.lookup(stmt.target.name);
+          if (sym && sym.kind === "variable") {
+            const refKind = sym.declaration.type.referenceKind;
+            if (refKind !== "ref_to" && refKind !== "reference_to") {
+              this.addError(
+                `REF= requires a REF_TO or REFERENCE TO target; '${stmt.target.name}' is not a reference`,
+                stmt.target.sourceSpan.startLine,
+                stmt.target.sourceSpan.startCol,
+                stmt.target.sourceSpan.file,
+              );
+            }
+          }
+        }
         break;
       }
 

--- a/tests/frontend/references.test.ts
+++ b/tests/frontend/references.test.ts
@@ -316,4 +316,37 @@ describe('Phase 2.4 - References and Pointers', () => {
       expect(func?.returnType.name).toBe('INT');
     });
   });
+
+  describe('Semantic: REF= target validation', () => {
+    it('rejects REF= on a non-reference target', () => {
+      const source = `
+        PROGRAM Main
+          VAR
+            a : INT;
+            b : INT;
+          END_VAR
+          a REF= b;
+        END_PROGRAM
+      `;
+      const result = compile(source);
+      expect(result.success).toBe(false);
+      expect(
+        result.errors.some((e) => /REF=.*reference|not a reference/i.test(e.message)),
+      ).toBe(true);
+    });
+
+    it('accepts REF= on a REFERENCE TO target', () => {
+      const source = `
+        PROGRAM Main
+          VAR
+            target : INT;
+            myref : REFERENCE_TO INT;
+          END_VAR
+          myref REF= target;
+        END_PROGRAM
+      `;
+      const result = compile(source);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -804,6 +804,32 @@ describeIfGpp('C++ Compilation Tests', () => {
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'fb_ref_to_input');
     expect(cppResult.success).toBe(true);
   });
+
+  it('compiles the REF_LINK block (assignment + graphical EN/IN/ENO call forms)', () => {
+    // REF_LINK is the callable form of the REF() operator (REF is a reserved
+    // token and cannot take the EN/IN/ENO block-call form). It lowers to
+    // REF(x); assigning to a REF_TO variable binds it.
+    const source = `
+      PROGRAM Main
+        VAR
+          another_var : INT := 43;
+          ref_a : REF_TO INT;
+          ref_b : REF_TO INT;
+          done_b : BOOL;
+          result : INT;
+        END_VAR
+        ref_a := REF_LINK(another_var);
+        ref_b := REF_LINK(EN := TRUE, IN := another_var, ENO => done_b);
+        ref_a^ := 100;
+        result := ref_b^;
+      END_PROGRAM
+    `;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    expect(result.cppCode).toContain('REF(ANOTHER_VAR)');
+    const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'ref_link_block');
+    expect(cppResult.success).toBe(true);
+  });
 });
 
 /**

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -739,6 +739,71 @@ describeIfGpp('C++ Compilation Tests', () => {
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'external_comments');
     expect(cppResult.success).toBe(true);
   });
+
+  // ---------------------------------------------------------------------------
+  // References (REF_TO / REFERENCE TO)
+  // ---------------------------------------------------------------------------
+
+  it('compiles REF_TO: declare, := REF(), and ^ read/write', () => {
+    const source = `
+      PROGRAM Main
+        VAR
+          v1 : INT;
+          v2 : INT := 7;
+          rv : REF_TO INT;
+        END_VAR
+        rv := REF(v2);
+        rv^ := 12;
+        v1 := rv^;
+      END_PROGRAM
+    `;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    expect(result.headerCode).toContain('IEC_REF_TO<INT_t>');
+    expect(result.headerCode).toContain('#include "iec_pointer.hpp"');
+    const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'ref_to_basic');
+    expect(cppResult.success).toBe(true);
+  });
+
+  it('compiles REFERENCE_TO: declare, REF= bind, implicit read/write', () => {
+    const source = `
+      PROGRAM Main
+        VAR
+          target : INT := 10;
+          other : INT := 99;
+          myref : REFERENCE_TO INT;
+          x : INT;
+        END_VAR
+        myref REF= target;
+        myref := 42;
+        x := myref;
+      END_PROGRAM
+    `;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    expect(result.headerCode).toContain('IEC_REFERENCE_TO<INT_t>');
+    const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'reference_to_basic');
+    expect(cppResult.success).toBe(true);
+  });
+
+  it('compiles a FUNCTION_BLOCK with a REF_TO input rebound via REF= (link_reference)', () => {
+    // Regression: a REF_TO target lowers REF= to `= REF(src)` (IEC_REF_TO has
+    // no bind()), not `.bind()`. Previously emitted IEC_INT + .bind() -> error.
+    const source = `
+      FUNCTION_BLOCK link_reference
+        VAR_INPUT
+          ref_in : REF_TO INT;
+          var_in : INT;
+        END_VAR
+        ref_in REF= var_in;
+      END_FUNCTION_BLOCK
+    `;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    expect(result.headerCode).toContain('IEC_REF_TO<INT_t>');
+    const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'fb_ref_to_input');
+    expect(cppResult.success).toBe(true);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

References were half-implemented in the backend: the `REF=` statement emitted `.bind()`, but reference *declarations* fell through to a plain `IEC_INT`, so any `REF_TO` / `REFERENCE TO` variable failed to compile (`IECVar<int> has no member bind`). This wires references end-to-end and adds a graphical-friendly `REF_LINK` block.

## Changes

**Declarations (`5a7d15f`)**
- `mapTypeRefToCpp`: `ref_to → IEC_REF_TO<T>`, `reference_to → IEC_REFERENCE_TO<T>` (same raw-elem resolution as `pointer_to`/`IEC_Ptr<T>`).
- Emit `#include "iec_pointer.hpp"` so the wrappers are in scope.
- Skip references from the program constructor initializer list — `name(0)` is ambiguous for `IEC_REF_TO`; they default-construct unbound and are bound later.
- `generateRefAssignStatement` branches on the target's reference kind: `REFERENCE TO → target.bind(src)`, `REF_TO → target = REF(src)` (`IEC_REF_TO` has no `bind()`), via a new `currentScopeVarRefKinds` scope map.
- Type-checker: `REF=` on a non-reference target now reports a clear error.
- Runtime: `IEC_REFERENCE_TO` gains a default constructor (unbound) so it can be declared then bound; kept C++14-clean.

**`REF_LINK` block (`f407b48`)**
- `REF()` is a reserved operator token and can't take the graphical `EN/IN/ENO` call form, so a `REF` block can't parse. `REF_LINK` is an ordinary System-category std function that codegen lowers to the runtime `REF(x)` — exactly as `ADR` lowers to `&(x)`. Wire its output to a `REF_TO` variable to bind it. Replaces hand-written "link a reference" function blocks.
- analyzer: `REF_LINK` requires an l-value argument (like `ADR`).

## Tests

- g++-backed integration tests for `REF_TO` (`:= REF()`, `^` read/write), `REFERENCE TO` (`REF=` bind, implicit read/write), a FB `REF_TO` input rebound via `REF=`, and `REF_LINK` (assignment + `EN/IN/ENO` block-call forms).
- Semantic tests for `REF=` target validation.
- Full suite: 1921 passing, 0 failures.

## Notes

- The synthesized `iec-std-functions.stlib` (gitignored build artifact) now carries a `REF_LINK` System entry for the editor block palette; it regenerates via `npm run build` at release time.
- References inside **struct fields** are a tracked follow-up (the struct-field codegen path uses a raw-pointer model and needs separate design).
- Reaches OpenPLC Editor only after a strucpp release + the editor's bundled-strucpp bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)