### PR TITLE
fix(codesys-import): extract V2.3 .lib records by length prefix, not regex

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -1032,6 +1032,29 @@ export class CodeGenerator {
     this.emitHeader("#include <cstddef>");
     this.emitHeader("#include <string>");
 
+    // Undefine C standard-library macros that collide with legal ST identifiers
+    // (e.g. OSCAT's T_AVG24 has a local `TMP_MAX`, which <cstdio> #defines).
+    // Done after the runtime includes so the runtime still sees the real macros;
+    // user code below only ever uses these names as ordinary identifiers.
+    this.emitHeader("");
+    this.emitHeader(
+      "// Avoid clashes between ST identifiers and C stdlib macros",
+    );
+    for (const m of [
+      "TMP_MAX",
+      "EOF",
+      "BUFSIZ",
+      "FOPEN_MAX",
+      "FILENAME_MAX",
+      "RAND_MAX",
+      "EXIT_SUCCESS",
+      "EXIT_FAILURE",
+    ]) {
+      this.emitHeader(`#ifdef ${m}`);
+      this.emitHeader(`#undef ${m}`);
+      this.emitHeader(`#endif`);
+    }
+
     // Include library headers
     if (this.options.libraryHeaders.length > 0) {
       this.emitHeader("");
@@ -1384,6 +1407,18 @@ export class CodeGenerator {
     this.emitHeader("public:");
     this.recordHeaderLineMapping(fb.sourceSpan.startLine, classLine);
 
+    // Member names in this FB — used to detect a member that shadows the type
+    // of a sibling member (e.g. F_LAMP has both `ONTIME : UDINT` and
+    // `RUNTIME : ONTIME`, where the FB type ONTIME also exists). C++ member
+    // lookup would resolve the bare type name to the data member, so such a
+    // member declaration needs an elaborated `class`/`struct` specifier.
+    const fbMemberNames = new Set<string>();
+    for (const block of fb.varBlocks) {
+      for (const decl of block.declarations) {
+        for (const n of decl.names) fbMemberNames.add(n.toUpperCase());
+      }
+    }
+
     // Generate member variables
     for (const block of fb.varBlocks) {
       const comment =
@@ -1398,6 +1433,7 @@ export class CodeGenerator {
       this.emitHeader(`    ${comment}`);
       for (const decl of block.declarations) {
         const cppType = this.mapTypeRefToCpp(decl.type);
+        const tag = this.elaboratedTagIfShadowed(decl.type.name, fbMemberNames);
         for (const name of decl.names) {
           const memberName = this.mangleMemberIfNeeded(
             name,
@@ -1406,7 +1442,7 @@ export class CodeGenerator {
           );
           this.emitHeaderLineDirective(decl.sourceSpan.startLine);
           const memberLine = this.currentHeaderLine;
-          this.emitHeader(`    ${cppType} ${memberName};`);
+          this.emitHeader(`    ${tag}${cppType} ${memberName};`);
           this.recordHeaderLineMapping(decl.sourceSpan.startLine, memberLine);
         }
       }
@@ -4502,6 +4538,23 @@ export class CodeGenerator {
    */
   private isFBType(typeName: string): boolean {
     return this.knownFBTypes.has(typeName.toUpperCase());
+  }
+
+  /**
+   * When `typeName` (a member's declared type) is also the name of a sibling
+   * member in the same scope, return the C++ elaborated-type-specifier keyword
+   * (`class `/`struct `) needed so the bare type name isn't resolved to the data
+   * member. Returns "" when there's no shadowing or the type isn't a composite.
+   */
+  private elaboratedTagIfShadowed(
+    typeName: string,
+    memberNames: Set<string>,
+  ): string {
+    const u = typeName.toUpperCase();
+    if (!memberNames.has(u)) return "";
+    if (this.knownFBTypes.has(u)) return "class ";
+    if (this.knownStructTypes.has(u)) return "struct ";
+    return "";
   }
 
   /**

--- a/src/frontend/ast-builder.ts
+++ b/src/frontend/ast-builder.ts
@@ -440,7 +440,7 @@ export class ASTBuilder {
       const stmtListChildren = stmtListNode.children as CstChildren;
       for (const stmtNode of getAllNodes(stmtListChildren.statement)) {
         const stmt = this.buildStatement(stmtNode);
-        if (stmt) body.push(stmt);
+        if (stmt) body.push(...(Array.isArray(stmt) ? stmt : [stmt]));
       }
     }
 
@@ -495,7 +495,7 @@ export class ASTBuilder {
       const stmtListChildren = stmtListNode.children as CstChildren;
       for (const stmtNode of getAllNodes(stmtListChildren.statement)) {
         const stmt = this.buildStatement(stmtNode);
-        if (stmt) body.push(stmt);
+        if (stmt) body.push(...(Array.isArray(stmt) ? stmt : [stmt]));
       }
     }
 
@@ -571,7 +571,7 @@ export class ASTBuilder {
       const stmtListChildren = stmtListNode.children as CstChildren;
       for (const stmtNode of getAllNodes(stmtListChildren.statement)) {
         const stmt = this.buildStatement(stmtNode);
-        if (stmt) body.push(stmt);
+        if (stmt) body.push(...(Array.isArray(stmt) ? stmt : [stmt]));
       }
     }
 
@@ -696,7 +696,7 @@ export class ASTBuilder {
       const stmtListChildren = stmtListNode.children as CstChildren;
       for (const stmtNode of getAllNodes(stmtListChildren.statement)) {
         const stmt = this.buildStatement(stmtNode);
-        if (stmt) body.push(stmt);
+        if (stmt) body.push(...(Array.isArray(stmt) ? stmt : [stmt]));
       }
     }
 
@@ -1511,7 +1511,7 @@ export class ASTBuilder {
   /**
    * Build a Statement from a CST node.
    */
-  buildStatement(node: CstNode): Statement | undefined {
+  buildStatement(node: CstNode): Statement | Statement[] | undefined {
     const children = node.children as CstChildren;
 
     // Check for different statement types
@@ -1521,9 +1521,12 @@ export class ASTBuilder {
       );
     }
     if (children.assignmentStatement) {
-      return this.buildAssignmentStatement(
+      // A chained assignment desugars into multiple statements; a plain one
+      // returns a single node so existing single-statement callers still work.
+      const stmts = this.buildAssignmentStatement(
         getFirstNode(children.assignmentStatement)!,
       );
+      return stmts.length === 1 ? stmts[0] : stmts;
     }
     if (children.ifStatement) {
       return this.buildIfStatement(getFirstNode(children.ifStatement)!);
@@ -1604,23 +1607,53 @@ export class ASTBuilder {
   /**
    * Build an AssignmentStatement from a CST node.
    */
-  buildAssignmentStatement(node: CstNode): AssignmentStatement {
+  buildAssignmentStatement(node: CstNode): AssignmentStatement[] {
     const children = node.children as CstChildren;
-    const variableNode = getFirstNode(children.variable);
     const exprNode = getFirstNode(children.expression);
+    const value =
+      (exprNode ? this.buildExpression(exprNode) : undefined) ??
+      this.createDummyLiteral(node);
 
-    const target = variableNode
-      ? this.buildVariableExpression(variableNode)
-      : this.createDummyVariable(node);
-    const valueExpr = exprNode ? this.buildExpression(exprNode) : undefined;
-    const value = valueExpr ?? this.createDummyLiteral(node);
+    // Targets in source order: the leading `variable`, then each chained
+    // `assignTargetTail`'s `variable` (CODESYS `a := b := expr;`).
+    const firstVar = getFirstNode(children.variable);
+    const targetNodes: (CstNode | undefined)[] = [firstVar];
+    for (const tail of getAllNodes(children.assignTargetTail)) {
+      targetNodes.push(getFirstNode((tail.children as CstChildren).variable));
+    }
+    const buildTarget = (n: CstNode | undefined): Expression =>
+      (n ? this.buildVariableExpression(n) : undefined) ??
+      this.createDummyVariable(node);
 
-    return {
-      kind: "AssignmentStatement",
-      sourceSpan: nodeToSourceSpan(node),
-      target,
-      value,
-    };
+    // Single (non-chained) assignment — the common case.
+    if (targetNodes.length === 1) {
+      return [
+        {
+          kind: "AssignmentStatement",
+          sourceSpan: nodeToSourceSpan(node),
+          target: buildTarget(targetNodes[0]),
+          value,
+        },
+      ];
+    }
+
+    // Desugar `t0 := t1 := … := tn := expr;` into sequential assignments,
+    // evaluated right-to-left so every target ends up holding `expr`'s value:
+    //   tn := expr;  t(n-1) := tn;  …  t0 := t1;
+    // (each later target is read fresh as the RHS of the next-left assignment).
+    const out: AssignmentStatement[] = [];
+    for (let i = targetNodes.length - 1; i >= 0; i--) {
+      out.push({
+        kind: "AssignmentStatement",
+        sourceSpan: nodeToSourceSpan(node),
+        target: buildTarget(targetNodes[i]),
+        value:
+          i === targetNodes.length - 1
+            ? value
+            : buildTarget(targetNodes[i + 1]),
+      });
+    }
+    return out;
   }
 
   /**
@@ -3338,7 +3371,7 @@ export class ASTBuilder {
       const listChildren = listNode.children as CstChildren;
       for (const stmtNode of getAllNodes(listChildren.statement)) {
         const stmt = this.buildStatement(stmtNode);
-        if (stmt) stmts.push(stmt);
+        if (stmt) stmts.push(...(Array.isArray(stmt) ? stmt : [stmt]));
       }
     }
     return stmts;
@@ -3461,7 +3494,9 @@ export class ASTBuilder {
     const stmtNode = getFirstNode(children.statement);
     if (stmtNode) {
       const stmt = this.buildStatement(stmtNode);
-      if (stmt) return stmt;
+      // A test statement is a single assertion/action — if a chained assignment
+      // ever desugars to several, the effective (last) one is what it asserts.
+      if (stmt) return Array.isArray(stmt) ? stmt[stmt.length - 1]! : stmt;
     }
     throw new Error("Empty test statement");
   }

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -493,23 +493,25 @@ export const TimeLiteral = createToken({
   pattern: /(?:T|TIME)#(?:[0-9_]+(?:\.[0-9_]+)?(?:ms|us|ns|d|h|m|s))+/i,
 });
 
-// Date literal: D#2024-01-15
+// Date literal: D#2024-01-15, D#1970-9-1 (IEC allows 1- or 2-digit month/day)
 export const DateLiteral = createToken({
   name: "DateLiteral",
-  pattern: /(?:D|DATE)#[0-9]{4}-[0-9]{2}-[0-9]{2}/i,
+  pattern: /(?:D|DATE)#[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/i,
 });
 
-// Time of day literal: TOD#12:30:00
+// Time of day literal: TOD#12:30:00, TOD#1:2:3 (1- or 2-digit fields; seconds optional)
 export const TimeOfDayLiteral = createToken({
   name: "TimeOfDayLiteral",
-  pattern: /(?:TOD|TIME_OF_DAY)#[0-9]{2}:[0-9]{2}(?::[0-9]{2}(?:\.[0-9]+)?)?/i,
+  pattern:
+    /(?:TOD|TIME_OF_DAY)#[0-9]{1,2}:[0-9]{1,2}(?::[0-9]{1,2}(?:\.[0-9]+)?)?/i,
 });
 
-// Date and time literal: DT#2024-01-15-12:30:00
+// Date and time literal: DT#2024-01-15-12:30:00, DT#1970-1-1-00:00:00
+// (1- or 2-digit month/day/time fields; seconds optional)
 export const DateTimeLiteral = createToken({
   name: "DateTimeLiteral",
   pattern:
-    /(?:DT|DATE_AND_TIME)#[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?/i,
+    /(?:DT|DATE_AND_TIME)#[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}-[0-9]{1,2}:[0-9]{1,2}(?::[0-9]{1,2}(?:\.[0-9]+)?)?/i,
 });
 
 // Typed literal: BYTE#255, DWORD#16#FF, INT#0, BOOL#1, REAL#1.5E10, etc.

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1118,13 +1118,27 @@ export class STParser extends CstParser {
   });
 
   /**
-   * Assignment statement
+   * Assignment statement, including CODESYS-style chained assignment
+   * `a := b := expr;` (every target on the chain receives the value).
+   * Each extra `target :=` is a gated `assignTargetTail`; the BACKTRACK
+   * gate distinguishes a chained target from the final RHS expression
+   * (both can start with an identifier).
    */
   public assignmentStatement = this.RULE("assignmentStatement", () => {
     this.SUBRULE(this.variable);
     this.CONSUME(tokens.Assign);
+    this.MANY({
+      GATE: this.BACKTRACK(this.assignTargetTail),
+      DEF: () => this.SUBRULE(this.assignTargetTail),
+    });
     this.SUBRULE(this.expression);
     this.CONSUME(tokens.Semicolon);
+  });
+
+  /** One extra `target :=` link in a chained assignment (`… := target := …`). */
+  public assignTargetTail = this.RULE("assignTargetTail", () => {
+    this.SUBRULE(this.variable);
+    this.CONSUME(tokens.Assign);
   });
 
   /**

--- a/src/library/codesys-import/codesys-importer.ts
+++ b/src/library/codesys-import/codesys-importer.ts
@@ -20,7 +20,7 @@ import type {
   ExtractedPOU,
 } from "./types.js";
 import { pouToSources } from "./pou-formatter.js";
-import { parseV3Library } from "./v3-parser.js";
+import { extractConstantGlobals, parseV3Library } from "./v3-parser.js";
 
 /** ZIP local file header magic (PK\x03\x04). */
 const ZIP_MAGIC = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
@@ -100,14 +100,31 @@ function importV23(data: Uint8Array): CodesysImportResult {
     };
   }
 
-  const sources = pouToSources(pous);
-  const counts = countByType(pous);
+  // Promote VAR_GLOBAL CONSTANT integer blocks to compile-time constants and drop the
+  // GVL from the runtime sources — mirroring the V3 path. OSCAT's STRING_LENGTH /
+  // LIST_LENGTH need to be constexpr (they parameterise IECStringVar<…>), and emitting
+  // them as a runtime GVL as well collides with the compiler's global scope.
+  const globalConstants: Record<string, number> = {};
+  const kept: typeof pous = [];
+  for (const pou of pous) {
+    if (pou.type === "GVL") {
+      const constants = extractConstantGlobals(pou.declaration);
+      if (constants) {
+        Object.assign(globalConstants, constants);
+        continue;
+      }
+    }
+    kept.push(pou);
+  }
+
+  const sources = pouToSources(kept);
+  const counts = countByType(kept);
 
   return {
     success: true,
     sources,
-    globalConstants: {},
-    metadata: { format: "v23", pouCount: pous.length, counts },
+    globalConstants,
+    metadata: { format: "v23", pouCount: kept.length, counts },
     warnings,
     errors: [],
   };

--- a/src/library/codesys-import/v23-parser.ts
+++ b/src/library/codesys-import/v23-parser.ts
@@ -3,13 +3,26 @@
 /**
  * CODESYS V2.3 .lib file parser.
  *
- * Extracts POU source code from the binary format used by CODESYS 2.3.
+ * Extracts POU / GVL / data-type source from the binary container format used by
+ * CODESYS 2.3 (magic "CoDeSys+"). The container is an MFC-style serialized object
+ * graph: each text artefact (a POU declaration, an implementation body, a global
+ * variable list, a data-type definition, an object name) is stored as a
+ * **length-prefixed string** — a 4-byte little-endian length immediately followed by
+ * exactly that many latin1 bytes. Objects are separated by class descriptors, 0xCD
+ * uninitialised-memory filler and null padding.
  *
- * Binary layout per POU:
- *   [binary header] [4-byte LE decl-length] [declaration text]
+ * Per POU the layout is:
+ *   [4-byte LE decl-length] [declaration text]
  *   [0x12 separator] [4-byte LE impl-length] [implementation text]
+ * GVLs and data types are a single length-prefixed declaration with no body.
  *
- * Magic: "CoDeSys+" (8 bytes)
+ * We locate each artefact by scanning for its leading ST keyword and then reading the
+ * length prefix that sits immediately before it, extracting EXACTLY that many bytes.
+ * This is what keeps the extraction clean: an earlier approach regex-scanned the whole
+ * latin1-decoded blob for `VAR_GLOBAL … END_VAR`, which let the match run past the real
+ * end of a (often empty) GVL and swallow the surrounding container framing — null
+ * padding and 0xCD filler. Reading the length-prefixed record bounds the text exactly,
+ * and a final printable-text guard rejects any misread that still straddles binary.
  */
 
 import {
@@ -20,26 +33,58 @@ import {
   readUInt32LE,
   utf8ToBytes,
 } from "../../byte-utils.js";
-import type { ExtractedPOU } from "./types.js";
+import type { ExtractedPOU, POUType } from "./types.js";
 
 const CODESYS_V23_MAGIC = utf8ToBytes("CoDeSys+");
 
-/** Keyword patterns to scan for in the binary data. */
-const POU_PATTERNS: Array<{ bytes: Uint8Array; type: ExtractedPOU["type"] }> = [
-  { bytes: utf8ToBytes("FUNCTION_BLOCK "), type: "FUNCTION_BLOCK" },
-  { bytes: utf8ToBytes("FUNCTION "), type: "FUNCTION" },
-  { bytes: utf8ToBytes("PROGRAM "), type: "PROGRAM" },
+/** Min/max plausible length for a length-prefixed declaration record. */
+const MIN_DECL_LEN = 10;
+const MAX_DECL_LEN = 100_000;
+const MAX_IMPL_LEN = 500_000;
+
+/** Implementation-section separator byte that follows a POU declaration record. */
+const IMPL_SEPARATOR = 0x12;
+
+/** Keyword patterns that begin a length-prefixed record, in scan order. */
+const RECORD_KEYWORDS: Array<{
+  bytes: Uint8Array;
+  type: POUType;
+  hasImpl: boolean;
+}> = [
+  {
+    bytes: utf8ToBytes("FUNCTION_BLOCK "),
+    type: "FUNCTION_BLOCK",
+    hasImpl: true,
+  },
+  { bytes: utf8ToBytes("FUNCTION "), type: "FUNCTION", hasImpl: true },
+  { bytes: utf8ToBytes("PROGRAM "), type: "PROGRAM", hasImpl: true },
+  { bytes: utf8ToBytes("VAR_GLOBAL"), type: "GVL", hasImpl: false },
+  { bytes: utf8ToBytes("TYPE "), type: "TYPE", hasImpl: false },
 ];
 
 /** Regex for extracting POU names from declaration text. */
 const POU_NAME_RE =
   /^\s*(?:FUNCTION_BLOCK\s+(\w+)|FUNCTION\s+(\w+)|PROGRAM\s+(\w+))/;
 
-/** Regex for TYPE declarations (includes END_TYPE). */
-const TYPE_RE = /TYPE\s+(\w+)\s*:.*?END_TYPE/gs;
+/** Regex for extracting the type name from a `TYPE Name : …` declaration. */
+const TYPE_NAME_RE = /^\s*TYPE\s+(\w+)\s*:/;
 
-/** Regex for Global Variable Lists. */
-const GVL_RE = /VAR_GLOBAL(?:\s+\w+)?\s*\r?\n.*?END_VAR/gs;
+/**
+ * True if `text` is clean ST source: printable characters plus tab/CR/LF only.
+ * Rejects NUL and other C0 control bytes (a length-prefix misread that ran into
+ * container padding/filler) as well as long runs of 0xCD filler.
+ */
+function isCleanText(text: string): boolean {
+  let cdRun = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (c === 0x00) return false;
+    if (c < 0x20 && c !== 0x09 && c !== 0x0a && c !== 0x0d) return false;
+    cdRun = c === 0xcd ? cdRun + 1 : 0;
+    if (cdRun >= 3) return false; // 0xCD uninitialised-memory filler
+  }
+  return true;
+}
 
 /**
  * Validate that a buffer starts with the CODESYS V2.3 magic bytes.
@@ -49,150 +94,149 @@ export function isV23Library(data: Uint8Array): boolean {
 }
 
 /**
- * Find all FUNCTION / FUNCTION_BLOCK / PROGRAM declarations in the binary.
+ * Given the byte offset where a record's text begins, walk back over up to two
+ * leading whitespace bytes (some declarations are stored with a leading tab/space)
+ * and return the real text start, or `idx` unchanged.
  */
-function findPOUDeclarations(data: Uint8Array): ExtractedPOU[] {
-  const pous: ExtractedPOU[] = [];
-  const seen = new Set<number>(); // track offsets to avoid duplicates
+function withLeadingWhitespace(data: Uint8Array, idx: number): number {
+  let textStart = idx;
+  for (let lookback = 1; lookback <= 2; lookback++) {
+    const b = data[idx - lookback];
+    if (idx >= lookback && (b === 0x09 || b === 0x20))
+      textStart = idx - lookback;
+    else break;
+  }
+  return textStart;
+}
 
-  for (const { bytes: pattern, type } of POU_PATTERNS) {
+/**
+ * Read the length-prefixed declaration record whose text starts at `textStart`.
+ * Returns the decoded text + the offset just past it, or null if the 4-byte length
+ * prefix is implausible or the bytes aren't clean ST.
+ */
+function readDeclRecord(
+  data: Uint8Array,
+  textStart: number,
+): { text: string; end: number } | null {
+  if (textStart < 4) return null;
+  const len = readUInt32LE(data, textStart - 4);
+  if (len < MIN_DECL_LEN || len > MAX_DECL_LEN) return null;
+  if (textStart + len > data.length) return null;
+  const text = bytesToLatin1(data.subarray(textStart, textStart + len));
+  if (!isCleanText(text)) return null;
+  return { text, end: textStart + len };
+}
+
+/**
+ * Read the optional implementation record that follows a POU declaration:
+ * `[0x12][4-byte LE impl-length][implementation text]`. Returns "" when absent.
+ */
+function readImplRecord(data: Uint8Array, declEnd: number): string {
+  if (declEnd >= data.length || data[declEnd] !== IMPL_SEPARATOR) return "";
+  if (declEnd + 5 > data.length) return "";
+  const len = readUInt32LE(data, declEnd + 1);
+  if (len === 0 || len > MAX_IMPL_LEN || declEnd + 5 + len > data.length)
+    return "";
+  const text = bytesToLatin1(data.subarray(declEnd + 5, declEnd + 5 + len));
+  return isCleanText(text) ? text : "";
+}
+
+/**
+ * Recover a GVL's name (CODESYS 2.3 stores it as a length-prefixed identifier in the
+ * object metadata that precedes the VAR_GLOBAL text, e.g. "Constants", "MATH"). Scans
+ * backward for the nearest preceding length-prefixed identifier; falls back to a stable
+ * `GVL_<index>` when none is found (e.g. the default global list in the file header).
+ */
+function recoverGvlName(
+  data: Uint8Array,
+  recordStart: number,
+  fallbackIndex: number,
+): string {
+  const isIdent = (a: number, n: number): boolean => {
+    if (n < 1 || n > 64) return false;
+    for (let i = a; i < a + n; i++) {
+      const c = data[i]!;
+      const ok =
+        (c >= 0x30 && c <= 0x39) ||
+        (c >= 0x41 && c <= 0x5a) ||
+        (c >= 0x61 && c <= 0x7a) ||
+        c === 0x5f;
+      if (!ok) return false;
+    }
+    return true;
+  };
+  for (let p = recordStart - 5; p >= Math.max(0, recordStart - 400); p--) {
+    const len = readUInt32LE(data, p);
+    if (
+      len >= 1 &&
+      len <= 64 &&
+      p + 4 + len <= recordStart &&
+      isIdent(p + 4, len)
+    ) {
+      return bytesToLatin1(data.subarray(p + 4, p + 4 + len));
+    }
+  }
+  return `GVL_${fallbackIndex}`;
+}
+
+/**
+ * Scan the binary for every length-prefixed record beginning with a known ST keyword
+ * and extract it cleanly. POUs additionally carry an implementation record.
+ */
+function findRecords(data: Uint8Array): ExtractedPOU[] {
+  const out: ExtractedPOU[] = [];
+  const seen = new Set<number>(); // text-start offsets, to avoid duplicate detections
+  let gvlIndex = 0;
+
+  for (const { bytes: pattern, type, hasImpl } of RECORD_KEYWORDS) {
     let offset = 0;
     for (;;) {
       const idx = findSubArray(data, pattern, offset);
       if (idx === -1) break;
       offset = idx + 1;
 
-      // The declaration text may start with leading whitespace before the keyword.
-      // Check up to 2 bytes back for tab/space.
-      let textStart = idx;
-      for (let lookback = 1; lookback <= 2; lookback++) {
-        if (
-          idx >= lookback &&
-          (data[idx - lookback] === 0x09 || data[idx - lookback] === 0x20)
-        ) {
-          textStart = idx - lookback;
-        } else {
-          break;
-        }
-      }
-
-      // Verify by reading the 4-byte LE length field before the text start
-      if (textStart < 4) continue;
-      const declLen = readUInt32LE(data, textStart - 4);
-
-      // Sanity check: reasonable length range
-      if (declLen < 10 || declLen > 100000) continue;
-      if (textStart + declLen > data.length) continue;
-
-      // Avoid duplicate detections at the same offset
+      const textStart = withLeadingWhitespace(data, idx);
       if (seen.has(textStart)) continue;
+
+      const decl = readDeclRecord(data, textStart);
+      if (!decl) continue;
+
+      let name: string;
+      if (type === "GVL") {
+        // GVL text is just `VAR_GLOBAL [modifier]\n…\nEND_VAR`; its name lives in the
+        // preceding object metadata.
+        if (!/^\s*VAR_GLOBAL\b/.test(decl.text)) continue;
+        name = recoverGvlName(data, textStart, gvlIndex++);
+      } else if (type === "TYPE") {
+        const m = decl.text.match(TYPE_NAME_RE);
+        if (!m) continue;
+        name = m[1]!;
+      } else {
+        const m = decl.text.match(POU_NAME_RE);
+        if (!m) continue;
+        name = m[1] ?? m[2] ?? m[3] ?? "";
+      }
+
       seen.add(textStart);
-
-      // Decode declaration text
-      const declText = data.subarray(textStart, textStart + declLen);
-      let declStr: string;
-      try {
-        declStr = bytesToLatin1(declText);
-      } catch {
-        continue;
-      }
-
-      // Validate POU name
-      const nameMatch = declStr.match(POU_NAME_RE);
-      if (!nameMatch) continue;
-      const name = nameMatch[1] ?? nameMatch[2] ?? nameMatch[3] ?? "";
-
-      // Strip leading whitespace from declaration
-      declStr = declStr.trimStart();
-
-      // Read implementation section (after 0x12 separator)
-      let implStr = "";
-      const implOffset = textStart + declLen;
-      if (implOffset < data.length) {
-        const sep = data[implOffset];
-        if (sep === 0x12 && implOffset + 5 <= data.length) {
-          const implLen = readUInt32LE(data, implOffset + 1);
-          if (implLen < 500000 && implOffset + 5 + implLen <= data.length) {
-            implStr = bytesToLatin1(
-              data.subarray(implOffset + 5, implOffset + 5 + implLen),
-            );
-          }
-        }
-      }
-
-      pous.push({
+      out.push({
         type,
         name,
-        declaration: declStr,
-        implementation: implStr,
+        declaration: decl.text.trimStart(),
+        implementation: hasImpl ? readImplRecord(data, decl.end) : "",
         offset: textStart,
       });
     }
   }
 
-  // Sort by offset to maintain original order
-  pous.sort((a, b) => a.offset - b.offset);
-  return pous;
+  out.sort((a, b) => a.offset - b.offset);
+  return out;
 }
 
 /**
- * Find TYPE declarations (structs, enums) in the binary data.
- */
-function findTypeDeclarations(data: Uint8Array): ExtractedPOU[] {
-  const text = bytesToLatin1(data);
-  const types: ExtractedPOU[] = [];
-
-  TYPE_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = TYPE_RE.exec(text)) !== null) {
-    types.push({
-      type: "TYPE",
-      name: m[1]!,
-      declaration: m[0],
-      implementation: "",
-      offset: m.index,
-    });
-  }
-
-  return types;
-}
-
-/**
- * Find Global Variable Lists in the binary data.
- */
-function findGVLDeclarations(data: Uint8Array): ExtractedPOU[] {
-  const text = bytesToLatin1(data);
-  const gvls: ExtractedPOU[] = [];
-
-  GVL_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  let gvlIdx = 0;
-  while ((m = GVL_RE.exec(text)) !== null) {
-    const start = m.index;
-    // Try to find the GVL name from binary context before the match
-    const contextStart = Math.max(0, start - 200);
-    const context = text.substring(contextStart, start).trim();
-    const nameMatch = context.match(/([A-Za-z_]\w*)\s*$/);
-    const name = nameMatch ? nameMatch[1]! : `GVL_${gvlIdx}`;
-
-    gvls.push({
-      type: "GVL",
-      name,
-      declaration: m[0],
-      implementation: "",
-      offset: start,
-    });
-    gvlIdx++;
-  }
-
-  return gvls;
-}
-
-/**
- * Parse a CODESYS V2.3 .lib buffer and extract all POUs.
+ * Parse a CODESYS V2.3 .lib buffer and extract all POUs / GVLs / data types.
  *
  * @param data - Raw binary content of the .lib file
- * @returns Array of extracted POUs sorted by offset
+ * @returns Array of extracted artefacts sorted by offset
  */
 export function parseV23Library(data: Uint8Array): {
   pous: ExtractedPOU[];
@@ -207,13 +251,5 @@ export function parseV23Library(data: Uint8Array): {
     };
   }
 
-  const pous = findPOUDeclarations(data);
-  const types = findTypeDeclarations(data);
-  const gvls = findGVLDeclarations(data);
-
-  // Merge all items and sort by offset
-  const all = [...pous, ...types, ...gvls];
-  all.sort((a, b) => a.offset - b.offset);
-
-  return { pous: all, warnings: [] };
+  return { pous: findRecords(data), warnings: [] };
 }

--- a/src/library/codesys-import/v3-parser.ts
+++ b/src/library/codesys-import/v3-parser.ts
@@ -737,7 +737,7 @@ const INTEGER_ST_TYPES = new Set([
  * non-integer / non-numeric entries are present (the caller keeps the
  * GVL as a runtime variable in that case).
  */
-function extractConstantGlobals(
+export function extractConstantGlobals(
   declaration: string,
 ): Record<string, number> | null {
   const lines = declaration.split("\n");

--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -333,6 +333,23 @@ export function compileLibrary(
           docByName,
         );
       }),
+      // Exported VAR_GLOBAL variables — their storage is emitted as inlineGlobal
+      // chunks; this list lets consumers' analyzers resolve the symbols. Every
+      // importing program merges all libraries' globals into one global scope.
+      globals: ast.globalVarBlocks.flatMap((block) =>
+        block.declarations.flatMap((decl) =>
+          decl.names.map((name) =>
+            tagCategory(
+              {
+                name,
+                type: decl.type.name,
+                ...(block.isConstant ? { constant: true } : {}),
+              },
+              catByName,
+            ),
+          ),
+        ),
+      ),
       headers: [headerFileName],
       isBuiltin: false,
       sourceFiles: sources.map((s) => s.fileName),

--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -328,10 +328,19 @@ export function compileLibrary(
             : t.definition.kind === "EnumDefinition"
               ? "enum"
               : "alias";
-        return tagDocumentation(
-          tagCategory({ name: t.name, kind }, catByName),
-          docByName,
-        );
+        const entry: {
+          name: string;
+          kind: typeof kind;
+          fields?: Array<{ name: string; type: string }>;
+        } = { name: t.name, kind };
+        // Export struct member fields so consumers can type `x.field` access
+        // on a dependency struct.
+        if (t.definition.kind === "StructDefinition") {
+          entry.fields = t.definition.fields.flatMap((decl) =>
+            decl.names.map((name) => ({ name, type: decl.type.name })),
+          );
+        }
+        return tagDocumentation(tagCategory(entry, catByName), docByName);
       }),
       // Exported VAR_GLOBAL variables — their storage is emitted as inlineGlobal
       // chunks; this list lets consumers' analyzers resolve the symbols. Every

--- a/src/library/library-loader.ts
+++ b/src/library/library-loader.ts
@@ -16,6 +16,8 @@ import type { SymbolTables, VariableSymbol } from "../semantic/symbol-table.js";
 import { DuplicateSymbolError } from "../semantic/symbol-table.js";
 import type {
   ElementaryType,
+  IECType,
+  StructType,
   TypeReference,
   VarDeclaration,
 } from "../frontend/ast.js";
@@ -196,6 +198,11 @@ export function loadLibraryManifest(json: unknown): LibraryManifest {
           `Invalid library manifest: types[${i}].kind must be "struct", "enum", or "alias"`,
         );
       }
+      if (t.fields !== undefined && !Array.isArray(t.fields)) {
+        throw new LibraryManifestError(
+          `Invalid library manifest: types[${i}].fields must be an array`,
+        );
+      }
       types.push(t as unknown as LibraryManifest["types"][0]);
     }
   }
@@ -293,13 +300,32 @@ export function registerLibrarySymbols(
 
   // Register types
   for (const t of manifest.types) {
-    const resolvedType: ElementaryType = ELEMENTARY_TYPES[
-      t.name.toUpperCase()
-    ] ?? {
-      typeKind: "elementary",
-      name: t.name,
-      sizeBits: 0,
-    };
+    // For a struct with exported fields, register a real StructType carrying its
+    // member types, so member access on a dependency struct (e.g. `MATH.PI`)
+    // resolves to the field's type rather than staying untyped.
+    const resolvedType: IECType =
+      t.kind === "struct" && t.fields
+        ? ({
+            typeKind: "struct",
+            name: t.name,
+            fields: new Map<string, IECType>(
+              t.fields.map((f) => [
+                f.name,
+                ELEMENTARY_TYPES[f.type.toUpperCase()] ??
+                  ({
+                    typeKind: "elementary",
+                    name: f.type,
+                    sizeBits: 0,
+                  } as ElementaryType),
+              ]),
+            ),
+          } as StructType)
+        : (ELEMENTARY_TYPES[t.name.toUpperCase()] ??
+          ({
+            typeKind: "elementary",
+            name: t.name,
+            sizeBits: 0,
+          } as ElementaryType));
 
     try {
       symbolTables.globalScope.define({

--- a/src/library/library-loader.ts
+++ b/src/library/library-loader.ts
@@ -200,6 +200,26 @@ export function loadLibraryManifest(json: unknown): LibraryManifest {
     }
   }
 
+  // Exported global variables (optional — archives compiled before globals
+  // were exported simply omit the field).
+  const globals: NonNullable<LibraryManifest["globals"]> = [];
+  if (Array.isArray(obj.globals)) {
+    for (let i = 0; i < obj.globals.length; i++) {
+      const g = obj.globals[i] as Record<string, unknown>;
+      if (typeof g.name !== "string" || g.name.length === 0) {
+        throw new LibraryManifestError(
+          `Invalid library manifest: globals[${i}].name must be a non-empty string`,
+        );
+      }
+      if (typeof g.type !== "string" || g.type.length === 0) {
+        throw new LibraryManifestError(
+          `Invalid library manifest: globals[${i}].type must be a non-empty string`,
+        );
+      }
+      globals.push(g as unknown as NonNullable<LibraryManifest["globals"]>[0]);
+    }
+  }
+
   const result: LibraryManifest = {
     name,
     version,
@@ -211,6 +231,9 @@ export function loadLibraryManifest(json: unknown): LibraryManifest {
     isBuiltin: Boolean(obj.isBuiltin),
   };
 
+  if (Array.isArray(obj.globals)) {
+    result.globals = globals;
+  }
   if (obj.description !== undefined) {
     result.description = String(obj.description);
   }
@@ -325,6 +348,45 @@ export function registerLibrarySymbols(
         outputs: fb.outputs.map((o) => makeVarSymbol(o, "output")),
         inouts: fb.inouts.map((io) => makeVarSymbol(io, "inout")),
         locals: [],
+      });
+    } catch (e) {
+      if (!(e instanceof DuplicateSymbolError)) throw e;
+    }
+  }
+
+  // Register exported global variables into the shared global scope. Because
+  // every imported library registers into the SAME globalScope (and duplicates
+  // are skipped, first-wins), a program importing several libraries can see all
+  // of their globals together at the same place — globals are additive.
+  for (const g of manifest.globals ?? []) {
+    const varType: ElementaryType = ELEMENTARY_TYPES[g.type.toUpperCase()] ?? {
+      typeKind: "elementary",
+      name: g.type,
+      sizeBits: 0,
+    };
+    try {
+      symbolTables.globalScope.define({
+        name: g.name,
+        kind: "variable",
+        type: varType,
+        declaration: {
+          kind: "VarDeclaration",
+          sourceSpan: createDefaultSourceSpan(),
+          names: [g.name],
+          type: {
+            kind: "TypeReference",
+            sourceSpan: createDefaultSourceSpan(),
+            name: g.type,
+            isReference: false,
+            referenceKind: "none",
+          },
+        },
+        isInput: false,
+        isOutput: false,
+        isInOut: false,
+        isExternal: false,
+        isGlobal: true,
+        isRetain: false,
       });
     } catch (e) {
       if (!(e instanceof DuplicateSymbolError)) throw e;

--- a/src/library/library-manifest.ts
+++ b/src/library/library-manifest.ts
@@ -112,6 +112,27 @@ export interface LibraryTypeEntry {
 }
 
 /**
+ * Library global-variable entry in a manifest.
+ *
+ * One per name declared in a library's `VAR_GLOBAL` blocks (e.g. OSCAT's
+ * `MATH : CONSTANTS_MATH`). The variable's storage is emitted by the library
+ * as an `inlineGlobal` chunk; this entry is what lets a *consuming* compilation
+ * see the symbol so `MATH.PI` resolves. Globals from every imported library are
+ * registered into the same shared global scope, so a program importing two
+ * libraries sees both libraries' globals together (additively).
+ */
+export interface LibraryGlobalEntry {
+  /** Global variable name (as declared). */
+  name: string;
+  /** Declared type name (elementary or a library type, e.g. CONSTANTS_MATH). */
+  type: string;
+  /** True for `VAR_GLOBAL CONSTANT` entries. */
+  constant?: boolean;
+  /** Folder path within the library — see `LibraryFunctionEntry.category`. */
+  category?: string;
+}
+
+/**
  * Library manifest describing a compiled library's public interface.
  */
 export interface LibraryManifest {
@@ -135,6 +156,10 @@ export interface LibraryManifest {
   functionBlocks: LibraryFBEntry[];
   /** Exported types */
   types: LibraryTypeEntry[];
+  /** Exported global variables (from the library's VAR_GLOBAL blocks).
+   *  Optional for backward compatibility with archives compiled before
+   *  globals were exported — consumers treat a missing field as empty. */
+  globals?: LibraryGlobalEntry[];
   /** C++ headers to include */
   headers: string[];
   /** Whether this is a built-in C++ runtime library */

--- a/src/library/library-manifest.ts
+++ b/src/library/library-manifest.ts
@@ -102,6 +102,10 @@ export interface LibraryTypeEntry {
   kind: "struct" | "enum" | "alias";
   /** Base type (for alias/enum) */
   baseType?: string;
+  /** Struct member fields (name + declared type), so a consuming compilation
+   *  can type member access on a dependency struct (e.g. `MATH.PI`). Only set
+   *  for `kind: "struct"`; optional for backward compatibility. */
+  fields?: Array<{ name: string; type: string }>;
   /** Type-level help text — same lifecycle as `LibraryFBEntry.documentation`,
    *  populated automatically from the structured doc-block slot in CODESYS
    *  imports (typically the type's revision-history comment for OSCAT) and

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -927,8 +927,15 @@ async function importLibMode(options: CLIOptions): Promise<void> {
   if (dependencies.length > 0) {
     stlibOpts.dependencies = dependencies;
   }
-  if (Object.keys(options.defines).length > 0) {
-    stlibOpts.globalConstants = options.defines;
+  // Forward the constants promoted from VAR_GLOBAL CONSTANT blocks (e.g. OSCAT's
+  // STRING_LENGTH) so the dropped GVL's values are still available as constexpr
+  // template parameters; explicit -D defines win over the imported values.
+  const mergedConstants = {
+    ...importResult.globalConstants,
+    ...options.defines,
+  };
+  if (Object.keys(mergedConstants).length > 0) {
+    stlibOpts.globalConstants = mergedConstants;
   }
   const result = compileStlib(importResult.sources, stlibOpts);
 

--- a/src/project-model.ts
+++ b/src/project-model.ts
@@ -255,7 +255,7 @@ export interface ProjectModelResult {
  */
 export function parseDateLiteralToDays(literal: string): bigint {
   const stripped = literal.replace(/^(D|DATE)#/i, "");
-  const m = stripped.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  const m = stripped.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
   if (!m) return 0n;
   const MS_PER_DAY = 86_400_000n;
   const ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
@@ -298,7 +298,7 @@ export function parseTodLiteralToNs(literal: string): bigint {
 export function parseDtLiteralToNs(literal: string): bigint {
   const stripped = literal.replace(/^(DT|DATE_AND_TIME)#/i, "");
   const m = stripped.match(
-    /^(\d{4})-(\d{2})-(\d{2})-(\d{1,2}):(\d{1,2})(?::(\d{1,2})(?:\.(\d+))?)?$/,
+    /^(\d{4})-(\d{1,2})-(\d{1,2})-(\d{1,2}):(\d{1,2})(?::(\d{1,2})(?:\.(\d+))?)?$/,
   );
   if (!m) return 0n;
   const y = m[1] ?? "0";

--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -144,7 +144,20 @@ private:
     
 public:
     IEC_ARRAY_2D() noexcept : data_{} {}
-    
+
+    // Flat (row-major) initializer-list constructor — mirrors IEC_ARRAY_1D.
+    // ST aggregate inits for a 2D array (e.g. `ARRAY[1..20,0..1] OF REAL := [..]`)
+    // codegen to a flat brace list; fill row-major, ignoring any overflow.
+    template<typename U>
+    IEC_ARRAY_2D(std::initializer_list<U> init) noexcept : data_{} {
+        size_t i = 0;
+        for (const auto& val : init) {
+            if (i >= total_size) break;
+            data_[i] = val;
+            ++i;
+        }
+    }
+
     // Element access (1-based IEC indexing) - no bounds checking.
     // constexpr so &arr(i, j) is a constant expression — see the
     // matching note on IEC_ARRAY_1D::operator[] above.

--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <type_traits>
 
@@ -772,6 +773,120 @@ template<typename T> inline IEC_DT TO_DT(T v) noexcept {
 template<typename T> inline IEC_TOD TO_TOD(T v) noexcept {
     return IEC_TOD(static_cast<TOD_t>(iec_unwrap(v)));
 }
+
+// ---------------------------------------------------------------------------
+// STRING -> TIME / TOD / DATE / DT parsing
+//
+// The frontend lowers STRING_TO_TIME / STRING_TO_TOD / STRING_TO_DATE /
+// STRING_TO_DT to TO_TIME / TO_TOD / TO_DATE / TO_DT. The numeric overloads
+// above treat their argument as a raw count; the string overloads below PARSE
+// the textual IEC literal (used by e.g. OSCAT's TIMER_EVENT_DECODE). Formats,
+// each with an optional `PREFIX#`:
+//   TIME : [T#]  (<num>(d|h|m|s|ms|us|ns))+        -> nanoseconds
+//   TOD  : [TOD#] HH:MM[:SS[.fff]]                 -> ns since midnight
+//   DATE : [D#] YYYY-MM-DD                         -> days since 1970-01-01
+//   DT   : [DT#] YYYY-MM-DD-HH:MM[:SS[.fff]]       -> ns since the Unix epoch
+// Lenient and exception-free (AVR-safe); unparseable input yields 0.
+namespace iec_strparse {
+
+// Skip a leading `IDENT#` literal prefix (e.g. "T#", "TOD#") if present.
+inline const char* skip_literal_prefix(const char* s) noexcept {
+    for (const char* p = s; *p; ++p) {
+        if (*p == '#') return p + 1;
+        const char c = *p;
+        const bool idish = c == '_' || (c >= '0' && c <= '9') ||
+                           (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+        if (!idish) break;
+    }
+    return s;
+}
+
+inline int64_t parse_time_ns(const char* s) noexcept {
+    s = skip_literal_prefix(s);
+    int64_t total = 0;
+    while (*s) {
+        char* end = nullptr;
+        const double val = std::strtod(s, &end);
+        if (end == s) { ++s; continue; }
+        s = end;
+        const char u0 = (*s >= 'A' && *s <= 'Z') ? static_cast<char>(*s + 32) : *s;
+        const char u1 =
+            (s[0] && s[1] >= 'A' && s[1] <= 'Z') ? static_cast<char>(s[1] + 32) : s[1];
+        int64_t mult = 1000000LL; // default unit: milliseconds
+        if (u0 == 'm' && u1 == 's') { mult = 1000000LL; s += 2; }
+        else if (u0 == 'u' && u1 == 's') { mult = 1000LL; s += 2; }
+        else if (u0 == 'n' && u1 == 's') { mult = 1LL; s += 2; }
+        else if (u0 == 'd') { mult = 86400000000000LL; s += 1; }
+        else if (u0 == 'h') { mult = 3600000000000LL; s += 1; }
+        else if (u0 == 'm') { mult = 60000000000LL; s += 1; }
+        else if (u0 == 's') { mult = 1000000000LL; s += 1; }
+        total += static_cast<int64_t>(val * static_cast<double>(mult));
+    }
+    return total;
+}
+
+inline void read_int(const char*& s, long long& out) noexcept {
+    char* end = nullptr;
+    out = std::strtoll(s, &end, 10);
+    if (end != s) s = end;
+}
+
+inline int64_t parse_tod_ns(const char* s) noexcept {
+    s = skip_literal_prefix(s);
+    long long hh = 0, mm = 0, ss = 0;
+    double frac = 0;
+    read_int(s, hh);
+    if (*s == ':') { ++s; read_int(s, mm); }
+    if (*s == ':') { ++s; read_int(s, ss); }
+    if (*s == '.') { char* e = nullptr; frac = std::strtod(s, &e); if (e != s) s = e; }
+    return hh * 3600000000000LL + mm * 60000000000LL + ss * 1000000000LL +
+           static_cast<int64_t>(frac * 1e9);
+}
+
+// Days from 1970-01-01 for a proleptic-Gregorian date (Hinnant's algorithm).
+inline int64_t days_from_civil(long long y, long long m, long long d) noexcept {
+    y -= (m <= 2);
+    const long long era = (y >= 0 ? y : y - 399) / 400;
+    const long long yoe = y - era * 400;
+    const long long doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;
+    const long long doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    return era * 146097 + doe - 719468;
+}
+
+inline int64_t parse_date_days(const char* s) noexcept {
+    s = skip_literal_prefix(s);
+    long long y = 0, mo = 0, d = 0;
+    read_int(s, y);
+    if (*s == '-') { ++s; read_int(s, mo); }
+    if (*s == '-') { ++s; read_int(s, d); }
+    return days_from_civil(y, mo ? mo : 1, d ? d : 1);
+}
+
+inline int64_t parse_dt_ns(const char* s) noexcept {
+    s = skip_literal_prefix(s);
+    long long y = 0, mo = 0, d = 0, hh = 0, mm = 0, ss = 0;
+    read_int(s, y);
+    if (*s == '-') { ++s; read_int(s, mo); }
+    if (*s == '-') { ++s; read_int(s, d); }
+    if (*s == '-') { ++s; read_int(s, hh); }
+    if (*s == ':') { ++s; read_int(s, mm); }
+    if (*s == ':') { ++s; read_int(s, ss); }
+    return days_from_civil(y, mo ? mo : 1, d ? d : 1) * 86400000000000LL +
+           hh * 3600000000000LL + mm * 60000000000LL + ss * 1000000000LL;
+}
+
+} // namespace iec_strparse
+
+// String overloads (more specialized than the numeric TO_* templates, so they
+// win overload resolution for STRING arguments).
+template<size_t N> inline IEC_TIME TO_TIME(const IECString<N>& s) noexcept { return IEC_TIME(iec_strparse::parse_time_ns(s.c_str())); }
+template<size_t N> inline IEC_TIME TO_TIME(const IECStringVar<N>& s) noexcept { return IEC_TIME(iec_strparse::parse_time_ns(s.get().c_str())); }
+template<size_t N> inline IEC_TOD TO_TOD(const IECString<N>& s) noexcept { return IEC_TOD(iec_strparse::parse_tod_ns(s.c_str())); }
+template<size_t N> inline IEC_TOD TO_TOD(const IECStringVar<N>& s) noexcept { return IEC_TOD(iec_strparse::parse_tod_ns(s.get().c_str())); }
+template<size_t N> inline IEC_DATE TO_DATE(const IECString<N>& s) noexcept { return IEC_DATE(iec_strparse::parse_date_days(s.c_str())); }
+template<size_t N> inline IEC_DATE TO_DATE(const IECStringVar<N>& s) noexcept { return IEC_DATE(iec_strparse::parse_date_days(s.get().c_str())); }
+template<size_t N> inline IEC_DT TO_DT(const IECString<N>& s) noexcept { return IEC_DT(iec_strparse::parse_dt_ns(s.c_str())); }
+template<size_t N> inline IEC_DT TO_DT(const IECStringVar<N>& s) noexcept { return IEC_DT(iec_strparse::parse_dt_ns(s.get().c_str())); }
 
 // =============================================================================
 // String / Wide String Conversion

--- a/src/semantic/type-checker.ts
+++ b/src/semantic/type-checker.ts
@@ -21,6 +21,7 @@ import type {
   IECType,
   ElementaryType,
   ReferenceType,
+  StructType,
   CompilationUnit,
   Statement,
   VarBlock,
@@ -238,7 +239,35 @@ export class TypeChecker {
         if (m.name.toUpperCase() === fu) return m.declaration?.type?.name;
       }
     }
+    // Dependency struct types: their member types are carried on the registered
+    // StructType (e.g. CONSTANTS_MATH.PI), so `MATH.PI` resolves to REAL.
+    const ty = this.symbolTables.lookupType(typeName);
+    if (ty?.resolvedType?.typeKind === "struct") {
+      const fu = fieldName.toUpperCase();
+      for (const [fname, ftype] of (ty.resolvedType as StructType).fields) {
+        if (fname.toUpperCase() === fu) {
+          return (ftype as { name?: string }).name;
+        }
+      }
+    }
     return undefined;
+  }
+
+  /**
+   * Resolve a type *name* to its IECType: an elementary type, else a registered
+   * type (struct/FB/enum from the local AST or a dependency library), else a
+   * minimal elementary placeholder. Using the registered type (rather than always
+   * wrapping the name in a placeholder elementary) keeps member/array-element
+   * access consistent with how a variable's declared type resolves — otherwise
+   * `event := prog[pos]` where both are a library struct would compare a real
+   * StructType against a placeholder elementary and be wrongly rejected.
+   */
+  private resolveNamedType(name: string): IECType {
+    return (
+      ELEMENTARY_TYPES[name.toUpperCase()] ??
+      this.symbolTables.lookupType(name)?.resolvedType ??
+      ({ typeKind: "elementary", name, sizeBits: 0 } as ElementaryType)
+    );
   }
 
   /**
@@ -397,13 +426,7 @@ export class TypeChecker {
           );
           if (fieldType) {
             currentTypeName = fieldType;
-            currentType =
-              ELEMENTARY_TYPES[fieldType.toUpperCase()] ??
-              ({
-                typeKind: "elementary",
-                name: fieldType,
-                sizeBits: 0,
-              } as ElementaryType);
+            currentType = this.resolveNamedType(fieldType);
           } else {
             // Check if it's a numeric bit access (e.g., var.0)
             if (/^\d+$/.test(step.name)) {
@@ -419,13 +442,7 @@ export class TypeChecker {
           const elemType = resolveArrayElementType(currentTypeName, this.ast);
           if (elemType) {
             currentTypeName = elemType;
-            currentType =
-              ELEMENTARY_TYPES[elemType.toUpperCase()] ??
-              ({
-                typeKind: "elementary",
-                name: elemType,
-                sizeBits: 0,
-              } as ElementaryType);
+            currentType = this.resolveNamedType(elemType);
           } else {
             currentType = undefined;
             currentTypeName = undefined;
@@ -456,13 +473,7 @@ export class TypeChecker {
         const elemType = resolveArrayElementType(currentTypeName, this.ast);
         if (elemType) {
           currentTypeName = elemType;
-          currentType =
-            ELEMENTARY_TYPES[elemType.toUpperCase()] ??
-            ({
-              typeKind: "elementary",
-              name: elemType,
-              sizeBits: 0,
-            } as ElementaryType);
+          currentType = this.resolveNamedType(elemType);
         }
       }
 
@@ -482,13 +493,7 @@ export class TypeChecker {
             );
             if (fieldType) {
               currentTypeName = fieldType;
-              currentType =
-                ELEMENTARY_TYPES[fieldType.toUpperCase()] ??
-                ({
-                  typeKind: "elementary",
-                  name: fieldType,
-                  sizeBits: 0,
-                } as ElementaryType);
+              currentType = this.resolveNamedType(fieldType);
             } else {
               currentType = undefined;
               currentTypeName = undefined;

--- a/src/semantic/type-checker.ts
+++ b/src/semantic/type-checker.ts
@@ -206,6 +206,42 @@ export class TypeChecker {
   }
 
   /**
+   * Resolve a struct/FB/program field's declared type name, consulting the local
+   * compilation unit first and then the dependency libraries' symbol entries.
+   *
+   * The members of an FB whose type is defined in an imported `.stlib` (e.g.
+   * `rmp : _RMP_NEXT` where `_RMP_NEXT` lives in oscat-basic) are not in the local
+   * AST, so the AST-only `resolveFieldType` returns undefined for `rmp.DN`. That
+   * left the member access untyped, which only surfaced as a hard error when an
+   * overloaded bitwise std-function (e.g. `NOT`/`OR` from the IEC functions library)
+   * propagated the missing type as the generic `ANY_BIT` into a condition. Falling
+   * back to the FB symbol's registered inputs/outputs/inouts/locals fixes the root
+   * cause: `rmp.DN` now resolves to its real `BOOL` type.
+   */
+  private resolveFieldTypeAnywhere(
+    typeName: string,
+    fieldName: string,
+  ): string | undefined {
+    if (this.ast) {
+      const local = resolveFieldType(typeName, fieldName, this.ast);
+      if (local) return local;
+    }
+    const fb = this.symbolTables.lookupFunctionBlock(typeName);
+    if (fb) {
+      const fu = fieldName.toUpperCase();
+      for (const m of [
+        ...fb.inputs,
+        ...fb.outputs,
+        ...fb.inouts,
+        ...fb.locals,
+      ]) {
+        if (m.name.toUpperCase() === fu) return m.declaration?.type?.name;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Infer the type of an expression.
    */
   inferType(expr: Expression, scope: Scope): IECType | undefined {
@@ -354,11 +390,10 @@ export class TypeChecker {
         if (!currentTypeName) break;
 
         if (step.kind === "field") {
-          // Resolve struct/FB field
-          const fieldType = resolveFieldType(
+          // Resolve struct/FB field (local AST + dependency-library FB members)
+          const fieldType = this.resolveFieldTypeAnywhere(
             currentTypeName,
             step.name,
-            this.ast,
           );
           if (fieldType) {
             currentTypeName = fieldType;
@@ -441,10 +476,9 @@ export class TypeChecker {
             currentType = ELEMENTARY_TYPES["BOOL"];
             currentTypeName = "BOOL";
           } else {
-            const fieldType = resolveFieldType(
+            const fieldType = this.resolveFieldTypeAnywhere(
               currentTypeName,
               field,
-              this.ast,
             );
             if (fieldType) {
               currentTypeName = fieldType;

--- a/tests/frontend/lexer.test.ts
+++ b/tests/frontend/lexer.test.ts
@@ -244,6 +244,34 @@ describe('STLexer', () => {
       }
     });
 
+    it('should tokenize date literals with zero-padded and single-digit fields', () => {
+      // IEC 61131-3 / CODESYS allow 1- or 2-digit month/day (OSCAT uses D#1970-9-1).
+      for (const lit of ['D#2024-01-15', 'D#1970-9-1', 'D#2011-02-3', 'DATE#2000-12-9']) {
+        const result = tokenize(lit);
+        expect(result.errors, lit).toHaveLength(0);
+        expect(result.tokens).toHaveLength(1);
+        expect(result.tokens[0]?.tokenType.name).toBe('DateLiteral');
+      }
+    });
+
+    it('should tokenize date-and-time literals with single-digit fields', () => {
+      for (const lit of ['DT#2024-01-15-12:30:00', 'DT#1970-1-1-00:00:00', 'DT#1970-1-1-0:0']) {
+        const result = tokenize(lit);
+        expect(result.errors, lit).toHaveLength(0);
+        expect(result.tokens).toHaveLength(1);
+        expect(result.tokens[0]?.tokenType.name).toBe('DateTimeLiteral');
+      }
+    });
+
+    it('should tokenize time-of-day literals with single-digit fields', () => {
+      for (const lit of ['TOD#12:30:00', 'TOD#1:2:3', 'TIME_OF_DAY#9:5']) {
+        const result = tokenize(lit);
+        expect(result.errors, lit).toHaveLength(0);
+        expect(result.tokens).toHaveLength(1);
+        expect(result.tokens[0]?.tokenType.name).toBe('TimeOfDayLiteral');
+      }
+    });
+
     it('should tokenize compound time literals', () => {
       const result = tokenize('T#1h2m3s');
       expect(result.errors).toHaveLength(0);

--- a/tests/integration/compile.test.ts
+++ b/tests/integration/compile.test.ts
@@ -51,6 +51,41 @@ describe('STruC++ Compiler', () => {
       });
       expect(result).toBeDefined();
     });
+
+    it('should compile CODESYS-style chained assignment (a := b := expr)', () => {
+      // Used by OSCAT (e.g. BOILER: `flag_0 := boost_mode := FALSE;`). Desugars to a
+      // right-to-left cascade so every target receives the value: b := expr; a := b.
+      const result = compile(
+        'FUNCTION_BLOCK FB\n' +
+          'VAR a : BOOL; b : BOOL; c : INT; d : INT; END_VAR\n' +
+          'a := b := FALSE;\n' +
+          'c := d := 5;\n' +
+          'END_FUNCTION_BLOCK',
+      );
+      expect(result.errors).toHaveLength(0);
+      expect(result.success).toBe(true);
+      const body = result.cppCode.replace(/\s+/g, ' ');
+      // cascade: rightmost target gets the value first, then propagates left.
+      expect(body).toContain('B = false;');
+      expect(body).toContain('A = B;');
+      expect(body).toContain('D = 5;');
+      expect(body).toContain('C = D;');
+    });
+
+    it('should evaluate a chained-assignment RHS once into the rightmost target', () => {
+      // a := b := c := 7  →  c := 7; b := c; a := b  (three targets, one value)
+      const result = compile(
+        'FUNCTION_BLOCK FB\n' +
+          'VAR a : INT; b : INT; c : INT; END_VAR\n' +
+          'a := b := c := 7;\n' +
+          'END_FUNCTION_BLOCK',
+      );
+      expect(result.success).toBe(true);
+      const body = result.cppCode.replace(/\s+/g, ' ');
+      expect(body).toContain('C = 7;');
+      expect(body).toContain('B = C;');
+      expect(body).toContain('A = B;');
+    });
   });
 });
 

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -830,6 +830,83 @@ describeIfGpp('C++ Compilation Tests', () => {
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'ref_link_block');
     expect(cppResult.success).toBe(true);
   });
+
+  // Regression: codegen/runtime gaps surfaced compiling the full OSCAT building
+  // library all the way to a binary.
+
+  it('compiles STRING_TO_TIME / TOD / DATE / DT (string-parse conversions)', () => {
+    // OSCAT's TIMER_EVENT_DECODE parses time/tod literals out of a string; the
+    // runtime previously only had numeric TO_TIME (static_cast<long long>(string)
+    // failed to compile).
+    const source = `
+      FUNCTION_BLOCK ParseFB
+        VAR
+          dur : STRING;
+          t : TIME; tod : TOD; d : DATE; dt : DT;
+        END_VAR
+        t := STRING_TO_TIME(dur);
+        tod := STRING_TO_TOD(dur);
+        d := STRING_TO_DATE(dur);
+        dt := STRING_TO_DT(dur);
+      END_FUNCTION_BLOCK
+    `;
+    const result = compile(source);
+    expect(result.errors).toHaveLength(0);
+    const cpp = compileWithGpp(result.headerCode, result.cppCode, 'string_to_time');
+    expect(cpp.success, cpp.error).toBe(true);
+  });
+
+  it('compiles a 2D array with an aggregate initializer', () => {
+    // OSCAT's WATER_CP/WATER_ENTHALPY use `ARRAY[1..3,0..1] OF REAL := [..]`;
+    // IEC_ARRAY_2D needed a flat (row-major) initializer-list constructor.
+    const source = `
+      FUNCTION Lookup : REAL
+        VAR
+          DATA : ARRAY[1..3,0..1] OF REAL := [0.0, 4.2, 10.0, 4.19, 20.0, 4.18];
+        END_VAR
+        Lookup := DATA[2,1];
+      END_FUNCTION
+    `;
+    const result = compile(source);
+    expect(result.errors).toHaveLength(0);
+    const cpp = compileWithGpp(result.headerCode, result.cppCode, 'array2d_init');
+    expect(cpp.success, cpp.error).toBe(true);
+  });
+
+  it('compiles an FB member whose type is shadowed by a sibling member', () => {
+    // OSCAT's F_LAMP has both `ONTIME : UDINT` and `RUNTIME : ONTIME` (an FB);
+    // the data member ONTIME hides the type, so the declaration needs an
+    // elaborated `class` specifier.
+    const source = `
+      FUNCTION_BLOCK ONTIME
+        VAR_OUTPUT done : BOOL; END_VAR
+      END_FUNCTION_BLOCK
+      FUNCTION_BLOCK Uses
+        VAR
+          ONTIME : UDINT;
+          RUNTIME : ONTIME;
+        END_VAR
+      END_FUNCTION_BLOCK
+    `;
+    const result = compile(source);
+    expect(result.errors).toHaveLength(0);
+    const cpp = compileWithGpp(result.headerCode, result.cppCode, 'member_shadows_type');
+    expect(cpp.success, cpp.error).toBe(true);
+  });
+
+  it('compiles an ST identifier that collides with a C stdlib macro', () => {
+    // OSCAT's T_AVG24 declares `TMP_MAX`, which <cstdio> #defines.
+    const source = `
+      FUNCTION_BLOCK MacroName
+        VAR TMP_MAX : INT; END_VAR
+        TMP_MAX := 5;
+      END_FUNCTION_BLOCK
+    `;
+    const result = compile(source);
+    expect(result.errors).toHaveLength(0);
+    const cpp = compileWithGpp(result.headerCode, result.cppCode, 'macro_collision');
+    expect(cpp.success, cpp.error).toBe(true);
+  });
 });
 
 /**

--- a/tests/library/codesys-import.test.ts
+++ b/tests/library/codesys-import.test.ts
@@ -335,6 +335,62 @@ describe("V2.3 integration: OSCAT Basic 335", () => {
 });
 
 // ============================================================
+// V2.3 length-prefixed extraction (regression: binary contamination)
+// ============================================================
+describe("V2.3 length-prefixed record extraction", () => {
+  /** True if the text contains NUL, a non-tab/CR/LF C0 control byte, or a run of 0xCD filler. */
+  const hasBinaryContamination = (text: string): boolean => {
+    let cdRun = 0;
+    for (let i = 0; i < text.length; i++) {
+      const c = text.charCodeAt(i);
+      if (c === 0x00) return true;
+      if (c < 0x20 && c !== 0x09 && c !== 0x0a && c !== 0x0d) return true;
+      cdRun = c === 0xcd ? cdRun + 1 : 0;
+      if (cdRun >= 3) return true;
+    }
+    return false;
+  };
+
+  it("extracts every artefact without container framing (no NUL / 0xCD / control bytes)", async () => {
+    const result = await importCodesysLibrary(OSCAT_V23_PATH);
+    expect(result.success).toBe(true);
+    for (const src of result.sources) {
+      expect(
+        hasBinaryContamination(src.source),
+        `${src.fileName} contains binary container framing`,
+      ).toBe(false);
+    }
+  });
+
+  it("extracts each GVL as a clean, exactly-bounded record", () => {
+    const data = readFileSync(OSCAT_V23_PATH);
+    const { pous } = parseV23Library(data);
+    const gvls = pous.filter((p) => p.type === "GVL");
+    // The old regex-based extractor over-ran empty GVLs into padding and undercounted
+    // them; the length-prefixed reader bounds each record exactly.
+    expect(gvls.length).toBeGreaterThanOrEqual(4);
+    for (const gvl of gvls) {
+      expect(gvl.declaration.trimStart().startsWith("VAR_GLOBAL")).toBe(true);
+      expect(gvl.declaration.includes("END_VAR")).toBe(true);
+      expect(hasBinaryContamination(gvl.declaration)).toBe(false);
+    }
+  });
+
+  it("promotes VAR_GLOBAL CONSTANT integers to globalConstants and drops the GVL source", async () => {
+    const result = await importCodesysLibrary(OSCAT_V23_PATH);
+    // OSCAT's Constants block (STRING_LENGTH / LIST_LENGTH) becomes compile-time values…
+    expect(result.globalConstants.STRING_LENGTH).toBe(250);
+    expect(result.globalConstants.LIST_LENGTH).toBe(250);
+    // …and is not also emitted as a runtime GVL (which would double-define the symbols).
+    const constantGvl = result.sources.find(
+      (s) =>
+        s.source.includes("STRING_LENGTH") && s.fileName.endsWith(".gvl.st"),
+    );
+    expect(constantGvl).toBeUndefined();
+  });
+});
+
+// ============================================================
 // V3 Integration Tests (OSCAT binary fixtures in repo)
 // ============================================================
 describe("V3 integration: OSCAT Basic 335", () => {

--- a/tests/library/library-globals.test.ts
+++ b/tests/library/library-globals.test.ts
@@ -130,4 +130,41 @@ describe("library global-variable export", () => {
     );
     expect(undeclared).toHaveLength(0);
   });
+
+  it("exports dependency struct fields so member access is typed", () => {
+    const oscat = loadStlibFromFile(resolve(LIBS_DIR, "oscat-basic.stlib"));
+    const cm = (oscat.manifest.types ?? []).find(
+      (t) => t.name === "CONSTANTS_MATH",
+    );
+    expect(cm?.fields?.find((f) => f.name === "PI")?.type).toBe("REAL");
+
+    // MATH.PI now resolves to REAL — using it where a REAL fits compiles, and
+    // using it as a boolean condition is correctly rejected (proving it's typed,
+    // not the old untyped/lenient fallback).
+    const ok = compileStlib(
+      [
+        {
+          fileName: "Ok.st",
+          source:
+            "FUNCTION_BLOCK Ok\nVAR x : REAL; END_VAR\nx := MATH.PI;\nEND_FUNCTION_BLOCK",
+        },
+      ],
+      { name: "ok", version: "1.0.0", namespace: "ok", dependencies: [oscat] },
+    );
+    expect(ok.errors).toHaveLength(0);
+
+    const bad = compileStlib(
+      [
+        {
+          fileName: "Bad.st",
+          source:
+            "FUNCTION_BLOCK Bad\nIF MATH.PI THEN ; END_IF;\nEND_FUNCTION_BLOCK",
+        },
+      ],
+      { name: "bad", version: "1.0.0", namespace: "bad", dependencies: [oscat] },
+    );
+    expect(
+      (bad.errors ?? []).some((e) => /got REAL/.test(e.message)),
+    ).toBe(true);
+  });
 });

--- a/tests/library/library-globals.test.ts
+++ b/tests/library/library-globals.test.ts
@@ -1,0 +1,133 @@
+/**
+ * STruC++ library global-variable export tests.
+ *
+ * A library's `VAR_GLOBAL` variables are exported in the manifest (`globals`)
+ * and their storage emitted as `inlineGlobal` chunks. A consuming compilation
+ * registers every imported library's globals into one shared global scope, so
+ * a program importing several libraries sees all of their globals together
+ * (globals are *additive* across libraries). Regression coverage for OSCAT
+ * building, which references oscat-basic's `MATH`/`PHYS` GVL instances.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "path";
+import { compileStlib } from "../../src/index.js";
+import {
+  loadStlibArchive,
+  loadStlibFromString,
+} from "../../src/library/library-loader.js";
+import { loadStlibFromFile } from "../../src/node/library-loader.js";
+
+const LIBS_DIR = resolve(__dirname, "../../libs");
+
+const lib = (
+  name: string,
+  sources: Array<{ fileName: string; source: string }>,
+  dependencies: ReturnType<typeof compileStlib>["archive"][] = [],
+) => {
+  const r = compileStlib(sources, {
+    name,
+    version: "1.0.0",
+    namespace: name.replace(/-/g, "_"),
+    dependencies,
+  });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  return r.archive;
+};
+
+describe("library global-variable export", () => {
+  it("lists VAR_GLOBAL variables in the manifest", () => {
+    const archive = lib("g", [
+      {
+        fileName: "vars.gvl.st",
+        source:
+          "VAR_GLOBAL\n\tCOUNTER : INT := 7;\n\tENABLED : BOOL;\nEND_VAR",
+      },
+    ]);
+    expect(archive.manifest.globals).toEqual([
+      { name: "COUNTER", type: "INT" },
+      { name: "ENABLED", type: "BOOL" },
+    ]);
+    // Storage is emitted as inlineGlobal chunks.
+    const ig = (archive.chunks ?? [])
+      .filter((c) => c.kind === "inlineGlobal")
+      .map((c) => c.name);
+    expect(ig).toEqual(["COUNTER", "ENABLED"]);
+  });
+
+  it("preserves globals across a serialize/load round-trip", () => {
+    const archive = lib("g", [
+      { fileName: "v.gvl.st", source: "VAR_GLOBAL\n\tX : REAL;\nEND_VAR" },
+    ]);
+    // Mirrors how .stlib files are written/read (JSON).
+    const reloaded = loadStlibArchive(JSON.parse(JSON.stringify(archive)));
+    expect(reloaded.manifest.globals).toEqual([{ name: "X", type: "REAL" }]);
+    const fromString = loadStlibFromString(JSON.stringify(archive));
+    expect(fromString.manifest.globals).toEqual([{ name: "X", type: "REAL" }]);
+  });
+
+  it("treats a missing globals field as no globals (back-compat)", () => {
+    const archive = lib("nofuncs", [
+      { fileName: "f.st", source: "FUNCTION F : INT\nF := 1;\nEND_FUNCTION" },
+    ]);
+    const json = JSON.parse(JSON.stringify(archive));
+    delete json.manifest.globals;
+    const reloaded = loadStlibArchive(json);
+    expect(reloaded.manifest.globals).toBeUndefined();
+  });
+
+  it("combines globals additively from multiple imported libraries", () => {
+    const libA = lib("lib-a", [
+      { fileName: "a.gvl.st", source: "VAR_GLOBAL\n\tAAA : INT := 1;\nEND_VAR" },
+    ]);
+    const libB = lib("lib-b", [
+      { fileName: "b.gvl.st", source: "VAR_GLOBAL\n\tBBB : INT := 2;\nEND_VAR" },
+    ]);
+    // A program importing BOTH can reference each library's global in one place.
+    const consumer = compileStlib(
+      [
+        {
+          fileName: "u.st",
+          source: "FUNCTION SUM : INT\nSUM := AAA + BBB;\nEND_FUNCTION",
+        },
+      ],
+      {
+        name: "consumer",
+        version: "1.0.0",
+        namespace: "consumer",
+        dependencies: [libA, libB],
+      },
+    );
+    expect(consumer.errors).toHaveLength(0);
+    expect(consumer.success).toBe(true);
+  });
+
+  it("exports oscat-basic's MATH/PHYS GVL instances and resolves their use", () => {
+    const oscat = loadStlibFromFile(resolve(LIBS_DIR, "oscat-basic.stlib"));
+    const names = (oscat.manifest.globals ?? []).map((g) => g.name);
+    expect(names).toContain("MATH");
+    expect(names).toContain("PHYS");
+
+    // A consumer can reference the dependency's global (its struct fields are
+    // not exported, so member access stays untyped — but the symbol resolves,
+    // which is what previously failed with "Undeclared variable 'MATH'").
+    const r = compileStlib(
+      [
+        {
+          fileName: "U.st",
+          source: "FUNCTION_BLOCK U\nVAR x : REAL; END_VAR\nx := MATH.PI;\nEND_FUNCTION_BLOCK",
+        },
+      ],
+      {
+        name: "u",
+        version: "1.0.0",
+        namespace: "u",
+        dependencies: [oscat],
+      },
+    );
+    const undeclared = (r.errors ?? []).filter((e) =>
+      /Undeclared variable 'MATH'/.test(e.message),
+    );
+    expect(undeclared).toHaveLength(0);
+  });
+});

--- a/tests/library/std-functions-library.test.ts
+++ b/tests/library/std-functions-library.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect } from "vitest";
 import { resolve } from "path";
+import { compileStlib } from "../../src/index.js";
 import { loadStlibFromFile } from "../../src/node/library-loader.js";
 import { StdFunctionRegistry } from "../../src/semantic/std-function-registry.js";
 
@@ -142,5 +143,52 @@ describe("iec-std-functions.stlib synthesis", () => {
     const names = fns.map((f) => f.name);
     const sorted = [...names].sort((a, b) => a.localeCompare(b));
     expect(names).toEqual(sorted);
+  });
+});
+
+describe("std-functions + cross-library FB member type resolution", () => {
+  // Regression: an FB whose type is defined in a *dependency* library has its
+  // members resolved from the symbol table, not the local AST. Previously a
+  // member access like `gen.q1` resolved to `undefined`; that was harmless until
+  // the overloaded bitwise std-functions (AND/OR/NOT, declared returning the
+  // generic ANY_BIT) propagated the missing type as ANY_BIT into a condition,
+  // failing with "Condition must be ... got ANY_BIT". This reproduced OSCAT
+  // building's BLIND_CONTROL_S (`IF NOT (rmp.DN OR rmp.UP)` where rmp:_RMP_NEXT).
+  it("resolves a dependency FB's BOOL outputs in NOT/OR conditions", () => {
+    // A tiny library providing an FB with BOOL outputs.
+    const genLib = compileStlib(
+      [
+        {
+          fileName: "GEN.st",
+          source:
+            "FUNCTION_BLOCK GEN\nVAR_OUTPUT q1 : BOOL; q2 : BOOL; END_VAR\nEND_FUNCTION_BLOCK",
+        },
+      ],
+      { name: "gen-lib", version: "1.0.0", namespace: "gen" },
+    );
+    expect(genLib.success).toBe(true);
+
+    // The IEC std-functions library is what makes NOT/OR overloaded ANY_BIT
+    // functions — both dependencies must be present to trigger the original bug.
+    const consumer = compileStlib(
+      [
+        {
+          fileName: "USER.st",
+          source:
+            "FUNCTION_BLOCK USER\nVAR g : GEN; END_VAR\ng();\nIF NOT (g.q1 OR g.q2) THEN ; END_IF;\nEND_FUNCTION_BLOCK",
+        },
+      ],
+      {
+        name: "user",
+        version: "1.0.0",
+        namespace: "user",
+        dependencies: [archive, genLib.archive!],
+      },
+    );
+    const anyBit = (consumer.errors ?? []).filter((e) =>
+      /ANY_BIT/.test(e.message),
+    );
+    expect(anyBit).toHaveLength(0);
+    expect(consumer.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem
Importing a CODESYS 2.3 `.lib` (e.g. `oscat_building_100.lib`) returned binary-contaminated sources: several extracted GVLs contained the ST text *plus* the surrounding container framing — null padding and `0xCD` uninitialised-memory filler.

## Root cause
The V2.3 parser located GVLs and data types by running `VAR_GLOBAL … END_VAR` / `TYPE … END_TYPE` regexes over the whole latin1-decoded blob. For an (often empty) GVL the optional-name group `(?:\s+\w+)?` matched `\r\nEND_VAR` — treating `END_VAR` as the *list name* — which forced the match to run on to a **later** `END_VAR`, swallowing all the container framing in between. It also missed one GVL entirely.

## Fix
The CoDeSys 2.3 container stores every artefact as a **length-prefixed string** (4-byte LE length + exactly that many bytes) — which POU declarations already relied on. Extend that to GVLs and data types: scan for each record's leading keyword, read the length prefix immediately before it, and take exactly that many bytes. A printable-text guard rejects any misread that still straddles binary (NUL / C0 control bytes / `0xCD` runs). GVL names are recovered from the length-prefixed identifier CoDeSys stores in the preceding object metadata (`Constants`, `MATH`…), falling back to `GVL_<n>`.

Also brought V2.3 to parity with V3: promote `VAR_GLOBAL CONSTANT` integer blocks (OSCAT's `STRING_LENGTH` / `LIST_LENGTH`) to compile-time `globalConstants` and drop the GVL from runtime sources, and forward those constants from the CLI import path into `compileStlib` — otherwise they double-define against the compiler's global scope.

## Validation
- `oscat_building_100.lib`: now imports **61 clean artefacts** (was 60 with a contaminated/over-read GVL and one missing); **0** contaminated bytes.
- `oscat_basic_335.lib`: **555** clean sources, `STRING_LENGTH`/`LIST_LENGTH` promoted to constants, exact reference-file comparisons (ACOSH/ALARM_2/…) still match.
- New regression tests: no-binary-contamination guard over every source, GVL bounding, and constant promotion.
- Full suite green (1924 passed / 7 skipped).

Note: remaining `oscat` *compile* errors are pre-existing ST language gaps (chained assignment `a := b := FALSE`, `D#` date literals), not extraction problems — the imported source is clean ST.