### PR TITLE
feat(runtime): target-aware fault path via iec_runtime_fault()

### DIFF
--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -15,7 +15,8 @@
 #include <array>
 #include <cstdint>
 #include <initializer_list>
-#ifndef __AVR__
+#include "iec_fault.hpp"
+#if STRUCPP_HAS_EXCEPTIONS
 #include <stdexcept>
 #endif
 #include "iec_var.hpp"
@@ -86,10 +87,10 @@ public:
     // Bounds-checked access - throws std::out_of_range on invalid index
     var_type& at(int64_t index) {
         if (!Bounds::in_bounds(index)) {
-#ifdef __AVR__
-            for(;;); // halt on bounds error (no exceptions on AVR)
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
 #endif
         }
         return data_[to_internal_index(index)];
@@ -97,10 +98,10 @@ public:
     
     const var_type& at(int64_t index) const {
         if (!Bounds::in_bounds(index)) {
-#ifdef __AVR__
-            for(;;); // halt on bounds error (no exceptions on AVR)
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
 #endif
         }
         return data_[to_internal_index(index)];
@@ -172,10 +173,10 @@ public:
     // Bounds-checked access - throws std::out_of_range on invalid index
     var_type& at(int64_t i, int64_t j) {
         if (!Bounds1::in_bounds(i) || !Bounds2::in_bounds(j)) {
-#ifdef __AVR__
-            for(;;); // halt on bounds error (no exceptions on AVR)
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
 #endif
         }
         return data_[to_linear_index(i, j)];
@@ -183,10 +184,10 @@ public:
     
     const var_type& at(int64_t i, int64_t j) const {
         if (!Bounds1::in_bounds(i) || !Bounds2::in_bounds(j)) {
-#ifdef __AVR__
-            for(;;); // halt on bounds error (no exceptions on AVR)
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
 #endif
         }
         return data_[to_linear_index(i, j)];

--- a/src/runtime/include/iec_fault.hpp
+++ b/src/runtime/include/iec_fault.hpp
@@ -1,0 +1,63 @@
+/**
+ * iec_fault.hpp — unrecoverable-fault handling for the STruC++ runtime.
+ *
+ * STruC++ runs on two very different classes of target:
+ *
+ *   - Hosted (Linux/Windows OpenPLC runtime, the REPL, the test harness):
+ *     compiled WITH C++ exceptions. Runtime faults `throw`, and the host
+ *     catches them — e.g. to stop the offending POU while the rest of the
+ *     program keeps scanning, or to print a diagnostic and exit cleanly.
+ *
+ *   - Freestanding (microcontroller firmware: AVR, SAMD, RP2040, STM32, …):
+ *     compiled with `-fno-exceptions`. There is nothing to catch a throw and
+ *     the C++ exception runtime is dead weight (~10-15 KB of unwinder), so
+ *     instead of throwing, the runtime calls `iec_runtime_fault()`.
+ *
+ * The selection is keyed off whether the *compiler* has exceptions enabled
+ * (`STRUCPP_HAS_EXCEPTIONS`), NOT off any particular chip macro — so every
+ * `-fno-exceptions` target uniformly takes the fault path with no per-board
+ * flags.
+ */
+#pragma once
+
+#include <cstdint>
+
+// Are C++ exceptions available in this translation unit? GCC/Clang define
+// __cpp_exceptions / __EXCEPTIONS with -fexceptions (the hosted default) and
+// leave them undefined with -fno-exceptions; MSVC uses _CPPUNWIND.
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#  define STRUCPP_HAS_EXCEPTIONS 1
+#else
+#  define STRUCPP_HAS_EXCEPTIONS 0
+#endif
+
+namespace strucpp {
+
+/**
+ * Reason an unrecoverable runtime fault was raised. Passed to
+ * `iec_runtime_fault()` so a platform hook can react per-cause (distinct LED
+ * blink code, alarm tone, log line, …).
+ */
+enum class IecFault : uint8_t {
+    NullReference = 0,  ///< Dereferenced a NULL IEC pointer/reference.
+    ArrayBounds   = 1,  ///< IEC array index out of bounds.
+    BadLocation   = 2,  ///< Invalid located-variable area/size character.
+};
+
+/**
+ * Unrecoverable-fault handler for targets compiled WITHOUT exceptions — the
+ * freestanding analogue of `throw`. It MUST NOT return.
+ *
+ * Only *declared* here. A weak default definition (provided by the firmware
+ * glue) halts the CPU; a platform/VPP HAL may supply a strong definition to
+ * blink a fault LED keyed off `reason`, sound an alarm, reboot, etc.
+ *
+ * On hosted (exception) builds this is never referenced — those code paths
+ * `throw` instead — so no definition is required there.
+ *
+ * @param reason  what went wrong (for platform-specific signalling)
+ * @param context optional human-readable context; may be nullptr
+ */
+[[noreturn]] void iec_runtime_fault(IecFault reason, const char* context = nullptr) noexcept;
+
+}  // namespace strucpp

--- a/src/runtime/include/iec_located.hpp
+++ b/src/runtime/include/iec_located.hpp
@@ -15,8 +15,10 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#ifndef __AVR__
+#include "iec_fault.hpp"
+#if STRUCPP_HAS_EXCEPTIONS
 #include <stdexcept>
 #endif
 
@@ -141,10 +143,10 @@ inline LocatedArea parse_area(char c) {
         case 'I': case 'i': return LocatedArea::Input;
         case 'Q': case 'q': return LocatedArea::Output;
         case 'M': case 'm': return LocatedArea::Memory;
-#ifdef __AVR__
-        default: for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
         default: throw std::invalid_argument("Invalid area character");
+#else
+        default: iec_runtime_fault(IecFault::BadLocation, "Invalid area character");
 #endif
     }
 }
@@ -162,10 +164,10 @@ inline LocatedSize parse_size(char c) {
         case 'W': case 'w': return LocatedSize::Word;
         case 'D': case 'd': return LocatedSize::DWord;
         case 'L': case 'l': return LocatedSize::LWord;
-#ifdef __AVR__
-        default: for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
         default: throw std::invalid_argument("Invalid size character");
+#else
+        default: iec_runtime_fault(IecFault::BadLocation, "Invalid size character");
 #endif
     }
 }

--- a/src/runtime/include/iec_pointer.hpp
+++ b/src/runtime/include/iec_pointer.hpp
@@ -46,7 +46,8 @@
 #pragma once
 
 #include <cstddef>
-#ifndef __AVR__
+#include "iec_fault.hpp"
+#if STRUCPP_HAS_EXCEPTIONS
 #include <stdexcept>
 #include <string>
 #endif
@@ -58,7 +59,7 @@ namespace strucpp {
 // Null Reference Exception
 // =============================================================================
 
-#ifndef __AVR__
+#if STRUCPP_HAS_EXCEPTIONS
 /**
  * Exception thrown when dereferencing a NULL reference.
  * The runtime catches this and stops execution of the affected POU.
@@ -151,10 +152,10 @@ public:
      */
     IECVar<T>& deref() {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException();
+#else
+            iec_runtime_fault(IecFault::NullReference);
 #endif
         }
         return *ptr_;
@@ -162,10 +163,10 @@ public:
 
     const IECVar<T>& deref() const {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException();
+#else
+            iec_runtime_fault(IecFault::NullReference);
 #endif
         }
         return *ptr_;
@@ -176,10 +177,10 @@ public:
      */
     IECVar<T>& deref(const char* context) {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException(context);
+#else
+            iec_runtime_fault(IecFault::NullReference, context);
 #endif
         }
         return *ptr_;
@@ -187,10 +188,10 @@ public:
 
     const IECVar<T>& deref(const char* context) const {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException(context);
+#else
+            iec_runtime_fault(IecFault::NullReference, context);
 #endif
         }
         return *ptr_;
@@ -233,10 +234,10 @@ public:
      */
     pointer_type operator->() {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException();
+#else
+            iec_runtime_fault(IecFault::NullReference);
 #endif
         }
         return ptr_;
@@ -244,10 +245,10 @@ public:
 
     const pointer_type operator->() const {
         if (ptr_ == nullptr) {
-#ifdef __AVR__
-            for(;;);
-#else
+#if STRUCPP_HAS_EXCEPTIONS
             throw NullReferenceException();
+#else
+            iec_runtime_fault(IecFault::NullReference);
 #endif
         }
         return ptr_;


### PR DESCRIPTION
Gate runtime throw-vs-halt on **exception availability** (`STRUCPP_HAS_EXCEPTIONS`, from `__cpp_exceptions`/`__EXCEPTIONS`/`_CPPUNWIND`) instead of `__AVR__`. New `iec_fault.hpp` declares `[[noreturn]] iec_runtime_fault(IecFault, const char*)`. Each fault site:

```
#if STRUCPP_HAS_EXCEPTIONS
    throw ...;                        // hosted: catchable (per-POU stop)
#else
    iec_runtime_fault(IecFault::...); // freestanding: overridable halt
#endif
```

12 sites converted (iec_array ×4, iec_pointer ×6, iec_located ×2); exception classes + `<stdexcept>` move to the same gate; added `<cstddef>` to iec_located (used `size_t` transitively). AVR-memory quirks stay on `__AVR__`.

### Why
Non-AVR MCUs built `-fno-exceptions` (SAMD/RP2040/STM32) fell into the throw arm and failed to compile — forcing the ~10-15 KB EH unwinder via `-fexceptions`. Now every `-fno-exceptions` target uniformly uses the fault hook (weak default halts; firmware/VPP HALs override — e.g. P1AM blinks its LED).

### Verified
Hosted throw+catch (all sites); cortex-m0plus + atmega2560 `-fno-exceptions` compile cleanly with the fault path and no EH runtime; end-to-end on real generated firmware (SAMD via arduino-cli + AVR/avr8js); P1AM LED-blink fault confirmed on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)