### PR TITLE
release: development → main (v0.5.9 — __XWORD, required inputs, manifest initial values)

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -53,7 +53,7 @@ import {
   parseTodLiteralToNs,
 } from "../project-model.js";
 import { TypeRegistry } from "../semantic/type-registry.js";
-import { TypeCodeGenerator } from "./type-codegen.js";
+import { TypeCodeGenerator, IEC_TO_CPP_VAR_TYPE } from "./type-codegen.js";
 import { formatArrayType, iecBaseToCppLiteral } from "./codegen-utils.js";
 import {
   getTypeBits,
@@ -492,7 +492,10 @@ export class CodeGenerator {
       }
       return typeName;
     }
-    return `IEC_${typeName}`;
+    // Elementary types: use the canonical IECVar alias map so names whose
+    // wrapper isn't simply `IEC_<NAME>` (e.g. __XWORD → IEC_XWORD) resolve
+    // correctly; all standard types map to `IEC_<NAME>` as before.
+    return IEC_TO_CPP_VAR_TYPE[typeName.toUpperCase()] ?? `IEC_${typeName}`;
   }
 
   /**
@@ -2434,13 +2437,17 @@ export class CodeGenerator {
       // Initializer list
       const inits: string[] = [];
       for (const decl of prog.varDeclarations) {
-        // References (REF_TO / REFERENCE TO) wrap a pointer internally and
-        // must be default-constructed (unbound) — `name(0)` is ambiguous for
-        // IEC_REF_TO. They are bound later via REF= / := REF(). (An
-        // initialized `REFERENCE TO X := target` is a separate enhancement.)
+        // References (REF_TO / REFERENCE TO) and pointers (POINTER TO) wrap a
+        // pointer internally and must be default-constructed (unbound/null) —
+        // `name(0)` is ambiguous for IEC_REF_TO, and now also for IEC_Ptr,
+        // which gained an integer-address ctor (the `0` literal matches both
+        // the nullptr_t and the uintptr_t overload). The default ctor sets the
+        // pointer to nullptr, which is exactly the IEC default. References are
+        // bound later via REF= / := REF(); pointers via := ADR()/&.
         if (
           decl.referenceKind === "ref_to" ||
-          decl.referenceKind === "reference_to"
+          decl.referenceKind === "reference_to" ||
+          decl.referenceKind === "pointer_to"
         ) {
           continue;
         }
@@ -2487,13 +2494,17 @@ export class CodeGenerator {
       // Initializer list for local variables
       const inits: string[] = [];
       for (const decl of prog.varDeclarations) {
-        // References (REF_TO / REFERENCE TO) wrap a pointer internally and
-        // must be default-constructed (unbound) — `name(0)` is ambiguous for
-        // IEC_REF_TO. They are bound later via REF= / := REF(). (An
-        // initialized `REFERENCE TO X := target` is a separate enhancement.)
+        // References (REF_TO / REFERENCE TO) and pointers (POINTER TO) wrap a
+        // pointer internally and must be default-constructed (unbound/null) —
+        // `name(0)` is ambiguous for IEC_REF_TO, and now also for IEC_Ptr,
+        // which gained an integer-address ctor (the `0` literal matches both
+        // the nullptr_t and the uintptr_t overload). The default ctor sets the
+        // pointer to nullptr, which is exactly the IEC default. References are
+        // bound later via REF= / := REF(); pointers via := ADR()/&.
         if (
           decl.referenceKind === "ref_to" ||
-          decl.referenceKind === "reference_to"
+          decl.referenceKind === "reference_to" ||
+          decl.referenceKind === "pointer_to"
         ) {
           continue;
         }

--- a/src/backend/debug-table-gen.ts
+++ b/src/backend/debug-table-gen.ts
@@ -80,6 +80,9 @@ const IEC_NAME_TO_TAG: Record<string, TagName> = {
   WORD: "WORD",
   DWORD: "DWORD",
   LWORD: "LWORD",
+  // __XWORD is platform-width; the debug surface targets the native host
+  // (where pointers are 64-bit), so it reads as an LWORD-tagged 8-byte value.
+  __XWORD: "LWORD",
   TIME: "TIME",
   LTIME: "TIME",
   DATE: "DATE",
@@ -111,6 +114,7 @@ const IEC_NAME_TO_SIZE: Record<string, number> = {
   WORD: 2,
   DWORD: 4,
   LWORD: 8,
+  __XWORD: 8,
   TIME: 8,
   LTIME: 8,
   DATE: 8,

--- a/src/backend/type-codegen.ts
+++ b/src/backend/type-codegen.ts
@@ -72,6 +72,7 @@ const IEC_TO_CPP_TYPE: Record<string, string> = {
   UINT: "UINT_t",
   UDINT: "UDINT_t",
   ULINT: "ULINT_t",
+  __XWORD: "XWORD_t",
   REAL: "REAL_t",
   LREAL: "LREAL_t",
   TIME: "TIME_t",
@@ -94,7 +95,7 @@ const IEC_TO_CPP_TYPE: Record<string, string> = {
  * Map IEC elementary type names to their IECVar-wrapped C++ type names.
  * Used for struct fields and array elements that need per-element forcing.
  */
-const IEC_TO_CPP_VAR_TYPE: Record<string, string> = {
+export const IEC_TO_CPP_VAR_TYPE: Record<string, string> = {
   BOOL: "IEC_BOOL",
   BYTE: "IEC_BYTE",
   WORD: "IEC_WORD",
@@ -108,6 +109,7 @@ const IEC_TO_CPP_VAR_TYPE: Record<string, string> = {
   UINT: "IEC_UINT",
   UDINT: "IEC_UDINT",
   ULINT: "IEC_ULINT",
+  __XWORD: "IEC_XWORD",
   REAL: "IEC_REAL",
   LREAL: "IEC_LREAL",
   TIME: "IEC_TIME",

--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -15,7 +15,48 @@ import type {
 import { compile } from "../index.js";
 import { buildChunks } from "./library-chunks.js";
 import type { LibraryVarType } from "./library-manifest.js";
-import type { TypeReference } from "../frontend/ast.js";
+import type { Expression, TypeReference } from "../frontend/ast.js";
+
+/**
+ * Serialize a VAR_INPUT initial-value expression back into an ST string for the
+ * manifest (e.g. `255`, `-1`, `10.0`, `T#100ms`, `TRUE`, `MY_CONST`). Parameter
+ * defaults are almost always literals or simple expressions; the cases below
+ * cover them. Returns undefined for anything it can't faithfully render, so the
+ * caller omits the field rather than emit a wrong default.
+ */
+function serializeInitialValue(expr: Expression): string | undefined {
+  switch (expr.kind) {
+    case "LiteralExpression":
+      return expr.rawValue;
+    case "VariableExpression":
+      // A bare named constant/enum used as a default (no subscripts/fields).
+      return expr.subscripts.length === 0 &&
+        expr.fieldAccess.length === 0 &&
+        !expr.isDereference
+        ? expr.name
+        : undefined;
+    case "UnaryExpression": {
+      const operand = serializeInitialValue(expr.operand);
+      if (operand === undefined) return undefined;
+      return expr.operator === "NOT"
+        ? `NOT ${operand}`
+        : `${expr.operator}${operand}`;
+    }
+    case "ParenthesizedExpression": {
+      const inner = serializeInitialValue(expr.expression);
+      return inner === undefined ? undefined : `(${inner})`;
+    }
+    case "BinaryExpression": {
+      const left = serializeInitialValue(expr.left);
+      const right = serializeInitialValue(expr.right);
+      return left === undefined || right === undefined
+        ? undefined
+        : `${left} ${expr.operator} ${right}`;
+    }
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Serialize a variable's type reference into the manifest format,
@@ -270,8 +311,12 @@ export function compileLibrary(
               name: fn.name,
               returnType: fn.returnType.name,
               parameters: fn.varBlocks.flatMap((block) =>
-                block.declarations.flatMap((decl) =>
-                  decl.names.map((name) => ({
+                block.declarations.flatMap((decl) => {
+                  const initialValue =
+                    decl.initialValue !== undefined
+                      ? serializeInitialValue(decl.initialValue)
+                      : undefined;
+                  return decl.names.map((name) => ({
                     name,
                     type: decl.type.name,
                     direction:
@@ -280,8 +325,11 @@ export function compileLibrary(
                         : block.blockType === "VAR_IN_OUT"
                           ? "inout"
                           : "input",
-                  })),
-                ),
+                    // Present ⇒ optional input (default supplied); absent ⇒
+                    // mandatory. Preserved from user ST and CODESYS-imported ST.
+                    ...(initialValue !== undefined ? { initialValue } : {}),
+                  }));
+                }),
               ),
             },
             catByName,

--- a/src/library/library-loader.ts
+++ b/src/library/library-loader.ts
@@ -288,9 +288,16 @@ export function registerLibrarySymbols(
           body: [],
         },
         returnType,
-        parameters: fn.parameters.map((p) =>
-          makeVarSymbol({ name: p.name, type: p.type }, p.direction),
-        ),
+        parameters: fn.parameters.map((p) => {
+          const sym = makeVarSymbol(
+            { name: p.name, type: p.type },
+            p.direction,
+          );
+          // Carry the optional-input marker: a parameter with an initial value
+          // is optional at the call site (see Option A in the analyzer).
+          if (p.initialValue !== undefined) sym.initialValue = p.initialValue;
+          return sym;
+        }),
       });
     } catch (e) {
       // Skip duplicate symbol errors (first definition wins), re-throw others

--- a/src/library/library-manifest.ts
+++ b/src/library/library-manifest.ts
@@ -30,6 +30,15 @@ export interface LibraryFunctionEntry {
     name: string;
     type: string;
     direction: "input" | "output" | "inout";
+    /** Initial (default) value of the parameter, as an ST expression string
+     *  (e.g. "255", "10.0", "T#100ms"). Present only for inputs declared with
+     *  an initial value. Semantics: an input WITH an `initialValue` is
+     *  OPTIONAL at the call site (the compiler supplies the default when the
+     *  argument is omitted); an input WITHOUT one is MANDATORY (omitting it is
+     *  a compile error). Captured by the library compiler from VAR_INPUT
+     *  initial values in the source ST — including ST produced by the CODESYS
+     *  v2/v3 importers, which preserve declarations verbatim. */
+    initialValue?: string;
   }>;
   /** Variadic call shape. When set, `parameters` describes the leading
    *  required parameters and the function accepts any number of

--- a/src/runtime/include/iec_pointer.hpp
+++ b/src/runtime/include/iec_pointer.hpp
@@ -124,6 +124,14 @@ public:
      */
     IEC_REF_TO(std::nullptr_t) noexcept : ptr_(nullptr) {}
 
+    /**
+     * Constructor from an integer address (e.g. a __XWORD temp produced by
+     * REF_LINK()). The address is reinterpreted as the wrapped IECVar<T>*;
+     * it must originate from REF_LINK()/ADR() of a matching variable.
+     */
+    explicit IEC_REF_TO(std::uintptr_t addr) noexcept
+        : ptr_(reinterpret_cast<pointer_type>(addr)) {}
+
     // Copy and move constructors/assignment - default is fine
     IEC_REF_TO(const IEC_REF_TO&) = default;
     IEC_REF_TO(IEC_REF_TO&&) = default;
@@ -213,6 +221,16 @@ public:
      */
     IEC_REF_TO& operator=(std::nullptr_t) noexcept {
         set(nullptr);
+        return *this;
+    }
+
+    /**
+     * Assignment from an integer address (e.g. `ref := _TMP` where the temp is
+     * a __XWORD produced by REF_LINK()). The address is reinterpreted as the
+     * wrapped IECVar<T>*.
+     */
+    IEC_REF_TO& operator=(std::uintptr_t addr) noexcept {
+        set(reinterpret_cast<pointer_type>(addr));
         return *this;
     }
 

--- a/src/runtime/include/iec_ptr.hpp
+++ b/src/runtime/include/iec_ptr.hpp
@@ -48,6 +48,12 @@ public:
     template<typename U>
     IEC_Ptr(IEC_Ptr<U> other) noexcept : ptr_(other.get_void()) {}
 
+    // Construct from an integer address (e.g. __XWORD/ULINT from ADR()).
+    // `IEC_XWORD` implicitly converts to its underlying integer, which
+    // converts to uintptr_t here — the typed pointer round-trips the address.
+    explicit IEC_Ptr(std::uintptr_t addr) noexcept
+        : ptr_(reinterpret_cast<void*>(addr)) {}
+
     // Assignment from any raw pointer
     template<typename U>
     IEC_Ptr& operator=(U* p) noexcept {
@@ -64,6 +70,14 @@ public:
 
     IEC_Ptr& operator=(std::nullptr_t) noexcept {
         ptr_ = nullptr;
+        return *this;
+    }
+
+    // Assignment from an integer address (e.g. `ptr := _TMP` where the temp is
+    // __XWORD/ULINT from ADR()). The address is reinterpreted to the typed
+    // pointer; the source integer carries a pointer-width value.
+    IEC_Ptr& operator=(std::uintptr_t addr) noexcept {
+        ptr_ = reinterpret_cast<void*>(addr);
         return *this;
     }
 

--- a/src/runtime/include/iec_types.hpp
+++ b/src/runtime/include/iec_types.hpp
@@ -63,6 +63,21 @@ using DWORD_t = uint32_t;
 /** IEC LWORD - 64-bit bit string (IEC v3) */
 using LWORD_t = uint64_t;
 
+/**
+ * CODESYS __XWORD - unsigned integer sized to the target pointer width.
+ * Used for ADR()/REF() results and generic pointer-sized values, so an
+ * address round-trips without truncation and without wasting space on
+ * narrow targets (2 bytes on AVR, 8 on 64-bit hosts). `__SIZEOF_POINTER__`
+ * is provided by GCC/Clang/avr-gcc.
+ */
+#if __SIZEOF_POINTER__ <= 2
+using XWORD_t = uint16_t;
+#elif __SIZEOF_POINTER__ <= 4
+using XWORD_t = uint32_t;
+#else
+using XWORD_t = uint64_t;
+#endif
+
 // =============================================================================
 // Elementary Types - Signed Integers
 // =============================================================================

--- a/src/runtime/include/iec_var.hpp
+++ b/src/runtime/include/iec_var.hpp
@@ -240,6 +240,16 @@ public:
         return *this;
     }
 
+    /** Assignment from a raw pointer — stores the address as an integer.
+     *  Used by the ADR(x) lowering `_TMP : __XWORD := &(x)`. Integral targets
+     *  only; routed through uintptr_t so it is pointer-width-correct per
+     *  target (no truncation when T is __XWORD/XWORD_t). */
+    template<typename U, typename V = T, std::enable_if_t<std::is_integral<V>::value, int> = 0>
+    IECVar& operator=(U* p) noexcept {
+        set(static_cast<T>(reinterpret_cast<std::uintptr_t>(p)));
+        return *this;
+    }
+
     // =========================================================================
     // Container Access Forwarding (for array/struct types)
     // =========================================================================
@@ -486,6 +496,8 @@ using IEC_BYTE = IECVar<BYTE_t>;
 using IEC_WORD = IECVar<WORD_t>;
 using IEC_DWORD = IECVar<DWORD_t>;
 using IEC_LWORD = IECVar<LWORD_t>;
+// CODESYS __XWORD — pointer-width unsigned (see XWORD_t in iec_types.hpp).
+using IEC_XWORD = IECVar<XWORD_t>;
 
 // Signed integers
 using IEC_SINT = IECVar<SINT_t>;

--- a/src/semantic/analyzer.ts
+++ b/src/semantic/analyzer.ts
@@ -1590,6 +1590,34 @@ export class SemanticAnalyzer {
           expr.sourceSpan.file,
         );
       }
+    } else {
+      // Library function (not a built-in registry function).  A library
+      // function is emitted as a free C++ function with no default arguments
+      // AND no call-site default filling — so a call missing a required input
+      // (e.g. a graphical BIT_COUNT block left unconnected, generating
+      // `BIT_COUNT(EN := TRUE, ENO => tmp)`) would otherwise slip through to
+      // the C++ compiler and fail with an opaque "too few arguments" error.
+      // Flag it here with a clear message instead.
+      //
+      // Only library functions are checked: they carry resolved `parameters`.
+      // User-defined functions have empty `parameters` here and are left to
+      // codegen, which intentionally zero-fills their unfilled inputs (named/
+      // positional argument reordering).  Function-block invocations resolve
+      // to a variable, not a function, so their optional inputs never reach
+      // this path.
+      const sym = this.symbolTables.globalScope.lookup(nameUpper);
+      if (sym?.kind === "function") {
+        const requiredInputs = sym.parameters.filter((p) => p.isInput).length;
+        const providedInputs = userArgs.filter((a) => !a.isOutput).length;
+        if (providedInputs < requiredInputs) {
+          this.addError(
+            `'${nameUpper}' requires ${requiredInputs} argument(s), got ${providedInputs}`,
+            expr.sourceSpan.startLine,
+            expr.sourceSpan.startCol,
+            expr.sourceSpan.file,
+          );
+        }
+      }
     }
 
     // Additional ADR / REF_LINK constraint: argument must be an l-value

--- a/src/semantic/analyzer.ts
+++ b/src/semantic/analyzer.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  Argument,
   AssertCall,
   CompilationUnit,
   ElementaryType,
@@ -30,6 +31,7 @@ import type {
 import type { CompileError, SourceSpan } from "../types.js";
 import { StdFunctionRegistry } from "./std-function-registry.js";
 import { Scope, SymbolTables } from "./symbol-table.js";
+import type { FunctionSymbol } from "./symbol-table.js";
 import { TypeChecker } from "./type-checker.js";
 import {
   getBitAccessWidth,
@@ -1591,32 +1593,18 @@ export class SemanticAnalyzer {
         );
       }
     } else {
-      // Library function (not a built-in registry function).  A library
-      // function is emitted as a free C++ function with no default arguments
-      // AND no call-site default filling — so a call missing a required input
-      // (e.g. a graphical BIT_COUNT block left unconnected, generating
-      // `BIT_COUNT(EN := TRUE, ENO => tmp)`) would otherwise slip through to
-      // the C++ compiler and fail with an opaque "too few arguments" error.
-      // Flag it here with a clear message instead.
-      //
-      // Only library functions are checked: they carry resolved `parameters`.
-      // User-defined functions have empty `parameters` here and are left to
-      // codegen, which intentionally zero-fills their unfilled inputs (named/
-      // positional argument reordering).  Function-block invocations resolve
-      // to a variable, not a function, so their optional inputs never reach
-      // this path.
+      // Library or user-defined function (not a built-in registry function).
+      // Every input WITHOUT an initial value is mandatory; inputs WITH one are
+      // optional (the compiler supplies the default). A call that leaves a
+      // mandatory input unsupplied — e.g. a graphical block with an
+      // unconnected required pin, or hand-written ST missing an argument — is
+      // a compile error here, instead of a confusing failure further down
+      // (the C++ compiler for library functions, or silent zero-fill for
+      // user functions). Function-block invocations resolve to a variable,
+      // not a function, so their optional inputs never reach this path.
       const sym = this.symbolTables.globalScope.lookup(nameUpper);
       if (sym?.kind === "function") {
-        const requiredInputs = sym.parameters.filter((p) => p.isInput).length;
-        const providedInputs = userArgs.filter((a) => !a.isOutput).length;
-        if (providedInputs < requiredInputs) {
-          this.addError(
-            `'${nameUpper}' requires ${requiredInputs} argument(s), got ${providedInputs}`,
-            expr.sourceSpan.startLine,
-            expr.sourceSpan.startCol,
-            expr.sourceSpan.file,
-          );
-        }
+        this.checkRequiredFunctionInputs(expr, sym, userArgs);
       }
     }
 
@@ -1663,6 +1651,83 @@ export class SemanticAnalyzer {
           );
         }
       }
+    }
+  }
+
+  /**
+   * Ordered input parameters of a function, each flagged optional when it
+   * declares an initial value. Handles both symbol shapes:
+   *   - Library functions carry resolved `parameters` (a VariableSymbol per
+   *     param; its `initialValue` string marks an optional input).
+   *   - User-defined functions carry their VAR_INPUT declarations on
+   *     `declaration.varBlocks` (an AST `initialValue` marks an optional one).
+   */
+  private functionInputParams(
+    sym: FunctionSymbol,
+  ): Array<{ name: string; optional: boolean }> {
+    if (sym.parameters.length > 0) {
+      return sym.parameters
+        .filter((p) => p.isInput)
+        .map((p) => ({
+          name: p.name.toUpperCase(),
+          optional: p.initialValue !== undefined,
+        }));
+    }
+    const params: Array<{ name: string; optional: boolean }> = [];
+    for (const block of sym.declaration.varBlocks) {
+      if (block.blockType !== "VAR_INPUT") continue;
+      for (const decl of block.declarations) {
+        const optional = decl.initialValue !== undefined;
+        for (const n of decl.names)
+          params.push({ name: n.toUpperCase(), optional });
+      }
+    }
+    return params;
+  }
+
+  /**
+   * Option A: every input without an initial value is mandatory. Resolve the
+   * call's named/positional arguments to parameter slots (mirroring the
+   * codegen's argument reordering) and error if any mandatory input is left
+   * unsupplied.
+   */
+  private checkRequiredFunctionInputs(
+    expr: FunctionCallExpression,
+    sym: FunctionSymbol,
+    userArgs: Argument[],
+  ): void {
+    const inputParams = this.functionInputParams(sym);
+    const required = inputParams.filter((p) => !p.optional);
+    if (required.length === 0) return;
+
+    // Slots claimed by name; remaining positional args fill the rest in order.
+    const satisfied = new Set<string>();
+    const positional: Argument[] = [];
+    for (const arg of userArgs) {
+      if (arg.isOutput) continue; // `=> var` outputs don't fill inputs
+      if (arg.name !== undefined) satisfied.add(arg.name.toUpperCase());
+      else positional.push(arg);
+    }
+    let pi = 0;
+    for (const p of inputParams) {
+      if (pi >= positional.length) break;
+      if (satisfied.has(p.name)) continue;
+      satisfied.add(p.name);
+      pi++;
+    }
+
+    const missing = required
+      .filter((p) => !satisfied.has(p.name))
+      .map((p) => p.name);
+    if (missing.length > 0) {
+      this.addError(
+        `'${expr.functionName.toUpperCase()}' is missing required input${
+          missing.length > 1 ? "s" : ""
+        }: ${missing.join(", ")}`,
+        expr.sourceSpan.startLine,
+        expr.sourceSpan.startCol,
+        expr.sourceSpan.file,
+      );
     }
   }
 

--- a/src/semantic/iec-types-data.ts
+++ b/src/semantic/iec-types-data.ts
@@ -161,6 +161,22 @@ export const IEC_BASE_TYPES: readonly IECTypeMetadata[] = [
     wireFormat: "uint64",
     xml: { elementName: "LWORD", plcopenStandard: true },
   },
+  {
+    // CODESYS __XWORD: an unsigned integer whose width equals the target
+    // pointer width (resolved in C++ via `#if __SIZEOF_POINTER__`). Used as
+    // a generic address/pointer-sized value (ADR/REF_LINK return it; users
+    // may declare it for generic pointer functions/blocks). The byteSize/bits
+    // here are NOMINAL (max width); the type-checker exempts __XWORD from
+    // width-narrowing checks since its real width is target-dependent.
+    name: "__XWORD",
+    aliases: [],
+    byteSize: 8,
+    bits: 64,
+    signed: false,
+    cppType: "XWORD_t",
+    wireFormat: "uint64",
+    xml: { elementName: "__XWORD", plcopenStandard: false },
+  },
 
   // ── Signed integers ──────────────────────────────────────────────
   {

--- a/src/semantic/std-function-registry.ts
+++ b/src/semantic/std-function-registry.ts
@@ -866,13 +866,15 @@ export class StdFunctionRegistry {
   // ---------------------------------------------------------------------------
 
   private registerSystemFunctions(): void {
-    // ADR(variable) -> ULINT (address of variable)
+    // ADR(variable) -> __XWORD (pointer-width address of variable). Returning
+    // the pointer-width type lets a `_TMP : __XWORD := ADR(x)` temp round-trip
+    // the address on every target and assign to a typed POINTER TO X.
     this.register({
       name: "ADR",
       cppName: "ADR",
       returnConstraint: "specific",
       returnMatchesFirstParam: false,
-      specificReturnType: "ULINT",
+      specificReturnType: "__XWORD",
       params: [{ name: "IN", constraint: "ANY", isByRef: true }],
       isVariadic: false,
       isConversion: false,
@@ -890,7 +892,7 @@ export class StdFunctionRegistry {
       cppName: "REF",
       returnConstraint: "specific",
       returnMatchesFirstParam: false,
-      specificReturnType: "ANY",
+      specificReturnType: "__XWORD",
       params: [{ name: "IN", constraint: "ANY", isByRef: true }],
       isVariadic: false,
       isConversion: false,

--- a/src/semantic/symbol-table.ts
+++ b/src/semantic/symbol-table.ts
@@ -60,6 +60,11 @@ export interface VariableSymbol extends BaseSymbol {
   isGlobal: boolean;
   isRetain: boolean;
   address?: string | undefined;
+  /** Default value as an ST expression string, for library function/FB
+   *  parameters reconstructed from a manifest (whose `declaration` carries no
+   *  AST initial value). Presence marks the input as OPTIONAL. User-defined
+   *  POUs instead carry their default on `declaration.initialValue`. */
+  initialValue?: string | undefined;
 }
 
 /**

--- a/src/semantic/symbol-table.ts
+++ b/src/semantic/symbol-table.ts
@@ -295,6 +295,7 @@ export class SymbolTables {
       "UINT",
       "UDINT",
       "ULINT",
+      "__XWORD",
       "REAL",
       "LREAL",
       "TIME",

--- a/src/semantic/type-utils.ts
+++ b/src/semantic/type-utils.ts
@@ -99,6 +99,7 @@ export const TYPE_CATEGORIES: Record<string, TypeCategory[]> = {
   WORD: ["ANY", "ANY_ELEMENTARY", "ANY_BIT"],
   DWORD: ["ANY", "ANY_ELEMENTARY", "ANY_BIT"],
   LWORD: ["ANY", "ANY_ELEMENTARY", "ANY_BIT"],
+  __XWORD: ["ANY", "ANY_ELEMENTARY", "ANY_BIT"],
   SINT: ["ANY", "ANY_ELEMENTARY", "ANY_MAGNITUDE", "ANY_NUM", "ANY_INT"],
   INT: ["ANY", "ANY_ELEMENTARY", "ANY_MAGNITUDE", "ANY_NUM", "ANY_INT"],
   DINT: ["ANY", "ANY_ELEMENTARY", "ANY_MAGNITUDE", "ANY_NUM", "ANY_INT"],
@@ -127,6 +128,11 @@ const WIDENING_CATEGORY: Record<string, string> = {
   WORD: "BIT",
   DWORD: "BIT",
   LWORD: "BIT",
+  // __XWORD is a platform-width address type. We model it as a 64-bit
+  // bit-string for category purposes (its sizeBits is 64); the explicit
+  // free-conversion rule in isImplicitlyConvertible keeps address round-trips
+  // (ADR()/REF_LINK() into integers/pointers) warning-free.
+  __XWORD: "BIT",
   SINT: "SINT",
   INT: "SINT",
   DINT: "SINT",
@@ -319,6 +325,18 @@ export function isImplicitlyConvertible(
   const s = source.toUpperCase();
   const t = target.toUpperCase();
   if (s === t) return true;
+
+  // __XWORD is a platform-width address type (CODESYS __XWORD semantics).
+  // It is freely convertible — in either direction, without a narrowing
+  // warning — with any bit-string or integer type, since ADR()/REF_LINK()
+  // produce __XWORD and that address is routinely stored into BYTE/DWORD/...
+  // and back. POINTER/REF assignments are handled separately by the caller.
+  if (s === "__XWORD" || t === "__XWORD") {
+    const other = s === "__XWORD" ? t : s;
+    const otherCat = WIDENING_CATEGORY[other];
+    if (otherCat === "BIT" || otherCat === "SINT" || otherCat === "UINT")
+      return true;
+  }
 
   const sBits = ELEMENTARY_TYPES[s]?.sizeBits;
   const tBits = ELEMENTARY_TYPES[t]?.sizeBits;

--- a/tests/backend/codegen-functions.test.ts
+++ b/tests/backend/codegen-functions.test.ts
@@ -337,7 +337,7 @@ describe("Codegen - Function Calls", () => {
     it("should warn when => is used on a VAR_INPUT parameter", () => {
       const result = compile(`
         FUNCTION Divide : INT
-          VAR_INPUT dividend : INT; divisor : INT; END_VAR
+          VAR_INPUT dividend : INT := 0; divisor : INT; END_VAR
           VAR_OUTPUT remainder : INT; END_VAR
           remainder := dividend MOD divisor;
           Divide := dividend / divisor;
@@ -506,7 +506,7 @@ describe("Codegen - Function Calls", () => {
     it("should fill unfilled parameters with zero default", () => {
       const result = compileAndCheck(`
         FUNCTION Calc : INT
-          VAR_INPUT a : INT; b : INT; c : INT; END_VAR
+          VAR_INPUT a : INT; b : INT := 0; c : INT := 0; END_VAR
           Calc := a + b + c;
         END_FUNCTION
 
@@ -540,7 +540,7 @@ describe("Codegen - Function Calls", () => {
     it("should warn about named args referencing non-existent parameters", () => {
       const result = compile(`
         FUNCTION Calc : INT
-          VAR_INPUT x : INT; y : INT; END_VAR
+          VAR_INPUT x : INT := 0; y : INT := 0; END_VAR
           Calc := x + y;
         END_FUNCTION
 
@@ -563,7 +563,7 @@ describe("Codegen - Function Calls", () => {
     it("should fill all slots with defaults when named args have typos", () => {
       const result = compile(`
         FUNCTION Calc : INT
-          VAR_INPUT x : INT; y : INT; END_VAR
+          VAR_INPUT x : INT := 0; y : INT := 0; END_VAR
           Calc := x + y;
         END_FUNCTION
 
@@ -581,7 +581,7 @@ describe("Codegen - Function Calls", () => {
     it("should handle mix of positional before named correctly", () => {
       const result = compileAndCheck(`
         FUNCTION Calc : INT
-          VAR_INPUT a : INT; b : INT; c : INT; END_VAR
+          VAR_INPUT a : INT; b : INT := 0; c : INT; END_VAR
           Calc := a + b + c;
         END_FUNCTION
 
@@ -598,7 +598,7 @@ describe("Codegen - Function Calls", () => {
     it("should handle REAL parameter defaults correctly", () => {
       const result = compileAndCheck(`
         FUNCTION Scale : REAL
-          VAR_INPUT value : REAL; factor : REAL; END_VAR
+          VAR_INPUT value : REAL; factor : REAL := 0.0; END_VAR
           Scale := value * factor;
         END_FUNCTION
 

--- a/tests/backend/debug-table-gen.test.ts
+++ b/tests/backend/debug-table-gen.test.ts
@@ -17,6 +17,9 @@ describe("debug-table-gen helpers", () => {
     expect(tagNameForTypeName("LREAL")).toBe("LREAL");
     expect(tagNameForTypeName("TIME_OF_DAY")).toBe("TOD");
     expect(tagNameForTypeName("DATE_AND_TIME")).toBe("DT");
+    // __XWORD (platform-width address type) reads as an LWORD on the debug
+    // surface, which targets the native 64-bit host.
+    expect(tagNameForTypeName("__XWORD")).toBe("LWORD");
     expect(tagNameForTypeName("NOT_A_TYPE")).toBeUndefined();
   });
 
@@ -33,6 +36,7 @@ describe("debug-table-gen helpers", () => {
     // `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`.
     expect(sizeForTypeName("STRING")).toBe(127);
     expect(sizeForTypeName("WSTRING")).toBe(253);
+    expect(sizeForTypeName("__XWORD")).toBe(8);
   });
 
   it("TAG values are sequential from 0", () => {
@@ -83,6 +87,36 @@ END_CONFIGURATION
     const blink = map.leaves.find((l) => l.path === "INSTANCE0.BLINK")!;
     expect(blink.type).toBe("BOOL");
     expect(blink.size).toBe(1);
+  });
+
+  it("emits a debug leaf for a __XWORD variable (does not crash visitTypeRef)", () => {
+    // Regression: __XWORD is a builtin elementary type with no type-symbol
+    // declaration, so the debug walker must treat it as a leaf via the
+    // IEC_NAME_TO_TAG fast path rather than recursing through lookupType().
+    const source = `
+PROGRAM main
+  VAR
+    addr : __XWORD;
+  END_VAR
+  addr := addr;
+END_PROGRAM
+
+CONFIGURATION Config0
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 1);
+    PROGRAM instance0 WITH task0 : main;
+  END_RESOURCE
+END_CONFIGURATION
+`;
+    const result = compile(source);
+    expect(result.success).toBe(true);
+    expect(result.debugMap).toBeDefined();
+    const addr = result.debugMap!.leaves.find(
+      (l) => l.path === "INSTANCE0.ADDR",
+    )!;
+    expect(addr).toBeDefined();
+    expect(addr.type).toBe("LWORD");
+    expect(addr.size).toBe(8);
   });
 
   it("emits Entry rows for STRING and WSTRING leaves with the wire-width sizes", () => {

--- a/tests/integration/analyze.test.ts
+++ b/tests/integration/analyze.test.ts
@@ -88,6 +88,96 @@ describe("analyze() API", () => {
     expect(result.ast).toBeDefined();
   });
 
+  it("does not flag a user-defined function called with missing args (codegen zero-fills)", () => {
+    // User-defined functions intentionally zero-fill unfilled inputs at the
+    // call site (named/positional reordering), so a missing argument is not an
+    // error for them — only library functions, which have no default filling,
+    // are checked. This guards against re-introducing a false positive here.
+    const result = analyze(`
+      FUNCTION DOUBLE_IT : INT
+        VAR_INPUT IN : INT; END_VAR
+        DOUBLE_IT := IN * 2;
+      END_FUNCTION
+
+      PROGRAM Main
+        VAR y : INT; END_VAR
+        y := DOUBLE_IT();
+      END_PROGRAM
+    `);
+
+    expect(result.errors.some((e) => /requires \d+ argument/i.test(e.message))).toBe(false);
+  });
+
+  it("does not require arguments for a function-block invocation (inputs are optional)", () => {
+    const result = analyze(
+      `
+      PROGRAM Main
+        VAR fb : MyFB; END_VAR
+        fb();
+      END_PROGRAM
+    `,
+      {
+        additionalSources: [
+          {
+            fileName: "myfb.st",
+            source: `
+            FUNCTION_BLOCK MyFB
+              VAR_INPUT trigger : BOOL; END_VAR
+              VAR_OUTPUT done : BOOL; END_VAR
+              done := trigger;
+            END_FUNCTION_BLOCK
+          `,
+          },
+        ],
+      },
+    );
+
+    // fb() omits the optional input `trigger` — that is valid for an FB.
+    expect(result.errors.some((e) => /requires \d+ argument/i.test(e.message))).toBe(false);
+  });
+
+  it("errors when a LIBRARY function call omits its required input (the BIT_COUNT case)", () => {
+    // The graphical editor emits e.g. `BIT_COUNT(EN := TRUE, ENO => tmp)` when
+    // its data input is left unconnected.  With the library signature loaded,
+    // the analyzer must flag the missing argument instead of letting it reach
+    // the C++ compiler.
+    const bitCountLib = {
+      formatVersion: 1 as const,
+      manifest: {
+        name: "oscat-basic",
+        version: "1.0.0",
+        namespace: "oscat",
+        functions: [
+          {
+            name: "BIT_COUNT",
+            returnType: "INT",
+            parameters: [{ name: "IN", type: "DWORD", direction: "input" as const }],
+          },
+        ],
+        functionBlocks: [],
+        types: [],
+        headers: [],
+        isBuiltin: false,
+      },
+      chunks: [],
+      dependencies: [],
+    };
+
+    const result = analyze(
+      `
+      PROGRAM Main
+        VAR n : INT; END_VAR
+        n := BIT_COUNT(EN := TRUE);
+      END_PROGRAM
+    `,
+      { libraries: [bitCountLib] },
+    );
+
+    expect(
+      result.errors.some((e) => /BIT_COUNT.*requires 1 argument.*got 0/i.test(e.message)),
+    ).toBe(true);
+  });
+
   it("returns a defined result for empty/whitespace input", () => {
     const result = analyze("");
     expect(result).toBeDefined();

--- a/tests/integration/analyze.test.ts
+++ b/tests/integration/analyze.test.ts
@@ -88,11 +88,13 @@ describe("analyze() API", () => {
     expect(result.ast).toBeDefined();
   });
 
-  it("does not flag a user-defined function called with missing args (codegen zero-fills)", () => {
-    // User-defined functions intentionally zero-fill unfilled inputs at the
-    // call site (named/positional reordering), so a missing argument is not an
-    // error for them — only library functions, which have no default filling,
-    // are checked. This guards against re-introducing a false positive here.
+  // --- Option A: required vs. optional function inputs --------------------
+  // An input WITHOUT an initial value is mandatory; one WITH a default is
+  // optional. Enforced uniformly for user-defined and library functions.
+
+  const MISSING = /is missing required input/i;
+
+  it("errors when a user-defined function omits a required (no-default) input", () => {
     const result = analyze(`
       FUNCTION DOUBLE_IT : INT
         VAR_INPUT IN : INT; END_VAR
@@ -105,7 +107,26 @@ describe("analyze() API", () => {
       END_PROGRAM
     `);
 
-    expect(result.errors.some((e) => /requires \d+ argument/i.test(e.message))).toBe(false);
+    expect(
+      result.errors.some((e) => /DOUBLE_IT.*missing required input.*IN/i.test(e.message)),
+    ).toBe(true);
+  });
+
+  it("does not flag a user-defined function input that declares an initial value", () => {
+    const result = analyze(`
+      FUNCTION SCALE_IT : INT
+        VAR_INPUT IN : INT; FACTOR : INT := 2; END_VAR
+        SCALE_IT := IN * FACTOR;
+      END_FUNCTION
+
+      PROGRAM Main
+        VAR y : INT; END_VAR
+        y := SCALE_IT(IN := 21);
+      END_PROGRAM
+    `);
+
+    // FACTOR has a default, so omitting it is fine; IN is provided.
+    expect(result.errors.some((e) => MISSING.test(e.message))).toBe(false);
   });
 
   it("does not require arguments for a function-block invocation (inputs are optional)", () => {
@@ -133,7 +154,7 @@ describe("analyze() API", () => {
     );
 
     // fb() omits the optional input `trigger` — that is valid for an FB.
-    expect(result.errors.some((e) => /requires \d+ argument/i.test(e.message))).toBe(false);
+    expect(result.errors.some((e) => MISSING.test(e.message))).toBe(false);
   });
 
   it("errors when a LIBRARY function call omits its required input (the BIT_COUNT case)", () => {
@@ -174,8 +195,55 @@ describe("analyze() API", () => {
     );
 
     expect(
-      result.errors.some((e) => /BIT_COUNT.*requires 1 argument.*got 0/i.test(e.message)),
+      result.errors.some((e) => /BIT_COUNT.*missing required input.*IN/i.test(e.message)),
     ).toBe(true);
+  });
+
+  it("does not flag a LIBRARY function input that carries an initialValue", () => {
+    // A library function with an optional input (default in the manifest) may
+    // be called without it.
+    const scaleLib = {
+      formatVersion: 1 as const,
+      manifest: {
+        name: "demo",
+        version: "1.0.0",
+        namespace: "demo",
+        functions: [
+          {
+            name: "SCALE1",
+            returnType: "REAL",
+            parameters: [
+              { name: "IN", type: "REAL", direction: "input" as const },
+              {
+                name: "MAXV",
+                type: "REAL",
+                direction: "input" as const,
+                initialValue: "1000.0",
+              },
+            ],
+          },
+        ],
+        functionBlocks: [],
+        types: [],
+        headers: [],
+        isBuiltin: false,
+      },
+      chunks: [],
+      dependencies: [],
+    };
+
+    const result = analyze(
+      `
+      PROGRAM Main
+        VAR r : REAL; END_VAR
+        r := SCALE1(IN := 2.0);
+      END_PROGRAM
+    `,
+      { libraries: [scaleLib] },
+    );
+
+    // MAXV has a manifest default → optional; IN is provided.
+    expect(result.errors.some((e) => /missing required input/i.test(e.message))).toBe(false);
   });
 
   it("returns a defined result for empty/whitespace input", () => {

--- a/tests/integration/xword-pointer-e2e.test.ts
+++ b/tests/integration/xword-pointer-e2e.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * E2E for the __XWORD pointer-width address type: ADR()/REF_LINK() return
+ * __XWORD, a __XWORD temp round-trips an address to a typed pointer, and a
+ * user function may use __XWORD as a generic pointer-sized return.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { compile } from "../../src/index.js";
+import { hasGpp, createPCH, compileAndRunStandalone } from "./test-helpers.js";
+
+describe.skipIf(!hasGpp)("__XWORD pointer-width address type", () => {
+  let tempDir: string;
+  let pchPath: string;
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "strucpp-xword-"));
+    pchPath = createPCH(tempDir);
+  });
+  afterAll(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  it("ADR -> __XWORD temp -> typed pointer round-trips (write through pointer)", () => {
+    const result = compile(`
+      PROGRAM Main
+        VAR
+          v : INT := 5;
+          addr : __XWORD;
+          p : POINTER TO INT;
+          out : INT;
+        END_VAR
+        addr := ADR(v);   (* IEC_XWORD := &(v)        — address into the temp  *)
+        p := addr;        (* IEC_Ptr<int> := IEC_XWORD — address into a pointer *)
+        p^ := 42;         (* write through the pointer                          *)
+        out := v;         (* v is now 42 if the address round-tripped           *)
+      END_PROGRAM
+    `);
+    expect(result.success).toBe(true);
+
+    const stdout = compileAndRunStandalone({
+      tempDir,
+      pchPath,
+      headerCode: result.headerCode!,
+      cppCode: result.cppCode!,
+      testName: "xword_adr_roundtrip",
+      mainCode: `
+#include <iostream>
+int main() {
+    strucpp::Program_MAIN prog;
+    prog.run();
+    std::cout << static_cast<int>(prog.OUT) << std::endl;
+    return 0;
+}
+`,
+    });
+    expect(stdout).toBe("42");
+  });
+
+  it("a user function may return __XWORD and be used as a generic pointer", () => {
+    // Compilation is the contract here: __XWORD is a first-class declarable
+    // type on a user FUNCTION, and its result assigns to a typed pointer.
+    const result = compile(`
+      FUNCTION MAKE_PTR : __XWORD
+        VAR_INPUT x : INT; END_VAR
+        MAKE_PTR := ADR(x);
+      END_FUNCTION
+
+      PROGRAM Main
+        VAR a : INT := 9; p : POINTER TO INT; END_VAR
+        p := MAKE_PTR(a);
+      END_PROGRAM
+    `);
+    expect(result.errors).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/library/codesys-import.test.ts
+++ b/tests/library/codesys-import.test.ts
@@ -21,6 +21,8 @@ import type {
   CodesysImportResult,
   ExtractedPOU,
 } from "../../src/library/codesys-import/index.js";
+import { compileStlib } from "../../src/library/library-compiler.js";
+import type { LibraryManifest } from "../../src/library/library-manifest.js";
 
 // Tests previously called `await importCodesysLibrary(path)`; the public
 // API is now bytes-first so the file read sits in the test harness.
@@ -732,5 +734,49 @@ describe("CLI --import-lib", () => {
       expect(combined).toContain("Format: CODESYS V2.3");
       expect(combined).toContain("Extracted 555 items");
     }
+  });
+});
+
+describe("CODESYS import → manifest: VAR_INPUT initial values", () => {
+  // OSCAT's AIN function declares optional inputs with defaults
+  // (e.g. `sign : BYTE := 255; high : REAL := 10.0;`). Those defaults must
+  // survive the full import → compileStlib pipeline into the manifest, for
+  // both the v2.3 (.lib) and v3 (.library) importers.
+  // Compile just AIN (self-contained) from the imported sources — the full
+  // OSCAT set needs its dependency libraries to compile, which is out of scope
+  // here; AIN alone exercises importer → ST → compileStlib → manifest.
+  async function importAndCompileAin(path: string) {
+    const imported = await importCodesysLibrary(path);
+    expect(imported.success).toBe(true);
+    const ainSrc = imported.sources.find((s) => s.fileName === "AIN.st");
+    expect(ainSrc).toBeDefined();
+    const lib = compileStlib([ainSrc!], {
+      name: "oscat-ain",
+      version: "335.0.0",
+      namespace: "oscat",
+    });
+    expect(lib.success).toBe(true);
+    return lib.archive!.manifest.functions;
+  }
+
+  function assertAinDefaults(functions: LibraryManifest["functions"]) {
+    const ain = functions.find((f) => f.name === "AIN");
+    expect(ain).toBeDefined();
+    const byName = Object.fromEntries(
+      ain!.parameters.map((p) => [p.name.toUpperCase(), p]),
+    );
+    // mandatory input keeps no default
+    expect("initialValue" in byName.IN!).toBe(false);
+    // optional inputs carry their ST defaults
+    expect(byName.SIGN!.initialValue).toBe("255");
+    expect(byName.HIGH!.initialValue).toBe("10.0");
+  }
+
+  it("v2.3 (.lib) importer preserves function input defaults into the manifest", async () => {
+    assertAinDefaults(await importAndCompileAin(OSCAT_V23_PATH));
+  });
+
+  it("v3 (.library) importer preserves function input defaults into the manifest", async () => {
+    assertAinDefaults(await importAndCompileAin(OSCAT_V3_PATH));
   });
 });

--- a/tests/library/function-input-defaults.test.ts
+++ b/tests/library/function-input-defaults.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Tests for capturing VAR_INPUT initial values into the library manifest.
+ *
+ * Manifest parameter shape carries an optional `initialValue` (ST expression
+ * string). Present ⇒ the input is optional (compiler supplies the default when
+ * omitted); absent ⇒ the input is mandatory. This must be populated from the
+ * source ST for both user-authored library projects and CODESYS-imported
+ * libraries — the latter flow through the same compileStlib path, since the
+ * importer emits ST source verbatim (declarations, including `:=` defaults).
+ */
+
+import { describe, it, expect } from "vitest";
+import { compileStlib } from "../../src/library/library-compiler.js";
+
+function fnParams(source: string, fnName: string) {
+  const result = compileStlib([{ source, fileName: "lib.st" }], {
+    name: "test-lib",
+    version: "1.0.0",
+    namespace: "test",
+  });
+  expect(result.success).toBe(true);
+  const fn = result.archive!.manifest.functions.find((f) => f.name === fnName);
+  expect(fn).toBeDefined();
+  return fn!.parameters;
+}
+
+describe("library manifest: VAR_INPUT initial values", () => {
+  it("captures initialValue for defaulted inputs and omits it for mandatory ones", () => {
+    const params = fnParams(
+      `
+      FUNCTION SCALE_DEMO : REAL
+        VAR_INPUT
+          IN : REAL;
+          MAXV : REAL := 1000.0;
+          SIGN : BYTE := 255;
+        END_VAR
+        SCALE_DEMO := IN;
+      END_FUNCTION
+    `,
+      "SCALE_DEMO",
+    );
+
+    const byName = Object.fromEntries(params.map((p) => [p.name, p]));
+    // mandatory input — no default
+    expect(byName.IN).toMatchObject({ name: "IN", direction: "input" });
+    expect("initialValue" in byName.IN!).toBe(false);
+    // optional inputs — defaults preserved as ST strings
+    expect(byName.MAXV!.initialValue).toBe("1000.0");
+    expect(byName.SIGN!.initialValue).toBe("255");
+  });
+
+  it("serializes common default-expression forms", () => {
+    const params = fnParams(
+      `
+      FUNCTION DEFAULTS : INT
+        VAR_INPUT
+          a : INT := -1;
+          b : BOOL := TRUE;
+          c : TIME := T#100ms;
+          d : REAL := 3.14;
+        END_VAR
+        DEFAULTS := a;
+      END_FUNCTION
+    `,
+      "DEFAULTS",
+    );
+    const byName = Object.fromEntries(params.map((p) => [p.name, p]));
+    // Manifest normalizes parameter names to upper case.
+    expect(byName.A!.initialValue).toBe("-1");
+    expect(byName.B!.initialValue).toBe("TRUE");
+    expect(byName.C!.initialValue).toBe("T#100MS"); // time literals normalize upper-case
+    expect(byName.D!.initialValue).toBe("3.14");
+  });
+
+  it("preserves initialValue when reloaded from a serialized .stlib (round-trip)", () => {
+    const result = compileStlib(
+      [
+        {
+          source: `
+          FUNCTION F : INT
+            VAR_INPUT x : INT; y : INT := 7; END_VAR
+            F := x + y;
+          END_FUNCTION
+        `,
+          fileName: "lib.st",
+        },
+      ],
+      { name: "rt-lib", version: "1.0.0", namespace: "rt" },
+    );
+    expect(result.success).toBe(true);
+
+    // Round-trip through JSON, as the .stlib is persisted/loaded.
+    const json = JSON.parse(JSON.stringify(result.archive));
+    const fn = json.manifest.functions.find(
+      (f: { name: string }) => f.name === "F",
+    );
+    const byName = Object.fromEntries(
+      fn.parameters.map((p: { name: string }) => [p.name, p]),
+    );
+    expect("initialValue" in byName.X).toBe(false);
+    expect(byName.Y.initialValue).toBe("7");
+  });
+
+  it("captures defaults from CODESYS-importer-style ST (same compileStlib path)", () => {
+    // The CODESYS v2/v3 importers emit ST source verbatim; an imported OSCAT
+    // function like AIN carries VAR_INPUT defaults that must reach the manifest.
+    const params = fnParams(
+      `
+      FUNCTION AIN : REAL
+        VAR_INPUT
+          IN : DWORD;
+          sign : BYTE := 255;
+          high : REAL := 10.0;
+        END_VAR
+        AIN := high;
+      END_FUNCTION
+    `,
+      "AIN",
+    );
+    const byName = Object.fromEntries(params.map((p) => [p.name, p]));
+    expect("initialValue" in byName.IN!).toBe(false);
+    expect(byName.SIGN!.initialValue).toBe("255");
+    expect(byName.HIGH!.initialValue).toBe("10.0");
+  });
+});

--- a/tests/semantic/iec-types-data.test.ts
+++ b/tests/semantic/iec-types-data.test.ts
@@ -50,7 +50,9 @@ describe("IEC base-type registry", () => {
     it.each(IEC_BASE_TYPES.map((t) => [t.name, t]))(
       "%s has all required fields populated",
       (_name, t: IECTypeMetadata) => {
-        expect(t.name).toMatch(/^[A-Z][A-Z0-9_]*$/);
+        // Leading underscores are allowed for platform/vendor types such as
+        // __XWORD (CODESYS naming convention for the pointer-width address type).
+        expect(t.name).toMatch(/^_*[A-Z][A-Z0-9_]*$/);
         expect(t.aliases).toBeInstanceOf(Array);
         expect(typeof t.byteSize).toBe("number");
         expect(t.byteSize).toBeGreaterThanOrEqual(0);

--- a/tests/semantic/type-utils.test.ts
+++ b/tests/semantic/type-utils.test.ts
@@ -38,8 +38,10 @@ function parseAST(source: string) {
 
 describe("type-utils", () => {
   describe("ELEMENTARY_TYPES", () => {
-    it("should define all 23 types (21 canonical + TOD + DT aliases)", () => {
-      expect(Object.keys(ELEMENTARY_TYPES)).toHaveLength(23);
+    it("should define all 24 types (22 canonical + TOD + DT aliases)", () => {
+      // 22 canonical = 21 standard elementary types + __XWORD (platform-width
+      // address type); plus the TOD and DT alias entries.
+      expect(Object.keys(ELEMENTARY_TYPES)).toHaveLength(24);
     });
 
     it("should have correct sizes for integer types", () => {


### PR DESCRIPTION
Promotes development to main for the v0.5.9 release.

Includes #180: `__XWORD` platform-width address type, required-input checking (Option A), and manifest `initialValue` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)