### PR TITLE
fix(codegen): resolve inherited PROPERTY through derived FB instance

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -385,6 +385,9 @@ export class CodeGenerator {
   /** Map of UPPER(typeName).UPPER(propName) → declared property name for property access codegen */
   protected propertyNameMap: Map<string, string> = new Map();
 
+  /** Map of UPPER(FB name) → UPPER(parent FB name) for walking the EXTENDS chain during property resolution */
+  protected fbExtendsMap: Map<string, string> = new Map();
+
   /** Current FB name (set during generateFBImplementation for property resolution) */
   private currentFBName: string | undefined;
 
@@ -941,6 +944,9 @@ export class CodeGenerator {
 
     // Build method name map, property name map, and interface method names for FBs
     for (const fb of ast.functionBlocks) {
+      if (fb.extends) {
+        this.fbExtendsMap.set(fb.name.toUpperCase(), fb.extends.toUpperCase());
+      }
       for (const method of fb.methods) {
         this.methodNameMap.set(
           `${fb.name.toUpperCase()}.${method.name.toUpperCase()}`,
@@ -4684,14 +4690,28 @@ export class CodeGenerator {
   /**
    * Resolve a property name from the property name map.
    * Returns the declared property name if the field is a property, undefined otherwise.
+   *
+   * Walks the EXTENDS chain: a PROPERTY declared on a base FB is inherited and
+   * thus accessible through a derived FB instance, so each ancestor is consulted
+   * in turn. The visited set guards against malformed cyclic inheritance.
    */
   private resolvePropertyName(
     typeName: string | undefined,
     fieldName: string,
   ): string | undefined {
     if (!typeName) return undefined;
-    const key = `${typeName.toUpperCase()}.${fieldName.toUpperCase()}`;
-    return this.propertyNameMap.get(key);
+    const fieldUpper = fieldName.toUpperCase();
+    let currentType: string | undefined = typeName.toUpperCase();
+    const visited = new Set<string>();
+    while (currentType && !visited.has(currentType)) {
+      visited.add(currentType);
+      const declaredName = this.propertyNameMap.get(
+        `${currentType}.${fieldUpper}`,
+      );
+      if (declaredName) return declaredName;
+      currentType = this.fbExtendsMap.get(currentType);
+    }
+    return undefined;
   }
 
   /**

--- a/tests/backend/codegen-oop.test.ts
+++ b/tests/backend/codegen-oop.test.ts
@@ -229,9 +229,7 @@ describe("Codegen - OOP Features (Phase 5.2)", () => {
         PROGRAM Main END_PROGRAM
       `);
 
-      expect(result.headerCode).toContain(
-        "class WORKER : public IRUNNABLE {",
-      );
+      expect(result.headerCode).toContain("class WORKER : public IRUNNABLE {");
     });
   });
 
@@ -368,7 +366,10 @@ describe("Codegen - OOP Features (Phase 5.2)", () => {
       const childSection = result.cppCode.slice(
         result.cppCode.indexOf("void CHILD::operator()()"),
       );
-      const childBody = childSection.slice(0, childSection.indexOf("\n}\n") + 3);
+      const childBody = childSection.slice(
+        0,
+        childSection.indexOf("\n}\n") + 3,
+      );
       expect(childBody).not.toContain("BASE::operator()()");
     });
   });
@@ -480,6 +481,59 @@ describe("Codegen - OOP Features (Phase 5.2)", () => {
       );
       // No getter should be generated
       expect(result.headerCode).not.toContain("get_TARGET");
+    });
+
+    it("should resolve an inherited property accessed through a derived instance", () => {
+      const result = compileAndCheck(`
+        FUNCTION_BLOCK Base
+          VAR _v : INT; END_VAR
+          PROPERTY Val : INT
+            GET
+              Val := _v;
+            END_GET
+            SET
+              _v := Val;
+            END_SET
+          END_PROPERTY
+        END_FUNCTION_BLOCK
+        FUNCTION_BLOCK Derived EXTENDS Base
+        END_FUNCTION_BLOCK
+        PROGRAM Main
+          VAR d : Derived; x : INT; END_VAR
+          d.Val := 2;
+          x := d.Val;
+        END_PROGRAM
+      `);
+
+      // Access via the derived instance must go through the inherited accessors,
+      // not raw field access (D.VAL — DERIVED has no such member, the field is _V).
+      expect(result.cppCode).toContain("D.set_VAL(2);");
+      expect(result.cppCode).toContain("X = D.get_VAL();");
+      expect(result.cppCode).not.toContain("D.VAL");
+    });
+
+    it("should resolve a property inherited across multiple EXTENDS levels", () => {
+      const result = compileAndCheck(`
+        FUNCTION_BLOCK Base
+          VAR _v : INT; END_VAR
+          PROPERTY Val : INT
+            GET
+              Val := _v;
+            END_GET
+          END_PROPERTY
+        END_FUNCTION_BLOCK
+        FUNCTION_BLOCK Mid EXTENDS Base
+        END_FUNCTION_BLOCK
+        FUNCTION_BLOCK Leaf EXTENDS Mid
+        END_FUNCTION_BLOCK
+        PROGRAM Main
+          VAR l : Leaf; x : INT; END_VAR
+          x := l.Val;
+        END_PROGRAM
+      `);
+
+      expect(result.cppCode).toContain("X = L.get_VAL();");
+      expect(result.cppCode).not.toContain("L.VAL");
     });
   });
 


### PR DESCRIPTION
Fixes #182.

- Accessing a `PROPERTY` declared on a base FB *through an instance of a derived FB* emitted raw field access (`inst.PROP`) instead of the accessor call (`inst.get_PROP()` / `inst.set_PROP(...)`). The emitted C++ failed to compile while `strucpp` reported "Compilation successful!" — the error only surfaced later at g++.
- Root cause: `resolvePropertyName` looked up only the exact type name and never walked `fb.extends`, so `DERIVED.VAL` missed `propertyNameMap` and fell through to raw `.field`. (Methods were unaffected — a method call emits `.NAME()`, valid via C++ public inheritance, regardless of the lookup.)
- Fix: build an `fbExtendsMap` (FB -> parent) and walk the `EXTENDS` chain in `resolvePropertyName`, consulting each ancestor in turn with a visited guard against cyclic inheritance. All five property call sites (reads, writes, chained access) route through this one resolver, so the fix covers them together.

## Repro (before this PR)
```iecst
FUNCTION_BLOCK Base
  VAR _v : INT; END_VAR
  PROPERTY Val : INT
    GET Val := _v; END_GET
    SET _v := Val; END_SET
  END_PROPERTY
END_FUNCTION_BLOCK
FUNCTION_BLOCK Derived EXTENDS Base END_FUNCTION_BLOCK
PROGRAM Main
  VAR d : Derived; x : INT; END_VAR
  d.Val := 2;  x := d.Val;   (* emitted raw D.VAL -> g++: 'class DERIVED' has no member named 'VAL' *)
END_PROGRAM
```
After the fix this emits `D.set_VAL(2)` / `X = D.get_VAL()` and compiles clean.

## Tests
- Added two cases to `tests/backend/codegen-oop.test.ts`: inherited property via a derived instance, and a property inherited across multiple `EXTENDS` levels.
- Full suite green (`1957 passed, 7 skipped`); the generated C++ for the repro now passes `g++ -std=c++17 -fsyntax-only`.
- Also verified end-to-end on OpenPLC Runtime v4.1.5: the previously-broken program compiles to a `.so` and runs (`STATUS:RUNNING`, scan_count incrementing).