### PR TITLE
Release v0.5.10: threaded-model hardening

### DIFF
--- a/docs/ARRAY_BOUNDS_INVESTIGATION.md
+++ b/docs/ARRAY_BOUNDS_INVESTIGATION.md
@@ -1,0 +1,70 @@
+# Array out-of-bounds handling — investigation & fix
+
+## Problem (observed on OpenPLC Runtime v4, aarch64)
+
+An IEC program writing past the end of an array:
+
+```iecst
+PROGRAM faulter
+  VAR
+    arr : ARRAY[0..3] OF INT;
+    idx : INT;
+  END_VAR
+  idx := idx + 1;
+  arr[idx] := 7;   (* idx eventually exceeds 3 *)
+END_PROGRAM
+```
+
+did **not** raise a clean IEC fault. It silently wrote past `arr`, corrupted
+adjacent memory in the program's `Configuration` object, and eventually
+**SIGSEGV'd** — taking down not just the faulting task but an adjacent task
+whose data/vtable got clobbered. (The runtime's per-thread signal recovery
+contained it — both crashing threads terminated and the PLC stayed RUNNING —
+but a clean, localized fault is obviously preferable to memory corruption.)
+
+## Root cause
+
+`IecArray` (and `IEC_ARRAY_2D`) in `src/runtime/include/iec_array.hpp` already
+have **two** accessors:
+
+- `operator[]` / `operator()` — **unchecked**, `constexpr`, `noexcept`. Raw
+  index into the backing `std::array`. Intentionally so: the debug-table
+  generator emits `&g_config.foo.MY_ARRAY[i]` as a *constant expression*
+  (required for AVR PROGMEM placement of the pointer table), which needs a
+  constexpr, non-throwing `operator[]`.
+- `at()` — **bounds-checked**: on an out-of-range index it does
+  `throw std::out_of_range(...)` when `STRUCPP_HAS_EXCEPTIONS`, else
+  `iec_runtime_fault(IecFault::ArrayBounds)`. This is exactly the
+  cross-platform fault path we want.
+
+But codegen (`src/backend/codegen.ts`) emitted **`operator[]` / `operator()`**
+for POU array accesses — so every array read/write in user logic used the
+*unchecked* path. The checked `at()` was never reached from generated code.
+
+## Fix
+
+Codegen now emits **`.at(...)`** for POU array subscripts (both the legacy flat
+path and the interleaved access-chain path; 1-D and N-D). `operator[]` is left
+untouched and continues to serve the debug-table generator's constexpr
+`&arr[i]` address-of expressions. Net effect per target:
+
+| Target | `STRUCPP_HAS_EXCEPTIONS` | Out-of-bounds behaviour |
+|--------|--------------------------|-------------------------|
+| OpenPLC Runtime v4 (Linux/Windows, hosted) | 1 | `throw std::out_of_range` → caught by the runtime's per-task `try/catch`; that task logs `terminated by unhandled exception: Array index out of bounds` and stops, **other tasks keep running** |
+| Microcontroller firmware (AVR/SAMD/RP2040/STM32, `-fno-exceptions`) | 0 | `iec_runtime_fault(IecFault::ArrayBounds)` — the weak halt default, overridable by a VPP HAL (blink LED, etc.) |
+
+This is the same dual path the rest of the runtime faults (`iec_pointer`,
+`iec_located`) already use, so array OOB now behaves consistently with null
+dereference / bad-located faults.
+
+## Notes / follow-ups
+
+- **Performance:** `.at()` adds one in-range comparison per subscript. For IEC
+  semantics this is the correct default (CODESYS and most runtimes bounds-check
+  arrays). If a perf escape hatch is ever wanted, a compile flag could map
+  `.at()` back to `operator[]` — but unchecked array access in a PLC is a
+  memory-safety hole, so checked-by-default is the right call.
+- **Golden tests:** codegen golden tests that assert `arr[i]` in the emitted C++
+  must be updated to `arr.at(i)` / `arr.at(i, j)`.
+- **Debug table unaffected:** `debug-table-gen.ts` keeps using `operator[]`
+  (constexpr `&arr[i]`), so AVR PROGMEM placement is preserved.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strucpp",
-  "version": "0.5.7",
+  "version": "0.5.10",
   "description": "IEC 61131-3 Structured Text to C++ Compiler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -2359,8 +2359,18 @@ export class CodeGenerator {
       if (prog.varExternal.length > 0) {
         this.emitHeader("    void sync_in() override {");
         for (const ext of prog.varExternal) {
+          // Snapshot the private working copy with a raw byte copy (memcpy),
+          // NOT `__prev = x`. IECVar::operator= routes through set() and copies
+          // ONLY value_ (it deliberately preserves forced_/forced_value_), so
+          // `__prev = x` leaves __prev's padding and forced_* bytes diverging
+          // from x's. The sync_out memcmp below then sees those stale bytes as a
+          // spurious "change" — making a program that merely READS a shared
+          // global write its stale snapshot back to canonical and clobber a
+          // concurrent writer (per-variable, so it can revert g_a but not g_b
+          // and tear a cross-global invariant). memcpy makes __prev byte-equal
+          // to x at sync_in, so the memcmp is a true value diff.
           this.emitHeader(
-            `        ${ext.name} = *${ext.name}__canon; ${ext.name}__prev = ${ext.name};`,
+            `        ${ext.name} = *${ext.name}__canon; __builtin_memcpy(&${ext.name}__prev, &${ext.name}, sizeof(${ext.name}));`,
           );
         }
         this.emitHeader("    }");
@@ -2368,12 +2378,12 @@ export class CodeGenerator {
         for (const ext of prog.varExternal) {
           // Dirty-diff over the whole object via its address + sizeof, NOT
           // .raw_ptr(): raw_ptr() exists only on scalar IECVar<T>, so arrays
-          // (Array1D) and structs would fail to compile. Comparing
-          // &x..&x+sizeof(x) is correct for every VAR_EXTERNAL kind because
-          // x__prev is a full-value copy of x, so equal values compare byte-
-          // equal and any changed byte (the whole array/struct included) is
-          // detected. sizeof(*raw_ptr()) was also wrong for arrays (element
-          // size, not array size).
+          // (Array1D) and structs would fail to compile. This is correct for
+          // every VAR_EXTERNAL kind ONLY because sync_in snapshots __prev with
+          // memcpy (a byte-exact copy): the body changes value_ via set(), and
+          // nothing else writes the object, so any byte difference here is a
+          // real value change. A pure reader leaves x byte-identical to __prev
+          // and commits nothing.
           this.emitHeader(
             `        if (__builtin_memcmp(&${ext.name}, &${ext.name}__prev, sizeof(${ext.name})) != 0) *${ext.name}__canon = ${ext.name};`,
           );

--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -3663,14 +3663,17 @@ export class CodeGenerator {
     }
 
     // Legacy path: flat subscripts/fieldAccess/dereference (no interleaving)
-    // Subscripts (array access)
-    // 2D+ arrays use operator() syntax: arr(i, j) — 1D uses operator[]: arr[i]
+    // Subscripts (array access). Use the bounds-checked .at() accessor (1D and
+    // 2D+) so an out-of-range index raises a clean fault — throw on exception
+    // targets (caught by the runtime, stops the faulting task), or
+    // iec_runtime_fault(ArrayBounds) on -fno-exceptions MCU targets — instead of
+    // the unchecked operator[]/operator() that silently corrupts memory.
     if (expr.subscripts.length > 1) {
       const args = expr.subscripts.map((sub) => this.generateExpression(sub));
-      result += `(${args.join(", ")})`;
+      result += `.at(${args.join(", ")})`;
     } else {
       for (const sub of expr.subscripts) {
-        result += `[${this.generateExpression(sub)}]`;
+        result += `.at(${this.generateExpression(sub)})`;
       }
     }
 
@@ -3769,13 +3772,19 @@ export class CodeGenerator {
           break;
         }
         case "subscript": {
+          // Bounds-checked .at() (not operator[]/operator()): an out-of-range
+          // IEC array index raises a clean fault — `throw` on exception targets
+          // (the runtime v4 dispatcher catches it and stops just the faulting
+          // task) and iec_runtime_fault(IecFault::ArrayBounds) on -fno-exceptions
+          // MCU targets. operator[] stays unchecked+constexpr for the debug-table
+          // generator's &arr[i] address-of expressions; POU bodies use .at().
           if (step.indices.length > 1) {
             const args = step.indices.map((idx) =>
               this.generateExpression(idx),
             );
-            result += `(${args.join(", ")})`;
+            result += `.at(${args.join(", ")})`;
           } else if (step.indices.length === 1) {
-            result += `[${this.generateExpression(step.indices[0]!)}]`;
+            result += `.at(${this.generateExpression(step.indices[0]!)})`;
           }
           break;
         }

--- a/src/runtime/include/iec_ptr.hpp
+++ b/src/runtime/include/iec_ptr.hpp
@@ -25,6 +25,11 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "iec_fault.hpp"   // STRUCPP_HAS_EXCEPTIONS, IecFault, iec_runtime_fault
+#if STRUCPP_HAS_EXCEPTIONS
+#include <stdexcept>
+#endif
+
 namespace strucpp {
 
 // Forward declare IECVar for arithmetic overloads
@@ -81,12 +86,30 @@ public:
         return *this;
     }
 
-    // Dereference
-    T& operator*() const noexcept { return *static_cast<T*>(ptr_); }
-    T* operator->() const noexcept { return static_cast<T*>(ptr_); }
+    // Null-fault helper: a dereference of an unassigned (NULL) POINTER TO
+    // raises a clean fault instead of an undefined access — throw on exception
+    // targets (the runtime catches it and stops just the faulting task), or
+    // iec_runtime_fault(IecFault::NullReference) on -fno-exceptions MCU targets
+    // (where there is no MMU to trap a null deref, so the unchecked access would
+    // silently read/write address 0). Mirrors REF_TO's NullReferenceException.
+    void __fault_if_null() const {
+        if (!ptr_) {
+#if STRUCPP_HAS_EXCEPTIONS
+            throw std::runtime_error("Null pointer dereference");
+#else
+            iec_runtime_fault(IecFault::NullReference);
+#endif
+        }
+    }
 
-    // Subscript (pointer[n])
-    T& operator[](std::ptrdiff_t n) const noexcept {
+    // Dereference (null-checked)
+    T& operator*() const { __fault_if_null(); return *static_cast<T*>(ptr_); }
+    T* operator->() const { __fault_if_null(); return static_cast<T*>(ptr_); }
+
+    // Subscript (pointer[n]) — null-checked base (the offset itself is
+    // unbounded raw pointer arithmetic, as in C).
+    T& operator[](std::ptrdiff_t n) const {
+        __fault_if_null();
         return *(static_cast<T*>(ptr_) + n);
     }
 

--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -1369,7 +1369,20 @@ inline T MOVE(T value) noexcept {
  * All calls to TIME() within the same cycle return the same value,
  * matching CODESYS behavior.
  */
+#ifdef STRUCPP_THREADED
+// Threaded runtime (OpenPLC v4): each IEC task runs on its own thread and must
+// observe an IEC TIME() value that is STABLE for the duration of its scan and
+// equal to the time at which the dispatcher released it. thread_local gives
+// every worker its own TIME() base; the runtime stamps it via
+// strucpp_set_current_time() at each dispatch, so a slow/overrunning task keeps
+// reading its own snapshot while the dispatcher's master clock advances freely
+// for the other tasks. Gated on STRUCPP_THREADED because single-threaded
+// targets (Arduino/bare-metal) may have no TLS runtime — there it stays a plain
+// global, which is correct for a one-thread scan loop.
+inline thread_local int64_t __CURRENT_TIME_NS = 0;
+#else
 inline int64_t __CURRENT_TIME_NS = 0;
+#endif
 
 /**
  * Returns the current scan-cycle time.

--- a/tests/backend/codegen-composite.test.ts
+++ b/tests/backend/codegen-composite.test.ts
@@ -43,7 +43,7 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("ARR[1] = 100;");
+    expect(result.cppCode).toContain("ARR.at(1) = 100;");
   });
 
   it("should generate 1D array element read", () => {
@@ -60,7 +60,7 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("X = ARR[5];");
+    expect(result.cppCode).toContain("X = ARR.at(5);");
   });
 
   it("should generate array access with variable index", () => {
@@ -77,7 +77,7 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("ARR[I] = ARR[I] + 1;");
+    expect(result.cppCode).toContain("ARR.at(I) = ARR.at(I) + 1;");
   });
 
   it("should generate array access with expression index", () => {
@@ -94,7 +94,7 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("ARR[I + 1] = ARR[I - 1] + ARR[I];");
+    expect(result.cppCode).toContain("ARR.at(I + 1) = ARR.at(I - 1) + ARR.at(I);");
   });
 
   it("should generate 2D array access with multiple subscripts", () => {
@@ -113,8 +113,8 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("MATRIX(0, 0) = 1.0;");
-    expect(result.cppCode).toContain("MATRIX(I, J) = 0.0;");
+    expect(result.cppCode).toContain("MATRIX.at(0, 0) = 1.0;");
+    expect(result.cppCode).toContain("MATRIX.at(I, J) = 0.0;");
   });
 
   it("should generate array access in FOR loop", () => {
@@ -137,8 +137,8 @@ describe("Phase 3.3: Array Element Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("ARR[I] = I * 10;");
-    expect(result.cppCode).toContain("SUM = SUM + ARR[I];");
+    expect(result.cppCode).toContain("ARR.at(I) = I * 10;");
+    expect(result.cppCode).toContain("SUM = SUM + ARR.at(I);");
   });
 });
 
@@ -248,8 +248,8 @@ describe("Phase 3.3: Combined Array/Struct Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("POINTS[1].X = 100;");
-    expect(result.cppCode).toContain("POINTS[I].Y = 200;");
+    expect(result.cppCode).toContain("POINTS.at(1).X = 100;");
+    expect(result.cppCode).toContain("POINTS.at(I).Y = 200;");
   });
 
   it("should generate array of struct access in loop", () => {
@@ -273,8 +273,8 @@ describe("Phase 3.3: Combined Array/Struct Access", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("POINTS[I].X = I;");
-    expect(result.cppCode).toContain("POINTS[I].Y = I * 2;");
+    expect(result.cppCode).toContain("POINTS.at(I).X = I;");
+    expect(result.cppCode).toContain("POINTS.at(I).Y = I * 2;");
   });
 });
 

--- a/tests/backend/codegen-literal-body.test.ts
+++ b/tests/backend/codegen-literal-body.test.ts
@@ -67,7 +67,7 @@ describe("issue #133: statement-body literal lowering", () => {
     );
     expect(body).toContain("U > 0x10");
     expect(body).toContain("U + 0x01");
-    expect(body).toContain("ARR[0b11] = 0xAA;");
+    expect(body).toContain("ARR.at(0b11) = 0xAA;");
   });
 
   it("emits valid reals (decimal point or exponent)", () => {

--- a/tests/backend/codegen-vla.test.ts
+++ b/tests/backend/codegen-vla.test.ts
@@ -82,7 +82,7 @@ describe("Phase 3.4: Inline ARRAY Types in VAR Blocks", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("MYARR[1] = 42;");
+    expect(result.cppCode).toContain("MYARR.at(1) = 42;");
   });
 
   it("should parse inline ARRAY[0..4] OF REAL in VAR block", () => {
@@ -95,7 +95,7 @@ describe("Phase 3.4: Inline ARRAY Types in VAR Blocks", () => {
       END_PROGRAM
     `);
     expect(result.success).toBe(true);
-    expect(result.cppCode).toContain("VALUES[0] = 3.14;");
+    expect(result.cppCode).toContain("VALUES.at(0) = 3.14;");
   });
 });
 
@@ -198,7 +198,7 @@ describe("Phase 3.4: Fixed Array Type Declarations Still Work", () => {
     `);
     expect(result.success).toBe(true);
     expect(result.headerCode).toContain("Array1D<IEC_INT, 0, 4>");
-    expect(result.cppCode).toContain("ARR[0] = 1;");
+    expect(result.cppCode).toContain("ARR.at(0) = 1;");
   });
 
   it("should still generate 2D array types in TYPE blocks", () => {

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -298,9 +298,9 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // Verify 2D access uses operator() syntax, not chained brackets
-    expect(result.cppCode).toContain('M(0, 0)');
-    expect(result.cppCode).toContain('M(1, 2)');
-    expect(result.cppCode).toContain('M(I, J)');
+    expect(result.cppCode).toContain('M.at(0, 0)');
+    expect(result.cppCode).toContain('M.at(1, 2)');
+    expect(result.cppCode).toContain('M.at(I, J)');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'array_2d_access');
     expect(cppResult.success).toBe(true);
@@ -333,9 +333,9 @@ describeIfGpp('C++ Compilation Tests', () => {
     expect(result.success).toBe(true);
 
     // 1D uses brackets, 2D uses parenthesized call syntax
-    expect(result.cppCode).toContain('ROW[1]');
-    expect(result.cppCode).toContain('GRID(1, 1)');
-    expect(result.cppCode).toContain('GRID(I, I)');
+    expect(result.cppCode).toContain('ROW.at(1)');
+    expect(result.cppCode).toContain('GRID.at(1, 1)');
+    expect(result.cppCode).toContain('GRID.at(I, I)');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'mixed_1d_2d_access');
     expect(cppResult.success).toBe(true);


### PR DESCRIPTION
Patch release. Merges threaded-model-hardening (thread_local TIME, array bounds, null-checked IEC_Ptr) and bumps to v0.5.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)