### PR TITLE
fix(codegen): .at() for array-view/pointer subscripts + enum elaborated-specifier

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -4665,6 +4665,10 @@ export class CodeGenerator {
   ): string {
     const u = typeName.toUpperCase();
     if (!memberNames.has(u)) return "";
+    // Enums are emitted as `using IEC_X = IEC_ENUM<X>` aliases, which cannot be
+    // named with an elaborated `struct`/`class` specifier. They also never need
+    // disambiguation here because the member is already mangled (name_).
+    if (this.enumTypeMembers.has(u)) return "";
     if (this.knownFBTypes.has(u)) return "class ";
     if (this.knownStructTypes.has(u)) return "struct ";
     return "";

--- a/src/runtime/include/iec_array.hpp
+++ b/src/runtime/include/iec_array.hpp
@@ -296,6 +296,30 @@ public:
         return data_[index - lower_];
     }
 
+    // Bounds-checked access — the codegen emits .at() for all subscripts so an
+    // out-of-range index raises a clean fault instead of corrupting memory.
+    T& at(int64_t index) {
+        if (index < lower_ || index > upper_) {
+#if STRUCPP_HAS_EXCEPTIONS
+            throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
+#endif
+        }
+        return data_[index - lower_];
+    }
+
+    const T& at(int64_t index) const {
+        if (index < lower_ || index > upper_) {
+#if STRUCPP_HAS_EXCEPTIONS
+            throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
+#endif
+        }
+        return data_[index - lower_];
+    }
+
     int64_t lower_bound(int = 1) const noexcept { return lower_; }
     int64_t upper_bound(int = 1) const noexcept { return upper_; }
     int64_t length() const noexcept { return upper_ - lower_ + 1; }
@@ -322,6 +346,29 @@ public:
     }
 
     const T& operator()(int64_t i, int64_t j) const noexcept {
+        return data_[(i - lower1_) * dim2_ + (j - lower2_)];
+    }
+
+    // Bounds-checked access — codegen emits .at(i, j) for 2D subscripts.
+    T& at(int64_t i, int64_t j) {
+        if (i < lower1_ || i > upper1_ || j < lower2_ || j > upper2_) {
+#if STRUCPP_HAS_EXCEPTIONS
+            throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
+#endif
+        }
+        return data_[(i - lower1_) * dim2_ + (j - lower2_)];
+    }
+
+    const T& at(int64_t i, int64_t j) const {
+        if (i < lower1_ || i > upper1_ || j < lower2_ || j > upper2_) {
+#if STRUCPP_HAS_EXCEPTIONS
+            throw std::out_of_range("Array index out of bounds");
+#else
+            iec_runtime_fault(IecFault::ArrayBounds);
+#endif
+        }
         return data_[(i - lower1_) * dim2_ + (j - lower2_)];
     }
 

--- a/src/runtime/include/iec_ptr.hpp
+++ b/src/runtime/include/iec_ptr.hpp
@@ -113,6 +113,14 @@ public:
         return *(static_cast<T*>(ptr_) + n);
     }
 
+    // Bounds-checked accessor used by codegen's subscript path. A POINTER TO has
+    // no bounds metadata, so this matches operator[]: null-checked base with
+    // unbounded raw pointer arithmetic (as in C).
+    T& at(std::ptrdiff_t n) const {
+        __fault_if_null();
+        return *(static_cast<T*>(ptr_) + n);
+    }
+
     // Raw access
     T* get() const noexcept { return static_cast<T*>(ptr_); }
     void* get_void() const noexcept { return ptr_; }

--- a/tests/fixtures/smart-traffic-light/README.md
+++ b/tests/fixtures/smart-traffic-light/README.md
@@ -1,0 +1,79 @@
+# Smart Traffic Light
+
+IEC 61131-3 Structured Text traffic light controller — a demo project for [STruC++](https://github.com/Autonomy-Logic/STruCpp).
+
+[![CI](https://github.com/Autonomy-Logic/smart-traffic-light/actions/workflows/ci.yml/badge.svg)](https://github.com/Autonomy-Logic/smart-traffic-light/actions/workflows/ci.yml)
+
+## Overview
+
+This project implements a smart traffic light intersection controller using IEC 61131-3 Structured Text. It demonstrates how to structure, compile, and test an ST project using the STruC++ compiler in a CI pipeline.
+
+## Features
+
+- **Enum types** with CODESYS dot notation (`TrafficState.RED`)
+- **Function blocks** with methods, EXTENDS, and OVERRIDE
+- **State machines** using CASE statements with enum labels
+- **Timer-based** phase control using TON standard function block
+- **Dynamic memory** with POINTER TO, `__NEW`, `__DELETE`
+- **Variable-length arrays** (ARRAY[\*] OF TIME)
+- **Located variables** for physical I/O mapping
+- **CONFIGURATION/RESOURCE/TASK** project structure
+- **Automated testing** with STruC++ test framework
+
+## Getting Started
+
+Install STruC++:
+
+```bash
+# Via npm
+npm install -g strucpp
+
+# Or download from releases
+# https://github.com/Autonomy-Logic/STruCpp/releases
+```
+
+Compile the project:
+
+```bash
+strucpp \
+  src/DataTypes/TrafficTypes.st \
+  src/Functions/TimingUtils.st \
+  src/FunctionBlocks/TrafficLight.st \
+  src/FunctionBlocks/PedestrianLight.st \
+  src/FunctionBlocks/VehicleDetector.st \
+  src/FunctionBlocks/TrafficLogger.st \
+  src/Programs/IntersectionController.st \
+  -o build/intersection.cpp
+```
+
+Run tests:
+
+```bash
+strucpp --test src/DataTypes/TrafficTypes.st src/FunctionBlocks/TrafficLight.st tests/test_traffic_light.st
+```
+
+## Project Structure
+
+```
+src/
+├── DataTypes/        # ENUM and STRUCT type definitions
+│   └── TrafficTypes.st
+├── Functions/        # Standalone functions (timing utilities)
+│   └── TimingUtils.st
+├── FunctionBlocks/   # Function blocks
+│   ├── TrafficLight.st       # Base traffic signal state machine
+│   ├── PedestrianLight.st    # Pedestrian signal (EXTENDS TrafficLight)
+│   ├── VehicleDetector.st    # Sensor-based vehicle counting
+│   └── TrafficLogger.st      # Circular buffer event logger
+└── Programs/         # Main programs
+    └── IntersectionController.st  # 4-way intersection coordinator
+tests/                # Test files using STruC++ test framework
+```
+
+## CI
+
+This project uses GitHub Actions with [setup-strucpp](https://github.com/Autonomy-Logic/setup-strucpp) to compile and test on every push and pull request.
+
+## License
+
+MIT

--- a/tests/fixtures/smart-traffic-light/src/DataTypes/TrafficTypes.st
+++ b/tests/fixtures/smart-traffic-light/src/DataTypes/TrafficTypes.st
@@ -1,0 +1,26 @@
+(* Traffic Light Data Types
+   Core type definitions for the intersection controller. *)
+
+TYPE
+  (* Traffic signal states *)
+  TrafficState : (RED, YELLOW, GREEN);
+
+  (* Pedestrian signal states *)
+  PedestrianState : (WALK, DONT_WALK, FLASHING);
+
+  (* Timing configuration for a single traffic light phase cycle *)
+  PhaseTiming :
+    STRUCT
+      greenDuration  : TIME := T#30s;
+      yellowDuration : TIME := T#5s;
+      redDuration    : TIME := T#35s;
+    END_STRUCT;
+
+  (* Log entry for state change events *)
+  LogEntry :
+    STRUCT
+      previousState : TrafficState;
+      newState      : TrafficState;
+      timestamp     : TIME;
+    END_STRUCT;
+END_TYPE

--- a/tests/fixtures/smart-traffic-light/src/FunctionBlocks/PedestrianLight.st
+++ b/tests/fixtures/smart-traffic-light/src/FunctionBlocks/PedestrianLight.st
@@ -1,0 +1,88 @@
+(* PedestrianLight Function Block
+   Extends TrafficLight with pedestrian signal logic.
+   Manages WALK/DONT_WALK/FLASHING states coordinated with the traffic signal. *)
+
+FUNCTION_BLOCK PedestrianLight EXTENDS TrafficLight
+  VAR_INPUT
+    walkRequest  : BOOL := FALSE;
+    walkDuration : TIME := T#20s;
+  END_VAR
+
+  VAR_OUTPUT
+    pedestrianState : PedestrianState := PedestrianState.DONT_WALK;
+    walkLight       : BOOL := FALSE;
+    dontWalkLight   : BOOL := TRUE;
+  END_VAR
+
+  VAR
+    walkTimer      : TON;
+    flashTimer     : TON;
+    flashCount     : INT := 0;
+    maxFlashes     : INT := 5;
+    flashOn        : BOOL := FALSE;
+  END_VAR
+
+  METHOD PUBLIC OVERRIDE GetState : TrafficState
+    GetState := currentState;
+  END_METHOD
+
+  METHOD PUBLIC IsWalking : BOOL
+    IsWalking := (pedestrianState = PedestrianState.WALK);
+  END_METHOD
+
+  METHOD PUBLIC RequestWalk : BOOL
+    walkRequest := TRUE;
+    RequestWalk := TRUE;
+  END_METHOD
+
+  (* Execute parent TrafficLight state machine first *)
+  SUPER^();
+
+  (* Pedestrian signal logic coordinated with traffic state *)
+  IF currentState = TrafficState.RED AND walkRequest THEN
+    (* Safe to walk when traffic is RED *)
+    IF pedestrianState = PedestrianState.DONT_WALK THEN
+      pedestrianState := PedestrianState.WALK;
+      flashCount := 0;
+    END_IF;
+
+    walkTimer(IN := (pedestrianState = PedestrianState.WALK), PT := walkDuration);
+
+    IF walkTimer.Q THEN
+      pedestrianState := PedestrianState.FLASHING;
+      walkTimer(IN := FALSE, PT := walkDuration);
+    END_IF;
+
+    (* Flashing phase before switching to DONT_WALK *)
+    IF pedestrianState = PedestrianState.FLASHING THEN
+      flashTimer(IN := TRUE, PT := T#500ms);
+      IF flashTimer.Q THEN
+        flashCount := flashCount + 1;
+        flashOn := NOT flashOn;
+        flashTimer(IN := FALSE, PT := T#500ms);
+        flashTimer(IN := TRUE, PT := T#500ms);
+      END_IF;
+
+      IF flashCount >= maxFlashes THEN
+        pedestrianState := PedestrianState.DONT_WALK;
+        walkRequest := FALSE;
+        flashCount := 0;
+        flashOn := FALSE;
+      END_IF;
+    END_IF;
+  ELSE
+    (* Not safe to walk — reset to DONT_WALK *)
+    IF currentState <> TrafficState.RED THEN
+      pedestrianState := PedestrianState.DONT_WALK;
+      walkRequest := FALSE;
+      flashCount := 0;
+      flashOn := FALSE;
+    END_IF;
+  END_IF;
+
+  (* Update pedestrian signal outputs *)
+  walkLight := (pedestrianState = PedestrianState.WALK) OR
+               (pedestrianState = PedestrianState.FLASHING AND flashOn);
+  dontWalkLight := (pedestrianState = PedestrianState.DONT_WALK) OR
+                   (pedestrianState = PedestrianState.FLASHING AND NOT flashOn);
+END_FUNCTION_BLOCK

--- a/tests/fixtures/smart-traffic-light/src/FunctionBlocks/TrafficLight.st
+++ b/tests/fixtures/smart-traffic-light/src/FunctionBlocks/TrafficLight.st
@@ -1,0 +1,67 @@
+(* TrafficLight Function Block
+   State machine for a standard 3-phase traffic signal.
+   Cycles: RED -> GREEN -> YELLOW -> RED *)
+
+FUNCTION_BLOCK TrafficLight
+  VAR_INPUT
+    enable   : BOOL := TRUE;
+    timing   : PhaseTiming;
+  END_VAR
+
+  VAR_OUTPUT
+    currentState : TrafficState := TrafficState.RED;
+    redLight     : BOOL := TRUE;
+    yellowLight  : BOOL := FALSE;
+    greenLight   : BOOL := FALSE;
+  END_VAR
+
+  VAR
+    phaseTimer : TON;
+    currentDuration : TIME;
+  END_VAR
+
+  METHOD PUBLIC GetState : TrafficState
+    GetState := currentState;
+  END_METHOD
+
+  METHOD PUBLIC IsGreen : BOOL
+    IsGreen := (currentState = TrafficState.GREEN);
+  END_METHOD
+
+  METHOD PUBLIC IsRed : BOOL
+    IsRed := (currentState = TrafficState.RED);
+  END_METHOD
+
+  (* Determine the duration for the current phase *)
+  CASE currentState OF
+    TrafficState.RED:
+      currentDuration := timing.redDuration;
+    TrafficState.GREEN:
+      currentDuration := timing.greenDuration;
+    TrafficState.YELLOW:
+      currentDuration := timing.yellowDuration;
+  END_CASE;
+
+  (* Run the phase timer *)
+  phaseTimer(IN := enable, PT := currentDuration);
+
+  (* Transition to the next state when timer expires *)
+  IF phaseTimer.Q THEN
+    CASE currentState OF
+      TrafficState.RED:
+        currentState := TrafficState.GREEN;
+      TrafficState.GREEN:
+        currentState := TrafficState.YELLOW;
+      TrafficState.YELLOW:
+        currentState := TrafficState.RED;
+    END_CASE;
+    (* Reset timer for next phase *)
+    phaseTimer(IN := FALSE, PT := currentDuration);
+    phaseTimer(IN := enable, PT := currentDuration);
+  END_IF;
+
+  (* Update output lights based on current state *)
+  redLight    := (currentState = TrafficState.RED);
+  yellowLight := (currentState = TrafficState.YELLOW);
+  greenLight  := (currentState = TrafficState.GREEN);
+END_FUNCTION_BLOCK

--- a/tests/fixtures/smart-traffic-light/src/FunctionBlocks/TrafficLogger.st
+++ b/tests/fixtures/smart-traffic-light/src/FunctionBlocks/TrafficLogger.st
@@ -1,0 +1,80 @@
+(* TrafficLogger Function Block
+   Maintains a circular buffer of state transition log entries.
+   Uses dynamic memory allocation for the log buffer. *)
+
+FUNCTION_BLOCK TrafficLogger
+  VAR_INPUT
+    bufferSize : INT := 20;
+  END_VAR
+
+  VAR_OUTPUT
+    entryCount : INT := 0;
+    isFull     : BOOL := FALSE;
+  END_VAR
+
+  VAR
+    logBuffer    : POINTER TO LogEntry;
+    writeIndex   : INT := 0;
+    initialized  : BOOL := FALSE;
+    totalEntries : DINT := 0;
+  END_VAR
+
+  METHOD PUBLIC Initialize : BOOL
+    IF NOT initialized THEN
+      logBuffer := __NEW(LogEntry, bufferSize);
+      initialized := TRUE;
+      Initialize := TRUE;
+    ELSE
+      Initialize := FALSE;
+    END_IF;
+  END_METHOD
+
+  METHOD PUBLIC Cleanup : BOOL
+    IF initialized THEN
+      __DELETE(logBuffer);
+      initialized := FALSE;
+      entryCount := 0;
+      writeIndex := 0;
+      totalEntries := 0;
+      isFull := FALSE;
+      Cleanup := TRUE;
+    ELSE
+      Cleanup := FALSE;
+    END_IF;
+  END_METHOD
+
+  METHOD PUBLIC LogTransition : BOOL
+    VAR_INPUT
+      fromState : TrafficState;
+      toState   : TrafficState;
+      time      : TIME;
+    END_VAR
+
+    IF NOT initialized THEN
+      LogTransition := FALSE;
+      RETURN;
+    END_IF;
+
+    logBuffer[writeIndex].previousState := fromState;
+    logBuffer[writeIndex].newState := toState;
+    logBuffer[writeIndex].timestamp := time;
+
+    writeIndex := writeIndex + 1;
+    IF writeIndex >= bufferSize THEN
+      writeIndex := 0;
+      isFull := TRUE;
+    END_IF;
+
+    totalEntries := totalEntries + 1;
+
+    IF entryCount < bufferSize THEN
+      entryCount := entryCount + 1;
+    END_IF;
+
+    LogTransition := TRUE;
+  END_METHOD
+
+  METHOD PUBLIC GetTotalTransitions : DINT
+    GetTotalTransitions := totalEntries;
+  END_METHOD
+END_FUNCTION_BLOCK

--- a/tests/fixtures/smart-traffic-light/src/FunctionBlocks/VehicleDetector.st
+++ b/tests/fixtures/smart-traffic-light/src/FunctionBlocks/VehicleDetector.st
@@ -1,0 +1,69 @@
+(* VehicleDetector Function Block
+   Detects vehicles using a sensor input and maintains a detection history
+   buffer allocated with dynamic memory. *)
+
+FUNCTION_BLOCK VehicleDetector
+  VAR_INPUT
+    sensorInput   : BOOL := FALSE;
+    maxHistory    : INT := 10;
+  END_VAR
+
+  VAR_OUTPUT
+    vehicleCount  : INT := 0;
+    isOccupied    : BOOL := FALSE;
+    lastDetected  : TIME := T#0s;
+  END_VAR
+
+  VAR
+    prevSensor     : BOOL := FALSE;
+    historyBuffer  : POINTER TO INT;
+    historySize    : INT := 0;
+    initialized    : BOOL := FALSE;
+    currentTime    : TIME := T#0s;
+  END_VAR
+
+  METHOD PUBLIC Initialize : BOOL
+    IF NOT initialized THEN
+      historyBuffer := __NEW(INT, maxHistory);
+      initialized := TRUE;
+      Initialize := TRUE;
+    ELSE
+      Initialize := FALSE;
+    END_IF;
+  END_METHOD
+
+  METHOD PUBLIC Cleanup : BOOL
+    IF initialized THEN
+      __DELETE(historyBuffer);
+      initialized := FALSE;
+      historySize := 0;
+      Cleanup := TRUE;
+    ELSE
+      Cleanup := FALSE;
+    END_IF;
+  END_METHOD
+
+  METHOD PUBLIC GetDetectionCount : INT
+    GetDetectionCount := vehicleCount;
+  END_METHOD
+
+  METHOD PUBLIC Reset : BOOL
+    vehicleCount := 0;
+    historySize := 0;
+    isOccupied := FALSE;
+    Reset := TRUE;
+  END_METHOD
+
+  (* Rising edge detection — count new vehicles *)
+  IF sensorInput AND NOT prevSensor THEN
+    vehicleCount := vehicleCount + 1;
+    isOccupied := TRUE;
+    lastDetected := currentTime;
+  END_IF;
+
+  IF NOT sensorInput AND prevSensor THEN
+    isOccupied := FALSE;
+  END_IF;
+
+  prevSensor := sensorInput;
+END_FUNCTION_BLOCK

--- a/tests/fixtures/smart-traffic-light/src/Functions/TimingUtils.st
+++ b/tests/fixtures/smart-traffic-light/src/Functions/TimingUtils.st
@@ -1,0 +1,67 @@
+(* TimingUtils — Helper functions for traffic timing calculations *)
+
+(* Calculate the total cycle time from an array of phase durations *)
+FUNCTION CalculateCycleTime : TIME
+  VAR_INPUT
+    durations : ARRAY[*] OF TIME;
+  END_VAR
+  VAR
+    i     : DINT;
+    total : TIME := T#0s;
+  END_VAR
+
+  FOR i := LOWER_BOUND(durations, 1) TO UPPER_BOUND(durations, 1) DO
+    total := total + durations[i];
+  END_FOR;
+
+  CalculateCycleTime := total;
+END_FUNCTION
+
+(* Find the longest phase duration in an array *)
+FUNCTION FindLongestPhase : TIME
+  VAR_INPUT
+    durations : ARRAY[*] OF TIME;
+  END_VAR
+  VAR
+    i       : DINT;
+    longest : TIME := T#0s;
+  END_VAR
+
+  FOR i := LOWER_BOUND(durations, 1) TO UPPER_BOUND(durations, 1) DO
+    IF durations[i] > longest THEN
+      longest := durations[i];
+    END_IF;
+  END_FOR;
+
+  FindLongestPhase := longest;
+END_FUNCTION
+
+(* Validate that all phase durations meet a minimum threshold *)
+FUNCTION ValidateMinDurations : BOOL
+  VAR_INPUT
+    durations  : ARRAY[*] OF TIME;
+    minAllowed : TIME;
+  END_VAR
+  VAR
+    i : DINT;
+  END_VAR
+
+  ValidateMinDurations := TRUE;
+
+  FOR i := LOWER_BOUND(durations, 1) TO UPPER_BOUND(durations, 1) DO
+    IF durations[i] < minAllowed THEN
+      ValidateMinDurations := FALSE;
+      RETURN;
+    END_IF;
+  END_FOR;
+END_FUNCTION
+
+(* Scale all durations by a percentage factor (100 = no change) *)
+FUNCTION ScaleDuration : TIME
+  VAR_INPUT
+    duration : TIME;
+    percent  : INT;
+  END_VAR
+
+  ScaleDuration := duration * percent / 100;
+END_FUNCTION

--- a/tests/fixtures/smart-traffic-light/src/Programs/IntersectionController.st
+++ b/tests/fixtures/smart-traffic-light/src/Programs/IntersectionController.st
@@ -1,0 +1,101 @@
+(* IntersectionController Program
+   Main control program for a 4-way intersection.
+   Uses located variables for I/O mapping and coordinates
+   traffic lights, pedestrian signals, and vehicle detection. *)
+
+PROGRAM IntersectionController
+  VAR_INPUT
+    (* Sensor inputs — mapped to physical I/O *)
+    northSensor AT %IX0.0 : BOOL;
+    southSensor AT %IX0.1 : BOOL;
+    eastSensor  AT %IX0.2 : BOOL;
+    westSensor  AT %IX0.3 : BOOL;
+    pedestrianButton AT %IX0.4 : BOOL;
+  END_VAR
+
+  VAR_OUTPUT
+    (* Signal outputs — mapped to physical I/O *)
+    northRed    AT %QX0.0 : BOOL;
+    northYellow AT %QX0.1 : BOOL;
+    northGreen  AT %QX0.2 : BOOL;
+    southRed    AT %QX0.3 : BOOL;
+    southYellow AT %QX0.4 : BOOL;
+    southGreen  AT %QX0.5 : BOOL;
+    pedestrianWalk AT %QX1.0 : BOOL;
+    pedestrianStop AT %QX1.1 : BOOL;
+  END_VAR
+
+  VAR
+    northSouthLight : TrafficLight;
+    eastWestLight   : TrafficLight;
+    pedestrian      : PedestrianLight;
+    northDetector   : VehicleDetector;
+    southDetector   : VehicleDetector;
+    logger          : TrafficLogger;
+    nsTiming        : PhaseTiming;
+    ewTiming        : PhaseTiming;
+    systemReady     : BOOL := FALSE;
+    cycleCount      : DINT := 0;
+    otherCount      : INT := 0;
+    someString      : STRING := 'hello';
+  END_VAR
+
+  (* Initialize on first scan *)
+  IF NOT systemReady THEN
+    nsTiming.redDuration := T#35s;
+    nsTiming.greenDuration := T#30s;
+    nsTiming.yellowDuration := T#5s;
+
+    ewTiming.redDuration := T#35s;
+    ewTiming.greenDuration := T#25s;
+    ewTiming.yellowDuration := T#5s;
+
+    northSouthLight.timing := nsTiming;
+    eastWestLight.timing := ewTiming;
+    pedestrian.timing := nsTiming;
+
+    logger.Initialize();
+    northDetector.Initialize();
+    southDetector.Initialize();
+    
+    systemReady := TRUE;
+  END_IF;
+
+
+  (* Update vehicle detectors *)
+  northDetector.sensorInput := northSensor;
+  northDetector();
+  southDetector.sensorInput := southSensor;
+  southDetector();
+
+  (* Update pedestrian request *)
+  IF pedestrianButton THEN
+    pedestrian.RequestWalk();
+  END_IF;
+
+  (* Run traffic light state machines *)
+  northSouthLight();
+  eastWestLight();
+  pedestrian();
+
+  (* Map to physical outputs *)
+  northRed    := northSouthLight.redLight;
+  northYellow := northSouthLight.yellowLight;
+  northGreen  := northSouthLight.greenLight;
+  southRed    := northSouthLight.redLight;
+  southYellow := northSouthLight.yellowLight;
+  southGreen  := northSouthLight.greenLight;
+  pedestrianWalk := pedestrian.walkLight;
+  pedestrianStop := pedestrian.dontWalkLight;
+
+  cycleCount := cycleCount + 1;
+
+END_PROGRAM
+
+(* Project configuration *)
+CONFIGURATION DefaultConfig
+  RESOURCE DefaultResource ON DefaultTarget
+    TASK MainTask(INTERVAL := T#100ms, PRIORITY := 1);
+    PROGRAM IntersectionInstance WITH MainTask : IntersectionController;
+  END_RESOURCE
+END_CONFIGURATION

--- a/tests/fixtures/smart-traffic-light/tests/test_data_types.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_data_types.st
@@ -1,0 +1,64 @@
+(* Tests for traffic light data types *)
+
+TEST 'TrafficState enum values are distinct'
+  VAR
+    s1 : TrafficState;
+    s2 : TrafficState;
+    s3 : TrafficState;
+  END_VAR
+
+  s1 := TrafficState.RED;
+  s2 := TrafficState.YELLOW;
+  s3 := TrafficState.GREEN;
+
+  ASSERT_NEQ(s1, s2, 'RED and YELLOW must differ');
+  ASSERT_NEQ(s2, s3, 'YELLOW and GREEN must differ');
+  ASSERT_NEQ(s1, s3, 'RED and GREEN must differ');
+END_TEST
+
+TEST 'PedestrianState enum values are distinct'
+  VAR
+    p1 : PedestrianState;
+    p2 : PedestrianState;
+    p3 : PedestrianState;
+  END_VAR
+
+  p1 := PedestrianState.WALK;
+  p2 := PedestrianState.DONT_WALK;
+  p3 := PedestrianState.FLASHING;
+
+  ASSERT_NEQ(p1, p2, 'WALK and DONT_WALK must differ');
+  ASSERT_NEQ(p2, p3, 'DONT_WALK and FLASHING must differ');
+END_TEST
+
+TEST 'PhaseTiming struct default values'
+  VAR timing : PhaseTiming; END_VAR
+
+  ASSERT_EQ(timing.greenDuration, T#30s, 'Default green should be 30s');
+  ASSERT_EQ(timing.yellowDuration, T#5s, 'Default yellow should be 5s');
+  ASSERT_EQ(timing.redDuration, T#35s, 'Default red should be 35s');
+END_TEST
+
+TEST 'PhaseTiming struct custom values'
+  VAR timing : PhaseTiming; END_VAR
+
+  timing.greenDuration := T#20s;
+  timing.yellowDuration := T#3s;
+  timing.redDuration := T#25s;
+
+  ASSERT_EQ(timing.greenDuration, T#20s);
+  ASSERT_EQ(timing.yellowDuration, T#3s);
+  ASSERT_EQ(timing.redDuration, T#25s);
+END_TEST
+
+TEST 'LogEntry struct initialization'
+  VAR entry : LogEntry; END_VAR
+
+  entry.previousState := TrafficState.RED;
+  entry.newState := TrafficState.GREEN;
+  entry.timestamp := T#1500ms;
+
+  ASSERT_EQ(entry.previousState, TrafficState.RED);
+  ASSERT_EQ(entry.newState, TrafficState.GREEN);
+  ASSERT_EQ(entry.timestamp, T#1500ms);
+END_TEST

--- a/tests/fixtures/smart-traffic-light/tests/test_pedestrian_light.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_pedestrian_light.st
@@ -1,0 +1,103 @@
+(* Tests for the PedestrianLight function block *)
+
+TEST 'PedestrianLight starts in DONT_WALK'
+  VAR ped : PedestrianLight; END_VAR
+
+  ped();
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.DONT_WALK, 'Should start DONT_WALK');
+  ASSERT_TRUE(ped.dontWalkLight, 'Dont walk light should be on');
+  ASSERT_FALSE(ped.walkLight, 'Walk light should be off');
+END_TEST
+
+TEST 'PedestrianLight walks when traffic is RED and requested'
+  VAR
+    ped : PedestrianLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#200ms;
+  timing.greenDuration := T#100ms;
+  timing.yellowDuration := T#50ms;
+  ped.timing := timing;
+  ped.walkDuration := T#80ms;
+
+  (* Start in RED *)
+  ped();
+  ASSERT_EQ(ped.currentState, TrafficState.RED, 'Should be RED');
+
+  (* Request walk *)
+  ped.walkRequest := TRUE;
+  ped();
+
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.WALK, 'Should be WALK after request during RED');
+  ASSERT_TRUE(ped.walkLight, 'Walk light should be on');
+END_TEST
+
+TEST 'PedestrianLight transitions WALK to FLASHING after duration'
+  VAR
+    ped : PedestrianLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#500ms;
+  timing.greenDuration := T#100ms;
+  timing.yellowDuration := T#50ms;
+  ped.timing := timing;
+  ped.walkDuration := T#80ms;
+
+  ped.walkRequest := TRUE;
+  ped();
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.WALK, 'Should be WALK');
+
+  (* Advance past walk duration *)
+  ADVANCE_TIME(T#40ms);
+  ped();
+  ADVANCE_TIME(T#40ms);
+  ped();
+
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.FLASHING, 'Should be FLASHING after walk duration');
+END_TEST
+
+TEST 'PedestrianLight IsWalking method'
+  VAR
+    ped : PedestrianLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#200ms;
+  ped.timing := timing;
+
+  ped();
+  ASSERT_FALSE(ped.IsWalking(), 'Not walking initially');
+
+  ped.walkRequest := TRUE;
+  ped();
+  ASSERT_TRUE(ped.IsWalking(), 'Walking after request during RED');
+END_TEST
+
+TEST 'PedestrianLight resets when traffic goes GREEN'
+  VAR
+    ped : PedestrianLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#100ms;
+  timing.greenDuration := T#100ms;
+  timing.yellowDuration := T#50ms;
+  ped.timing := timing;
+
+  (* Walk during RED *)
+  ped.walkRequest := TRUE;
+  ped();
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.WALK);
+
+  (* Advance to GREEN *)
+  ADVANCE_TIME(T#50ms);
+  ped();
+  ADVANCE_TIME(T#50ms);
+  ped();
+
+  ASSERT_EQ(ped.currentState, TrafficState.GREEN, 'Traffic should be GREEN');
+  ASSERT_EQ(ped.pedestrianState, PedestrianState.DONT_WALK, 'Ped should be DONT_WALK');
+  ASSERT_FALSE(ped.walkRequest, 'Walk request should be cleared');
+END_TEST

--- a/tests/fixtures/smart-traffic-light/tests/test_timing_utils.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_timing_utils.st
@@ -1,0 +1,65 @@
+(* Tests for TimingUtils functions *)
+
+TEST 'CalculateCycleTime sums all durations'
+  VAR
+    phases : ARRAY[1..3] OF TIME := [T#30s, T#5s, T#35s];
+    total  : TIME;
+  END_VAR
+
+  total := CalculateCycleTime(phases);
+  ASSERT_EQ(total, T#70s, 'Total cycle should be 70s');
+END_TEST
+
+TEST 'CalculateCycleTime with single phase'
+  VAR
+    phases : ARRAY[1..1] OF TIME := [T#45s];
+    total  : TIME;
+  END_VAR
+
+  total := CalculateCycleTime(phases);
+  ASSERT_EQ(total, T#45s, 'Single phase cycle');
+END_TEST
+
+TEST 'FindLongestPhase returns maximum duration'
+  VAR
+    phases  : ARRAY[1..3] OF TIME := [T#30s, T#5s, T#35s];
+    longest : TIME;
+  END_VAR
+
+  longest := FindLongestPhase(phases);
+  ASSERT_EQ(longest, T#35s, 'Longest should be 35s');
+END_TEST
+
+TEST 'ValidateMinDurations passes when all above threshold'
+  VAR
+    phases : ARRAY[1..3] OF TIME := [T#30s, T#5s, T#35s];
+    valid  : BOOL;
+  END_VAR
+
+  valid := ValidateMinDurations(phases, T#3s);
+  ASSERT_TRUE(valid, 'All durations above 3s');
+END_TEST
+
+TEST 'ValidateMinDurations fails when one below threshold'
+  VAR
+    phases : ARRAY[1..3] OF TIME := [T#30s, T#2s, T#35s];
+    valid  : BOOL;
+  END_VAR
+
+  valid := ValidateMinDurations(phases, T#3s);
+  ASSERT_FALSE(valid, 'One duration below 3s');
+END_TEST
+
+TEST 'ScaleDuration doubles at 200 percent'
+  VAR result : TIME; END_VAR
+
+  result := ScaleDuration(T#10s, 200);
+  ASSERT_EQ(result, T#20s, 'Should be doubled');
+END_TEST
+
+TEST 'ScaleDuration halves at 50 percent'
+  VAR result : TIME; END_VAR
+
+  result := ScaleDuration(T#10s, 50);
+  ASSERT_EQ(result, T#5s, 'Should be halved');
+END_TEST

--- a/tests/fixtures/smart-traffic-light/tests/test_traffic_light.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_traffic_light.st
@@ -1,0 +1,98 @@
+(* Tests for the TrafficLight function block *)
+
+TEST 'TrafficLight starts in RED state'
+  VAR light : TrafficLight; END_VAR
+
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.RED, 'Should start in RED');
+  ASSERT_TRUE(light.redLight, 'Red light should be on');
+  ASSERT_FALSE(light.greenLight, 'Green light should be off');
+  ASSERT_FALSE(light.yellowLight, 'Yellow light should be off');
+END_TEST
+
+TEST 'TrafficLight transitions RED to GREEN after red duration'
+  VAR
+    light : TrafficLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#100ms;
+  timing.greenDuration := T#100ms;
+  timing.yellowDuration := T#50ms;
+  light.timing := timing;
+
+  (* Run through the red phase *)
+  light();
+  ADVANCE_TIME(T#50ms);
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.RED, 'Still RED at 50ms');
+
+  ADVANCE_TIME(T#50ms);
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.GREEN, 'Should be GREEN after 100ms');
+  ASSERT_TRUE(light.greenLight);
+  ASSERT_FALSE(light.redLight);
+END_TEST
+
+TEST 'TrafficLight full cycle RED -> GREEN -> YELLOW -> RED'
+  VAR
+    light : TrafficLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#100ms;
+  timing.greenDuration := T#80ms;
+  timing.yellowDuration := T#40ms;
+  light.timing := timing;
+
+  (* Start in RED *)
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.RED);
+
+  (* Advance past red duration -> GREEN *)
+  ADVANCE_TIME(T#50ms);
+  light();
+  ADVANCE_TIME(T#50ms);
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.GREEN, 'After red duration -> GREEN');
+
+  (* Advance past green duration -> YELLOW *)
+  ADVANCE_TIME(T#40ms);
+  light();
+  ADVANCE_TIME(T#40ms);
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.YELLOW, 'After green duration -> YELLOW');
+
+  (* Advance past yellow duration -> RED *)
+  ADVANCE_TIME(T#20ms);
+  light();
+  ADVANCE_TIME(T#20ms);
+  light();
+  ASSERT_EQ(light.currentState, TrafficState.RED, 'After yellow duration -> back to RED');
+END_TEST
+
+TEST 'TrafficLight disabled does not advance'
+  VAR
+    light : TrafficLight;
+    timing : PhaseTiming;
+  END_VAR
+
+  timing.redDuration := T#100ms;
+  light.timing := timing;
+  light.enable := FALSE;
+
+  light();
+  ADVANCE_TIME(T#200ms);
+  light();
+
+  ASSERT_EQ(light.currentState, TrafficState.RED, 'Disabled light should stay in RED');
+END_TEST
+
+TEST 'TrafficLight methods report correct state'
+  VAR light : TrafficLight; END_VAR
+
+  light();
+  ASSERT_TRUE(light.IsRed(), 'IsRed should be TRUE initially');
+  ASSERT_FALSE(light.IsGreen(), 'IsGreen should be FALSE initially');
+  ASSERT_EQ(light.GetState(), TrafficState.RED, 'GetState should return RED');
+END_TEST

--- a/tests/fixtures/smart-traffic-light/tests/test_traffic_logger.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_traffic_logger.st
@@ -1,0 +1,82 @@
+(* Tests for the TrafficLogger function block *)
+
+TEST 'TrafficLogger starts empty'
+  VAR logger : TrafficLogger; END_VAR
+
+  ASSERT_EQ(logger.entryCount, 0, 'Should start empty');
+  ASSERT_FALSE(logger.isFull, 'Should not be full');
+END_TEST
+
+TEST 'TrafficLogger requires initialization'
+  VAR
+    logger : TrafficLogger;
+    ok     : BOOL;
+  END_VAR
+
+  ok := logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#1s);
+  ASSERT_FALSE(ok, 'Should fail without init');
+
+  ok := logger.Initialize();
+  ASSERT_TRUE(ok, 'Initialize should succeed');
+
+  ok := logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#1s);
+  ASSERT_TRUE(ok, 'Should succeed after init');
+  ASSERT_EQ(logger.entryCount, 1);
+
+  logger.Cleanup();
+END_TEST
+
+TEST 'TrafficLogger counts entries'
+  VAR
+    logger : TrafficLogger;
+    ok     : BOOL;
+  END_VAR
+
+  logger.Initialize();
+
+  logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#1s);
+  logger.LogTransition(TrafficState.GREEN, TrafficState.YELLOW, T#31s);
+  logger.LogTransition(TrafficState.YELLOW, TrafficState.RED, T#36s);
+
+  ASSERT_EQ(logger.entryCount, 3, 'Should have 3 entries');
+  ASSERT_EQ(logger.GetTotalTransitions(), 3, 'Total should be 3');
+  ASSERT_FALSE(logger.isFull, 'Should not be full with 3/20 entries');
+
+  logger.Cleanup();
+END_TEST
+
+TEST 'TrafficLogger wraps around when full'
+  VAR
+    logger : TrafficLogger;
+    i      : INT;
+  END_VAR
+
+  logger.bufferSize := 3;
+  logger.Initialize();
+
+  (* Fill the buffer *)
+  logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#1s);
+  logger.LogTransition(TrafficState.GREEN, TrafficState.YELLOW, T#31s);
+  logger.LogTransition(TrafficState.YELLOW, TrafficState.RED, T#36s);
+
+  ASSERT_TRUE(logger.isFull, 'Should be full at capacity');
+  ASSERT_EQ(logger.entryCount, 3, 'Entry count capped at buffer size');
+
+  (* Overwrite oldest entry *)
+  logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#71s);
+  ASSERT_EQ(logger.entryCount, 3, 'Still capped at 3');
+  ASSERT_EQ(logger.GetTotalTransitions(), 4, 'Total includes overwritten');
+
+  logger.Cleanup();
+END_TEST
+
+TEST 'TrafficLogger cleanup resets state'
+  VAR logger : TrafficLogger; END_VAR
+
+  logger.Initialize();
+  logger.LogTransition(TrafficState.RED, TrafficState.GREEN, T#1s);
+  logger.Cleanup();
+
+  ASSERT_EQ(logger.entryCount, 0, 'Count reset after cleanup');
+  ASSERT_FALSE(logger.isFull, 'Not full after cleanup');
+END_TEST

--- a/tests/fixtures/smart-traffic-light/tests/test_vehicle_detector.st
+++ b/tests/fixtures/smart-traffic-light/tests/test_vehicle_detector.st
@@ -1,0 +1,78 @@
+(* Tests for the VehicleDetector function block *)
+
+TEST 'VehicleDetector starts with zero count'
+  VAR det : VehicleDetector; END_VAR
+
+  det();
+  ASSERT_EQ(det.vehicleCount, 0, 'Count should start at 0');
+  ASSERT_FALSE(det.isOccupied, 'Not occupied initially');
+END_TEST
+
+TEST 'VehicleDetector counts on rising edge'
+  VAR det : VehicleDetector; END_VAR
+
+  det();
+
+  (* First vehicle *)
+  det.sensorInput := TRUE;
+  det();
+  ASSERT_EQ(det.vehicleCount, 1, 'One vehicle detected');
+  ASSERT_TRUE(det.isOccupied, 'Should be occupied');
+
+  (* Sensor still active — no new count *)
+  det();
+  ASSERT_EQ(det.vehicleCount, 1, 'Still one vehicle');
+
+  (* Vehicle leaves *)
+  det.sensorInput := FALSE;
+  det();
+  ASSERT_FALSE(det.isOccupied, 'No longer occupied');
+
+  (* Second vehicle *)
+  det.sensorInput := TRUE;
+  det();
+  ASSERT_EQ(det.vehicleCount, 2, 'Two vehicles total');
+END_TEST
+
+TEST 'VehicleDetector Initialize and Cleanup'
+  VAR
+    det : VehicleDetector;
+    ok  : BOOL;
+  END_VAR
+
+  ok := det.Initialize();
+  ASSERT_TRUE(ok, 'First initialize should succeed');
+
+  ok := det.Initialize();
+  ASSERT_FALSE(ok, 'Second initialize should fail (already init)');
+
+  ok := det.Cleanup();
+  ASSERT_TRUE(ok, 'Cleanup should succeed');
+
+  ok := det.Cleanup();
+  ASSERT_FALSE(ok, 'Second cleanup should fail (already cleaned)');
+END_TEST
+
+TEST 'VehicleDetector Reset clears count'
+  VAR det : VehicleDetector; END_VAR
+
+  det.sensorInput := TRUE;
+  det();
+  det.sensorInput := FALSE;
+  det();
+  det.sensorInput := TRUE;
+  det();
+  ASSERT_EQ(det.vehicleCount, 2, 'Should have 2 vehicles');
+
+  det.Reset();
+  ASSERT_EQ(det.vehicleCount, 0, 'Should be reset to 0');
+  ASSERT_FALSE(det.isOccupied, 'Not occupied after reset');
+END_TEST
+
+TEST 'VehicleDetector GetDetectionCount method'
+  VAR det : VehicleDetector; END_VAR
+
+  det.sensorInput := TRUE;
+  det();
+  ASSERT_EQ(det.GetDetectionCount(), 1, 'Method should return count');
+END_TEST

--- a/tests/integration/smart-traffic-light.test.ts
+++ b/tests/integration/smart-traffic-light.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Real-project integration test: the `smart-traffic-light` sample project.
+ *
+ * This is a multi-file IEC 61131-3 project (enums, structs, function blocks with
+ * inheritance and methods, arrays passed to functions, POINTER TO, the standard
+ * FB library) bundled with its own ST unit-test suite. Checking the whole project
+ * through compile → C++ → g++ → run guards against codegen regressions that unit
+ * tests on isolated snippets miss — e.g. `.at()` emitted for array-view / pointer
+ * subscripts, or an elaborated `struct` specifier wrongly applied to an enum
+ * alias. The fixture lives in tests/fixtures/smart-traffic-light/.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { hasGpp, runE2ETestPipeline } from "./test-helpers.js";
+import { loadStlibFromFile } from "../../src/node/library-loader.js";
+
+/** The project uses TON from the IEC standard FB library (auto-loaded by the CLI). */
+const IEC_STDLIB_PATH = path.resolve(
+  __dirname,
+  "../../libs/iec-standard-fb.stlib",
+);
+const iecStdlib = fs.existsSync(IEC_STDLIB_PATH)
+  ? loadStlibFromFile(IEC_STDLIB_PATH)
+  : undefined;
+
+const PROJECT_DIR = path.resolve(
+  __dirname,
+  "../fixtures/smart-traffic-light",
+);
+const SRC_DIR = path.join(PROJECT_DIR, "src");
+const TEST_DIR = path.join(PROJECT_DIR, "tests");
+
+/** Recursively collect every .st file under `dir`, sorted for determinism. */
+function collectST(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectST(full));
+    else if (entry.name.endsWith(".st")) out.push(full);
+  }
+  return out.sort();
+}
+
+/** Source files compiled together for every test run. */
+function loadSources(): {
+  primary: { source: string; fileName: string };
+  additional: Array<{ source: string; fileName: string }>;
+} {
+  const files = collectST(SRC_DIR).map((p) => ({
+    source: fs.readFileSync(p, "utf-8"),
+    fileName: path.basename(p),
+  }));
+  const [primary, ...additional] = files;
+  if (!primary) throw new Error("No source files found in fixture");
+  return { primary, additional };
+}
+
+describe.skipIf(!hasGpp)("smart-traffic-light project", () => {
+  const { primary, additional } = loadSources();
+  const testFiles = collectST(TEST_DIR);
+
+  it("has its source and test files checked into the fixture", () => {
+    expect(testFiles.length).toBeGreaterThan(0);
+    expect(additional.length).toBeGreaterThan(0);
+  });
+
+  // One case per ST test file: compile the whole project together with that test
+  // file, build, run, and require every assertion to pass.
+  for (const testPath of testFiles) {
+    const testName = path.basename(testPath);
+    it(`passes all unit tests in ${testName}`, () => {
+      const testST = fs.readFileSync(testPath, "utf-8");
+      const { stdout, exitCode } = runE2ETestPipeline({
+        sourceST: primary.source,
+        testST,
+        testFileName: testName,
+        isTestBuild: true,
+        tempDirPrefix: "strucpp-stl-",
+        compileOptions: {
+          fileName: primary.fileName,
+          additionalSources: additional,
+          libraries: iecStdlib ? [iecStdlib] : [],
+        },
+      });
+
+      // exitCode 0 only when every assertion passed; the summary line confirms
+      // every test ran (passed count == total) and none failed.
+      expect(stdout).not.toContain("[FAIL]");
+      const summary = stdout.match(
+        /(\d+) tests?, (\d+) passed, (\d+) failed/,
+      );
+      expect(summary, `no summary line in:\n${stdout}`).not.toBeNull();
+      const [, total, passed, failed] = summary!;
+      expect(Number(total)).toBeGreaterThan(0);
+      expect(passed).toBe(total);
+      expect(failed).toBe("0");
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes three codegen regressions that broke compilation of real multi-file projects (surfaced via the `smart-traffic-light` sample, whose entire ST unit suite failed to compile).

1. **`.at()` on array views / pointers** — `246ff97` switched array subscripts to the bounds-checked `.at()` accessor and added `.at()` to the concrete array type, but **not** to `ArrayView1D`/`ArrayView2D` (arrays passed as parameters) or `IEC_Ptr` (`POINTER TO`), which only had `operator[]`. Added matching `.at()`: bounds-checked (throw / `iec_runtime_fault`) on the views, null-checked on the pointer (no bounds metadata exists for a raw pointer, so it mirrors `operator[]`).
2. **`struct` specifier on enum alias** — all UDTs, including enums, are registered in `knownStructTypes`, so the member/type shadow-disambiguation helper wrongly prepended `struct ` to enum aliases (`using IEC_X = IEC_ENUM<X>`), which cannot take an elaborated specifier. `elaboratedTagIfShadowed()` now skips enums.
3. **Cascading `operator()` error** — the malformed enum member derailed clang's parse of the class body, producing a bogus base-class `operator()` error. Resolved by fix #2.

## Test coverage

Adds the `smart-traffic-light` project as a checked-in fixture (`tests/fixtures/smart-traffic-light/`) plus an integration test (`tests/integration/smart-traffic-light.test.ts`) that compiles the whole project and runs its ST unit suite end-to-end (compile → C++ → g++ → run), guarding against codegen regressions that isolated-snippet tests miss. New `.st` files dropped into the fixture are picked up automatically.

## Verification

- New fixture test: 7 passed.
- Regression-catching confirmed: reverting the enum fix turns the fixture test red (6 failures).
- Full suite: 78 files, 1962 passed, 7 skipped — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)