### PR TITLE
fix(codegen): Add global var types to currentScopeVarTypes

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -1135,30 +1135,6 @@ export class CodeGenerator {
       }
     }
 
-    // Generate top-level global variables (GVL files)
-    if (ast.globalVarBlocks.length > 0) {
-      this.emitHeader("// Global variables");
-      for (const block of ast.globalVarBlocks) {
-        const constQualifier = block.isConstant ? "const " : "";
-        for (const decl of block.declarations) {
-          const cppType = this.mapTypeRefToCpp(decl.type);
-          for (const name of decl.names) {
-            this.emitHeaderChunkMarker("begin", "inlineGlobal", name);
-            if (decl.initialValue) {
-              const initExpr = this.generateExpression(decl.initialValue);
-              this.emitHeader(
-                `${constQualifier}inline ${cppType} ${name} = ${initExpr};`,
-              );
-            } else {
-              this.emitHeader(`inline ${cppType} ${name}{};`);
-            }
-            this.emitHeaderChunkMarker("end", "inlineGlobal", name);
-          }
-        }
-      }
-      this.emitHeader("");
-    }
-
     // Inject reachable library chunks (header side).
     //
     // Per archive: emit `// Library: <name>` header, then `class X;`
@@ -1229,6 +1205,30 @@ export class CodeGenerator {
       this.emitHeaderChunkMarker("begin", "functionBlock", fb.name);
       this.generateFBHeaderDeclaration(fb);
       this.emitHeaderChunkMarker("end", "functionBlock", fb.name);
+    }
+
+    // Generate top-level global variables (GVL files)
+    if (ast.globalVarBlocks.length > 0) {
+      this.emitHeader("// Global variables");
+      for (const block of ast.globalVarBlocks) {
+        const constQualifier = block.isConstant ? "const " : "";
+        for (const decl of block.declarations) {
+          const cppType = this.mapTypeRefToCpp(decl.type);
+          for (const name of decl.names) {
+            this.emitHeaderChunkMarker("begin", "inlineGlobal", name);
+            if (decl.initialValue) {
+              const initExpr = this.generateExpression(decl.initialValue);
+              this.emitHeader(
+                `${constQualifier}inline ${cppType} ${name} = ${initExpr};`,
+              );
+            } else {
+              this.emitHeader(`inline ${cppType} ${name}{};`);
+            }
+            this.emitHeaderChunkMarker("end", "inlineGlobal", name);
+          }
+        }
+      }
+      this.emitHeader("");
     }
 
     // Generate program class declarations

--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -4885,7 +4885,9 @@ export class CodeGenerator {
 
   /**
    * Enter a new scope for code generation. Populates currentScopeVarTypes
-   * from the variable blocks of a program or function block.
+   * from the variable blocks of a program or function block, then adds
+   * VAR_GLOBAL declarations. When names collide, local declarations shadow
+   * global declarations.
    */
   private enterScope(
     varBlocks: CompilationUnit["programs"][0]["varBlocks"],
@@ -4893,6 +4895,25 @@ export class CodeGenerator {
     this.currentScopeVarTypes.clear();
     this.currentScopeVarRefKinds.clear();
     this.memberMangledNames.clear();
+
+    // Initialize with global declarations to allow local declarations to shadow them
+    for (const block of this.ast?.globalVarBlocks ?? []) {
+      for (const decl of block.declarations) {
+        for (const name of decl.names) {
+          this.currentScopeVarTypes.set(name.toUpperCase(), decl.type.name);
+          if (
+            decl.type.referenceKind !== undefined &&
+            decl.type.referenceKind !== "none"
+          ) {
+            this.currentScopeVarRefKinds.set(
+              name.toUpperCase(),
+              decl.type.referenceKind,
+            );
+          }
+        }
+      }
+    }
+
     for (const block of varBlocks) {
       for (const decl of block.declarations) {
         const cppType = this.isUserDefinedType(decl.type.name)

--- a/tests/backend/codegen-fb.test.ts
+++ b/tests/backend/codegen-fb.test.ts
@@ -122,6 +122,36 @@ describe("Codegen - Function Blocks", () => {
       expect(result.cppCode).toContain("SUM = ADD.RESULT;");
     });
 
+    it("should generate invocation of global FB as input assignment + operator()", () => {
+      const result = compileAndCheck(`
+        FUNCTION_BLOCK Adder
+          VAR_INPUT a, b : INT; END_VAR
+          VAR_OUTPUT result : INT; END_VAR
+          result := a + b;
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+          add : Adder;
+        END_VAR
+
+        PROGRAM Main
+          VAR
+            sum : INT;
+          END_VAR
+          add(a := 5, b := 3);
+          sum := add.result;
+        END_PROGRAM
+      `);
+
+      // FB invocation should assign inputs then call operator()
+      expect(result.cppCode).toContain("ADD.A = 5;");
+      expect(result.cppCode).toContain("ADD.B = 3;");
+      expect(result.cppCode).toContain("ADD();");
+
+      // Member access should be direct property access
+      expect(result.cppCode).toContain("SUM = ADD.RESULT;");
+    });
+
     it("should generate FB output capture with => syntax", () => {
       const result = compileAndCheck(`
         FUNCTION_BLOCK MyFB


### PR DESCRIPTION
This PR adds the types of global variable declarations to currentScopeVarTypes in order to fix #192 

Also moves the point where global variables are emitted in the header file to after the function block declarations in order to ensure that the resulting C++ can be compiled.