### PR TITLE
feat(modifiers): accept NON_RETAIN and PERSISTENT, and scope RETAIN correctly

### DIFF
--- a/docs/IEC_COMPLIANCE.md
+++ b/docs/IEC_COMPLIANCE.md
@@ -64,8 +64,9 @@ STruC++ implements the Structured Text (ST) language from IEC 61131-3. This docu
 | VAR_EXTERNAL | Supported | References either a CONFIGURATION or a file-level VAR_GLOBAL |
 | VAR_GLOBAL | Supported | Global variables (CONFIGURATION-scoped or file-level) |
 | CONSTANT | Supported | Compile-time constants |
-| RETAIN | Supported | Tracked in retain variable table |
-| NON_RETAIN | Supported | |
+| RETAIN | Supported | Allowed on `VAR`, `VAR_INPUT`, `VAR_OUTPUT` and `VAR_GLOBAL`, per IEC 61131-3. Rejected on `VAR_IN_OUT` / `VAR_TEMP` / `VAR_EXTERNAL`, and inside a `FUNCTION` or `METHOD` (no instance, nothing to retain) |
+| PERSISTENT | Partial | Accepted and treated as `RETAIN`. CODESYS also keeps a PERSISTENT value across a program download; that is not implemented, so the weaker shared guarantee is what is claimed |
+| NON_RETAIN | Supported | Accepted and treated as the default (a plain `VAR` is already non-retained). Rejected when combined with `RETAIN` or `CONSTANT` |
 | AT %IX0.0 | Supported | Located variables (I/Q/M areas, X/B/W/D/L sizes) |
 | Multiple names | Supported | `a, b, c : INT := 0;` |
 | Initialization | Supported | `:= expression` |

--- a/src/frontend/ast-builder.ts
+++ b/src/frontend/ast-builder.ts
@@ -760,7 +760,9 @@ export class ASTBuilder {
     else if (children.VAR_INST) blockType = "VAR_INST";
 
     const isConstant = !!children.CONSTANT;
-    const isRetain = !!children.RETAIN;
+    // PERSISTENT is RETAIN here — see the note on `VarBlock.isRetain`.
+    const isRetain = !!children.RETAIN || !!children.PERSISTENT;
+    const isNonRetain = !!children.NON_RETAIN;
 
     const declarations: VarDeclaration[] = [];
     for (const declNode of getAllNodes(children.varDeclaration)) {
@@ -773,6 +775,7 @@ export class ASTBuilder {
       blockType,
       isConstant,
       isRetain,
+      isNonRetain,
       declarations,
     };
   }
@@ -1351,7 +1354,9 @@ export class ASTBuilder {
     else if (children.VAR_TEMP) blockType = "VAR_TEMP";
 
     const isConstant = !!children.CONSTANT;
-    const isRetain = !!children.RETAIN;
+    // PERSISTENT is RETAIN here — see the note on `VarBlock.isRetain`.
+    const isRetain = !!children.RETAIN || !!children.PERSISTENT;
+    const isNonRetain = !!children.NON_RETAIN;
 
     const declarations: VarDeclaration[] = [];
     for (const declNode of getAllNodes(children.varDeclaration)) {
@@ -1364,6 +1369,7 @@ export class ASTBuilder {
       blockType,
       isConstant,
       isRetain,
+      isNonRetain,
       declarations,
     };
   }

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -227,7 +227,26 @@ export interface VarBlock extends ASTNode {
   kind: "VarBlock";
   blockType: VarBlockType;
   isConstant: boolean;
+  /**
+   * True for `RETAIN` and for `PERSISTENT`.
+   *
+   * PERSISTENT is folded in rather than tracked separately: CODESYS
+   * distinguishes them (PERSISTENT also survives a program download) and this
+   * toolchain does not implement that yet, so the honest mapping is the weaker
+   * guarantee both share. Splitting them would mean claiming a guarantee
+   * nothing delivers.
+   */
   isRetain: boolean;
+  /**
+   * True when the block spelled `NON_RETAIN` explicitly.
+   *
+   * Semantically the default — a plain `VAR` is already non-retained — so
+   * nothing downstream branches on it. It is recorded so the qualifier is not
+   * silently dropped by anything that reproduces source from the AST (the LSP
+   * formatter, `--decompile-lib`), and so `NON_RETAIN` combined with `RETAIN`
+   * can be reported as the contradiction it is.
+   */
+  isNonRetain: boolean;
   declarations: VarDeclaration[];
 }
 

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -266,6 +266,23 @@ export const VAR_GLOBAL = createToken({
 export const VAR_TEMP = createToken({ name: "VAR_TEMP", pattern: /VAR_TEMP/i });
 export const CONSTANT = createToken({ name: "CONSTANT", pattern: /CONSTANT/i });
 export const RETAIN = createToken({ name: "RETAIN", pattern: /RETAIN/i });
+// NON_RETAIN is IEC's explicit spelling of the DEFAULT — a variable that does
+// not survive a power cycle. Lexed so a CODESYS import parses rather than
+// failing on the next line: without a token, `NON_RETAIN` matched Identifier
+// and the parser then demanded a colon, reporting a syntax error one line
+// below the qualifier that caused it.
+export const NON_RETAIN = createToken({
+  name: "NON_RETAIN",
+  pattern: /NON_RETAIN/i,
+});
+// PERSISTENT folds into RETAIN. CODESYS distinguishes them (PERSISTENT also
+// survives a download), and this toolchain does not yet — so it is accepted
+// and treated as RETAIN rather than rejected, which is what lets a converted
+// project compile. Revisit if download-surviving retention is implemented.
+export const PERSISTENT = createToken({
+  name: "PERSISTENT",
+  pattern: /PERSISTENT/i,
+});
 export const AT = createToken({ name: "AT", pattern: /AT/i });
 
 // Type declarations
@@ -656,6 +673,8 @@ const keywordTokens = [
   VAR_TEMP,
   CONSTANT,
   RETAIN,
+  NON_RETAIN,
+  PERSISTENT,
   AT,
   TYPE,
   END_TYPE,
@@ -794,6 +813,8 @@ export const allTokens = [
   VAR,
   CONSTANT,
   RETAIN,
+  NON_RETAIN,
+  PERSISTENT,
   TYPE,
   STRUCT,
   ARRAY,

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -288,10 +288,17 @@ export class STParser extends CstParser {
       ],
       IGNORE_AMBIGUITIES: true,
     });
-    this.OPTION(() => {
+    // MANY, not OPTION: IEC and CODESYS both allow a combination, and
+    // `VAR RETAIN PERSISTENT` is the form a converted CODESYS project actually
+    // carries. Contradictory or repeated qualifiers are a semantic error, not a
+    // grammar one — `validateVarModifiers` reports them with a source span,
+    // which reads far better than a parser "expecting END_VAR".
+    this.MANY2(() => {
       this.OR2([
         { ALT: () => this.CONSUME(tokens.CONSTANT) },
         { ALT: () => this.CONSUME(tokens.RETAIN) },
+        { ALT: () => this.CONSUME(tokens.NON_RETAIN) },
+        { ALT: () => this.CONSUME(tokens.PERSISTENT) },
       ]);
     });
     this.MANY(() => {
@@ -402,10 +409,17 @@ export class STParser extends CstParser {
       { ALT: () => this.CONSUME(tokens.VAR_GLOBAL) },
       { ALT: () => this.CONSUME(tokens.VAR_TEMP) },
     ]);
-    this.OPTION(() => {
+    // MANY, not OPTION: IEC and CODESYS both allow a combination, and
+    // `VAR RETAIN PERSISTENT` is the form a converted CODESYS project actually
+    // carries. Contradictory or repeated qualifiers are a semantic error, not a
+    // grammar one — `validateVarModifiers` reports them with a source span,
+    // which reads far better than a parser "expecting END_VAR".
+    this.MANY2(() => {
       this.OR2([
         { ALT: () => this.CONSUME(tokens.CONSTANT) },
         { ALT: () => this.CONSUME(tokens.RETAIN) },
+        { ALT: () => this.CONSUME(tokens.NON_RETAIN) },
+        { ALT: () => this.CONSUME(tokens.PERSISTENT) },
       ]);
     });
     this.MANY(() => {

--- a/src/semantic/analyzer.ts
+++ b/src/semantic/analyzer.ts
@@ -375,6 +375,7 @@ export class SemanticAnalyzer {
           scope,
           "function",
           funcDecl.name,
+          false,
         );
       } catch (err) {
         if (err instanceof Error) {
@@ -408,6 +409,7 @@ export class SemanticAnalyzer {
           scope,
           "functionBlock",
           fbDecl.name,
+          true,
         );
 
         // Create method scopes (parent = FB scope for correct lookup chain)
@@ -422,6 +424,7 @@ export class SemanticAnalyzer {
               methodScope,
               "functionBlock",
               fbDecl.name,
+              false,
             );
             // Register method return variable (MethodName := value)
             if (method.returnType) {
@@ -506,6 +509,7 @@ export class SemanticAnalyzer {
           scope,
           "program",
           progDecl.name,
+          true,
         );
       } catch (err) {
         if (err instanceof Error) {
@@ -570,10 +574,19 @@ export class SemanticAnalyzer {
     scope: ReturnType<typeof this.symbolTables.createProgramScope>,
     scopeType: "program" | "function" | "functionBlock",
     scopeName: string,
+    /**
+     * Whether declarations here belong to something with instance storage.
+     *
+     * False for a FUNCTION and for a METHOD: neither has an instance, their
+     * locals are stack temporaries, and RETAIN over a stack slot is
+     * meaningless. `scopeType` cannot answer this — a method reports
+     * "functionBlock" so its located variables are rejected the same way an
+     * FB's are, and overloading it would change that unrelated rule.
+     */
+    hasInstanceState: boolean,
   ): void {
     for (const block of varBlocks) {
-      // Validate variable modifiers (CONSTANT, RETAIN)
-      this.validateVarModifiers(block);
+      this.validateVarModifiers(block, hasInstanceState);
 
       for (const decl of block.declarations) {
         for (const name of decl.names) {
@@ -1364,10 +1377,24 @@ export class SemanticAnalyzer {
    * - Block type restrictions for CONSTANT
    * - Block type restrictions for RETAIN
    */
-  private validateVarModifiers(block: VarBlock): void {
+  /**
+   * Validate variable block modifiers (CONSTANT, RETAIN, NON_RETAIN,
+   * PERSISTENT).
+   *
+   * PERSISTENT has already folded into `isRetain` by the time it gets here (see
+   * `VarBlock.isRetain`), so there is nothing PERSISTENT-specific to check.
+   * NON_RETAIN is the default spelled out, so it is accepted wherever a plain
+   * `VAR` would be — including on `VAR_TEMP`, where it is redundant but true,
+   * and rejecting a correct statement would fail a CODESYS import for no gain.
+   */
+  private validateVarModifiers(
+    block: VarBlock,
+    hasInstanceState: boolean,
+  ): void {
     const blockType = block.blockType;
 
-    // RETAIN + CONSTANT is invalid
+    // ---- Contradictions, checked first: once two qualifiers disagree there is
+    // no single intent left to validate the rest against. ------------------
     if (block.isRetain && block.isConstant) {
       this.addError(
         "Variable cannot be both RETAIN and CONSTANT",
@@ -1375,12 +1402,32 @@ export class SemanticAnalyzer {
         block.sourceSpan.startCol,
         block.sourceSpan.file,
       );
-      return; // Skip further validation for this block
+      return;
     }
 
-    // CONSTANT validation
+    if (block.isNonRetain && block.isRetain) {
+      this.addError(
+        "Variable cannot be both RETAIN and NON_RETAIN",
+        block.sourceSpan.startLine,
+        block.sourceSpan.startCol,
+        block.sourceSpan.file,
+      );
+      return;
+    }
+
+    if (block.isNonRetain && block.isConstant) {
+      this.addError(
+        "Variable cannot be both CONSTANT and NON_RETAIN",
+        block.sourceSpan.startLine,
+        block.sourceSpan.startCol,
+        block.sourceSpan.file,
+      );
+      return;
+    }
+
+    // ---- CONSTANT ---------------------------------------------------------
     if (block.isConstant) {
-      // CONSTANT requires initializer (except VAR_INPUT CONSTANT — caller provides value)
+      // CONSTANT requires initializer (except VAR_INPUT — caller provides value)
       if (blockType !== "VAR_INPUT") {
         for (const decl of block.declarations) {
           if (!decl.initialValue) {
@@ -1395,7 +1442,6 @@ export class SemanticAnalyzer {
         }
       }
 
-      // Block type restrictions for CONSTANT
       if (blockType === "VAR_OUTPUT") {
         this.addError(
           "VAR_OUTPUT cannot be CONSTANT",
@@ -1413,15 +1459,41 @@ export class SemanticAnalyzer {
       }
     }
 
-    // RETAIN validation - block type restrictions
+    // ---- RETAIN -----------------------------------------------------------
     if (block.isRetain) {
-      const invalidRetainTypes = [
-        "VAR_INPUT",
-        "VAR_OUTPUT",
-        "VAR_IN_OUT",
-        "VAR_TEMP",
-        "VAR_EXTERNAL",
-      ];
+      // No instance, no state to retain. A FUNCTION is re-entered from scratch
+      // on every call and a METHOD's locals live on the stack, so RETAIN there
+      // is not a restriction we are imposing — it has nothing to describe.
+      // Previously accepted in silence, which is the worst outcome: the user
+      // believes a value survives a power cycle and it never did.
+      if (!hasInstanceState) {
+        this.addError(
+          // Deliberately unnamed: the only scope name in reach here is the
+          // owning FB's, and a method-level RETAIN reported against the FB
+          // name reads as a lie — RETAIN on the FB's own VAR is legal. The
+          // source span points at the offending block.
+          "RETAIN is not allowed in a FUNCTION or METHOD: there is no instance, so the variables have nothing to retain",
+          block.sourceSpan.startLine,
+          block.sourceSpan.startCol,
+          block.sourceSpan.file,
+        );
+        return;
+      }
+
+      // VAR_INPUT and VAR_OUTPUT are deliberately absent: IEC 61131-3 permits
+      // RETAIN on VAR, VAR_INPUT, VAR_OUTPUT and VAR_GLOBAL, and CODESYS
+      // accepts all four. Refusing the first two rejected function blocks that
+      // are valid everywhere else.
+      //
+      // The three below have no retainable storage of their own:
+      //   VAR_IN_OUT   — a reference; the retention belongs to whatever it
+      //                  points at.
+      //   VAR_TEMP     — transient by definition, re-initialised every
+      //                  invocation.
+      //   VAR_EXTERNAL — a view onto a VAR_GLOBAL; that declaration is where
+      //                  RETAIN belongs, and putting it here would suggest two
+      //                  independent answers for one storage location.
+      const invalidRetainTypes = ["VAR_IN_OUT", "VAR_TEMP", "VAR_EXTERNAL"];
 
       if (invalidRetainTypes.includes(blockType)) {
         this.addError(

--- a/tests/semantic/variable-modifiers.test.ts
+++ b/tests/semantic/variable-modifiers.test.ts
@@ -158,7 +158,12 @@ describe('Phase 2.6 - Variable Modifiers', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should error when VAR_INPUT is RETAIN', () => {
+    // Inverted from an earlier assertion that VAR_INPUT RETAIN was an error.
+    // IEC 61131-3 permits RETAIN on VAR, VAR_INPUT, VAR_OUTPUT and VAR_GLOBAL,
+    // and CODESYS accepts all four — the old rule rejected function blocks that
+    // are valid everywhere else. Kept as a test so the restriction cannot
+    // quietly return.
+    it('should ACCEPT RETAIN on VAR_INPUT, as IEC 61131-3 does', () => {
       const source = `
         FUNCTION_BLOCK TestFB
           VAR_INPUT RETAIN
@@ -167,13 +172,12 @@ describe('Phase 2.6 - Variable Modifiers', () => {
         END_FUNCTION_BLOCK
       `;
       const result = compile(source);
-      expect(result.success).toBe(false);
-      expect(result.errors.some(e =>
-        e.message.includes('VAR_INPUT') && e.message.includes('RETAIN')
-      )).toBe(true);
+      expect(
+        result.errors.filter((e) => e.message.includes('RETAIN')),
+      ).toEqual([]);
     });
 
-    it('should error when VAR_OUTPUT is RETAIN', () => {
+    it('should ACCEPT RETAIN on VAR_OUTPUT, as IEC 61131-3 does', () => {
       const source = `
         FUNCTION_BLOCK TestFB
           VAR_OUTPUT RETAIN
@@ -182,10 +186,9 @@ describe('Phase 2.6 - Variable Modifiers', () => {
         END_FUNCTION_BLOCK
       `;
       const result = compile(source);
-      expect(result.success).toBe(false);
-      expect(result.errors.some(e =>
-        e.message.includes('VAR_OUTPUT') && e.message.includes('RETAIN')
-      )).toBe(true);
+      expect(
+        result.errors.filter((e) => e.message.includes('RETAIN')),
+      ).toEqual([]);
     });
 
     it('should error when VAR_IN_OUT is RETAIN', () => {
@@ -310,6 +313,186 @@ describe('Phase 2.6 - Variable Modifiers', () => {
       expect(result.success).toBe(true);
       expect(result.headerCode).not.toContain('__retain_vars');
       expect(result.headerCode).not.toContain('getRetainVars');
+    });
+  });
+});
+
+/**
+ * NON_RETAIN, PERSISTENT, and the RETAIN scope rules.
+ *
+ * NON_RETAIN previously had no token at all: it lexed as an Identifier, so
+ * `VAR NON_RETAIN x : DINT;` failed with "Expected Colon" on the line BELOW the
+ * qualifier — any CODESYS project carrying it died on import, pointing at the
+ * wrong place. PERSISTENT was the same.
+ *
+ * RETAIN was also refused on VAR_INPUT / VAR_OUTPUT, which IEC 61131-3 permits
+ * and CODESYS accepts, and silently ACCEPTED inside a FUNCTION, where there is
+ * no instance and nothing to retain.
+ */
+describe('RETAIN / NON_RETAIN / PERSISTENT', () => {
+  const CFG = `
+CONFIGURATION Config0
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`;
+
+  const errorsFor = (source: string): string[] =>
+    compile(source).errors.map((e) => e.message);
+
+  describe('accepted forms', () => {
+    it('lexes NON_RETAIN as a qualifier, not as a variable name', () => {
+      const result = parse(`
+        PROGRAM Main
+          VAR NON_RETAIN
+            scratch : DINT;
+          END_VAR
+        END_PROGRAM
+      `);
+      expect(result.errors).toHaveLength(0);
+      const block = result.ast?.programs[0].varBlocks[0];
+      expect(block?.isNonRetain).toBe(true);
+      expect(block?.isRetain).toBe(false);
+      // One declaration named SCRATCH — not a variable called NON_RETAIN.
+      expect(block?.declarations).toHaveLength(1);
+      expect(block?.declarations[0].names).toEqual(['SCRATCH']);
+    });
+
+    it('treats PERSISTENT as RETAIN', () => {
+      const block = parse(`
+        PROGRAM Main
+          VAR PERSISTENT
+            boots : DINT;
+          END_VAR
+        END_PROGRAM
+      `).ast?.programs[0].varBlocks[0];
+      expect(block?.isRetain).toBe(true);
+    });
+
+    it('accepts the RETAIN PERSISTENT combination CODESYS writes', () => {
+      const result = parse(`
+        PROGRAM Main
+          VAR RETAIN PERSISTENT
+            hours : DINT;
+          END_VAR
+        END_PROGRAM
+      `);
+      expect(result.errors).toHaveLength(0);
+      expect(result.ast?.programs[0].varBlocks[0].isRetain).toBe(true);
+    });
+
+    it.each(['VAR_INPUT', 'VAR_OUTPUT'])(
+      'allows RETAIN on %s, as IEC 61131-3 does',
+      (blockType) => {
+        const source = `
+FUNCTION_BLOCK Motor
+  ${blockType} RETAIN held : DINT; END_VAR
+  VAR other : DINT; END_VAR
+  other := 1;
+END_FUNCTION_BLOCK
+PROGRAM Main
+  VAR m : Motor; END_VAR
+  m();
+END_PROGRAM${CFG}`;
+        expect(errorsFor(source)).toEqual([]);
+      },
+    );
+
+    it('allows NON_RETAIN on VAR_TEMP — redundant, but true', () => {
+      const source = `
+FUNCTION_BLOCK FB
+  VAR_TEMP NON_RETAIN tmp : DINT; END_VAR
+  tmp := 1;
+END_FUNCTION_BLOCK
+PROGRAM Main
+  VAR f : FB; END_VAR
+  f();
+END_PROGRAM${CFG}`;
+      expect(errorsFor(source)).toEqual([]);
+    });
+  });
+
+  describe('rejected forms', () => {
+    it('rejects RETAIN inside a FUNCTION — no instance, nothing to retain', () => {
+      const errors = errorsFor(`
+FUNCTION AddOne : DINT
+  VAR_INPUT a : DINT; END_VAR
+  VAR RETAIN bad : DINT; END_VAR
+  AddOne := a + 1;
+END_FUNCTION`);
+      expect(errors.some((m) => /RETAIN is not allowed in a FUNCTION or METHOD/.test(m))).toBe(true);
+    });
+
+    it('rejects RETAIN inside a METHOD, whose locals are stack slots', () => {
+      const errors = errorsFor(`
+FUNCTION_BLOCK FB
+  VAR x : DINT; END_VAR
+  METHOD M : DINT
+    VAR RETAIN bad : DINT; END_VAR
+    M := 1;
+  END_METHOD
+END_FUNCTION_BLOCK
+PROGRAM Main
+  VAR f : FB; END_VAR
+  f.x := 1;
+END_PROGRAM${CFG}`);
+      const message = errors.find((m) => /RETAIN is not allowed/.test(m));
+      expect(message).toBeDefined();
+      // Must NOT blame the function block: RETAIN on the FB's own VAR is legal,
+      // and naming it here would read as a contradiction.
+      expect(message).not.toContain("'FB'");
+    });
+
+    it.each(['VAR_IN_OUT', 'VAR_TEMP'])(
+      'rejects RETAIN on %s — no storage of its own to retain',
+      (blockType) => {
+        const errors = errorsFor(`
+FUNCTION_BLOCK FB
+  ${blockType} RETAIN bad : DINT; END_VAR
+  VAR other : DINT; END_VAR
+  other := 1;
+END_FUNCTION_BLOCK
+PROGRAM Main
+  VAR f : FB; END_VAR
+  f();
+END_PROGRAM${CFG}`);
+        expect(errors.some((m) => m.includes(`${blockType} cannot be RETAIN`))).toBe(true);
+      },
+    );
+
+    it('rejects RETAIN on VAR_EXTERNAL — the VAR_GLOBAL owns the retention', () => {
+      // Program scope on purpose. The POU var-block AST builder does not map
+      // VAR_EXTERNAL, so a function block's external arrives as blockType
+      // "VAR" and slips past this rule — pre-existing (the previous rule
+      // listed VAR_EXTERNAL and was equally ineffective there), tracked
+      // separately.
+      const errors = errorsFor(`
+PROGRAM Main
+  VAR_EXTERNAL RETAIN g : DINT; END_VAR
+  g := 1;
+END_PROGRAM
+CONFIGURATION Config0
+  VAR_GLOBAL g : DINT; END_VAR
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`);
+      expect(errors.some((m) => m.includes('VAR_EXTERNAL cannot be RETAIN'))).toBe(true);
+    });
+
+    it.each([
+      ['RETAIN NON_RETAIN', 'both RETAIN and NON_RETAIN'],
+      ['RETAIN CONSTANT', 'both RETAIN and CONSTANT'],
+      ['CONSTANT NON_RETAIN', 'both CONSTANT and NON_RETAIN'],
+    ])('rejects the contradiction "%s"', (qualifiers, expected) => {
+      const errors = errorsFor(`
+PROGRAM Main
+  VAR ${qualifiers} bad : DINT := 1; END_VAR
+  ;
+END_PROGRAM${CFG}`);
+      expect(errors.some((m) => m.includes(expected))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Phase 1 of NODE-94, compiler half. The editor half (the **Flags** column) follows as an openplc-editor / openplc-web pair.

- **`NON_RETAIN` and `PERSISTENT` had no tokens.** `NON_RETAIN` lexed as an Identifier, so `VAR NON_RETAIN x : DINT;` failed with *"Expected Colon"* on the line **below** the qualifier — an imported CODESYS project died pointing at the wrong place. Both are tokens now.
- **`RETAIN` on `VAR_INPUT` / `VAR_OUTPUT` is now allowed**, per IEC 61131-3 Table 13 and CODESYS. The old rule rejected function blocks that are valid everywhere else.
- **`RETAIN` inside a `FUNCTION` or `METHOD` was silently accepted.** Neither has an instance — a function is re-entered from scratch, a method's locals are stack slots — so the qualifier had nothing to describe and the user was left believing a value survived a power cycle. Now an error.
- **The qualifier is a `MANY`, not an `OPTION`**, so `VAR RETAIN PERSISTENT` (the form a converted project carries) parses. Contradictions are semantic errors with a source span rather than a parser complaint about a missing `END_VAR`.

## Decisions worth a look

**`PERSISTENT` folds into `isRetain` rather than being tracked separately.** CODESYS also keeps a PERSISTENT value across a program download; we don't implement that, so the honest mapping is the weaker guarantee both share. Splitting them would claim something nothing delivers. `IEC_COMPLIANCE.md` now says **Partial** for PERSISTENT.

**`NON_RETAIN` is recorded (`isNonRetain`) even though nothing branches on it.** It is the default spelled out — but dropping it would lose the qualifier for anything reproducing source from the AST (LSP formatter, `--decompile-lib`), and keeping it is what lets `RETAIN NON_RETAIN` be reported as the contradiction it is.

**The FUNCTION/METHOD check needed its own flag, not `scopeType`.** A method reports `"functionBlock"` there so its located variables are rejected the way an FB's are; overloading it would have changed that unrelated rule. The error deliberately names no scope — the only name in reach is the owning FB's, and RETAIN on the FB's own `VAR` *is* legal, so naming it would read as a contradiction.

**Two existing tests asserted the VAR_INPUT/VAR_OUTPUT restriction.** Inverted rather than deleted, so it cannot quietly return.

## Found while testing, deliberately NOT fixed here

The POU var-block AST builder does not map `VAR_EXTERNAL`, so a function block's external block arrives as `blockType: "VAR"` and slips past the RETAIN rule. **Pre-existing** — the previous rule listed `VAR_EXTERNAL` and was equally ineffective there — and fixing the mapping touches located-variable validation and the external-resolution pass, so it wants its own change. Program-scope `VAR_EXTERNAL RETAIN` *is* caught, and the test sits at that scope with a comment explaining why.

## Verification

Every accepted form compiles (`VAR_INPUT RETAIN`, `VAR_OUTPUT RETAIN`, `VAR RETAIN PERSISTENT`, `VAR NON_RETAIN`, `VAR PERSISTENT`, `VAR_GLOBAL RETAIN`) and every rejection reports with a usable message:

```
FUNCTION VAR RETAIN      RETAIN is not allowed in a FUNCTION or METHOD: there is no instance…
METHOD VAR RETAIN        (same, and does NOT blame the enclosing FB)
VAR_TEMP RETAIN          VAR_TEMP cannot be RETAIN
VAR_IN_OUT RETAIN        VAR_IN_OUT cannot be RETAIN
VAR_EXTERNAL RETAIN      VAR_EXTERNAL cannot be RETAIN     (program scope)
RETAIN + NON_RETAIN      Variable cannot be both RETAIN and NON_RETAIN
RETAIN + CONSTANT        Variable cannot be both RETAIN and CONSTANT
CONSTANT + NON_RETAIN    Variable cannot be both CONSTANT and NON_RETAIN
```

Full suite: **92 files, 2261 passed / 7 skipped** (up 14). Typecheck clean, no new lint warnings.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3