### PR TITLE
feat(retain): leaf-addressed retain table, blob format and shared marshaller

### DIFF
--- a/src/backend/codegen.ts
+++ b/src/backend/codegen.ts
@@ -317,12 +317,6 @@ export class CodeGenerator {
    *  gated here (fail-loud) until locked field/element/call codegen lands. */
   private compositeExternals: Set<string> = new Set();
 
-  /** Track retain variables per program for table generation */
-  private programRetainVars: Map<
-    string,
-    Array<{ name: string; typeName: string }>
-  > = new Map();
-
   /** Store AST for looking up program bodies when using project model */
   protected ast?: CompilationUnit;
 
@@ -2361,9 +2355,6 @@ export class CodeGenerator {
       }
     }
 
-    // Collect retain variables for table generation
-    const retainVars: Array<{ name: string; typeName: string }> = [];
-
     // Generate local variable members and collect located variables
     if (prog.varDeclarations.length > 0) {
       this.emitHeader("    // Local variables");
@@ -2408,16 +2399,6 @@ export class CodeGenerator {
 
         if (stLine !== undefined) {
           this.recordHeaderLineMapping(stLine, memberLine);
-        }
-
-        // Collect retain variables (cppType — same metadata-aware lookup
-        // as the member emission above, so inline arrays don't end up as
-        // IEC___INLINE_ARRAY_<T> in the retain table either).
-        if (decl.isRetain) {
-          retainVars.push({
-            name: decl.name,
-            typeName: cppType,
-          });
         }
       }
     }
@@ -2497,23 +2478,14 @@ export class CodeGenerator {
       this.emitHeader("#endif");
     }
 
-    // Generate retain variable support if there are retain variables
-    if (retainVars.length > 0) {
-      this.emitHeader("");
-      this.emitHeader("    // Retain variable support");
-      this.emitHeader(
-        `    static const RetainVarInfo __retain_vars[${retainVars.length}];`,
-      );
-      this.emitHeader(
-        `    const RetainVarInfo* getRetainVars() const override { return __retain_vars; }`,
-      );
-      this.emitHeader(
-        `    size_t getRetainCount() const override { return ${retainVars.length}; }`,
-      );
-
-      // Store retain vars for implementation file generation
-      this.programRetainVars.set(prog.name, retainVars);
-    }
+    // No per-program retain members are emitted. Retained leaves are listed
+    // once, project-wide, in `generated_debug.cpp`'s `retain_vars[]` — see
+    // backend/debug-table-gen.ts and runtime/include/iec_retain.hpp.
+    //
+    // `getRetainVars` / `getRetainCount` stay as no-op base methods on
+    // ProgramBase and are deliberately NOT overridden: the v4 runtime's ABI
+    // mirror pins their vtable positions, and renumbering would mis-dispatch
+    // run() for any program built against a different version.
 
     this.emitHeader("};");
     this.emitHeader("");
@@ -2634,27 +2606,6 @@ export class CodeGenerator {
     if (astProg) {
       this.recordLineMapping(astProg.sourceSpan.endLine, closingBraceLine);
     }
-
-    // Generate retain variable table if there are retain variables
-    this.generateRetainTable(`Program_${prog.name}`, prog.name);
-  }
-
-  /**
-   * Generate retain variable table for a class.
-   */
-  private generateRetainTable(className: string, progName: string): void {
-    const retainVars = this.programRetainVars.get(progName);
-    if (!retainVars || retainVars.length === 0) return;
-
-    this.emit(`// Retain variable table for ${className}`);
-    this.emit(`const RetainVarInfo ${className}::__retain_vars[] = {`);
-    for (const v of retainVars) {
-      this.emit(
-        `    {"${v.name}", offsetof(${className}, ${v.name}), sizeof(${v.typeName})},`,
-      );
-    }
-    this.emit("};");
-    this.emit("");
   }
 
   /**

--- a/src/backend/debug-table-gen.ts
+++ b/src/backend/debug-table-gen.ts
@@ -74,6 +74,8 @@ export type TagName = keyof typeof TAG;
 // would leak the cleared value into the following sibling.
 // ---------------------------------------------------------------------------
 export const LEAF_FLAG_READONLY = 1 << 0;
+/** Mirrors LEAF_FLAG_RETAIN in runtime/include/debug_table.hpp. */
+export const LEAF_FLAG_RETAIN = 1 << 1;
 
 /**
  * Render an entry's flags byte as C++.
@@ -84,9 +86,58 @@ export const LEAF_FLAG_READONLY = 1 << 0;
  * compile against a header that renamed the flag instead of silently setting
  * the wrong bit.
  */
+/**
+ * Apply one var block's qualifiers to the flags inherited from its container.
+ *
+ * RETAIN is inherited: declaring `VAR RETAIN inst : FB;` retains every leaf
+ * inside `inst`, which is the CODESYS rule. NON_RETAIN is how a member opts
+ * back out, so it CLEARS the bit rather than merely failing to set it — and
+ * that is exactly why the walk passes flags down as a parameter instead of
+ * mutating shared state: a cleared bit must not leak into the next sibling.
+ */
+function applyBlockFlags(
+  inherited: number,
+  block: { isConstant: boolean; isRetain: boolean; isNonRetain: boolean },
+): number {
+  let flags = inherited;
+  if (block.isConstant) flags |= LEAF_FLAG_READONLY;
+  if (block.isRetain) flags |= LEAF_FLAG_RETAIN;
+  if (block.isNonRetain) flags &= ~LEAF_FLAG_RETAIN;
+  return flags;
+}
+
+/**
+ * FNV-1a (32-bit) over the retain layout — the ordered `path|typeTag` of every
+ * retained leaf.
+ *
+ * Identity of the LAYOUT, deliberately not of the program: a body edit leaves
+ * this unchanged and retained values survive, while adding, removing, retyping
+ * or reordering a retained variable changes it and the stored blob is refused.
+ * The project MD5 would have discarded retained state on every unrelated edit.
+ *
+ * FNV-1a rather than a cryptographic digest because this is a collision-check
+ * against accident, not against an attacker, and it has to be computable in a
+ * few lines on an AVR as well as here.
+ */
+function retainLayoutHashOf(
+  vars: Array<{ path: string; tagName: TagName }>,
+): string {
+  let hash = 0x811c9dc5;
+  for (const v of vars) {
+    for (const ch of `${v.path}|${v.tagName}`) {
+      hash ^= ch.codePointAt(0) ?? 0;
+      // >>> 0 after the multiply: JS bitwise ops are on int32, and FNV needs the
+      // product truncated to 32 unsigned bits at every step.
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
 function flagsLiteral(flags: number): string {
   const names: string[] = [];
   if (flags & LEAF_FLAG_READONLY) names.push("LEAF_FLAG_READONLY");
+  if (flags & LEAF_FLAG_RETAIN) names.push("LEAF_FLAG_RETAIN");
   return names.length > 0 ? names.join(" | ") : "0";
 }
 
@@ -198,6 +249,12 @@ export interface DebugLeaf {
    * pinned to an older strucpp release.
    */
   readOnly?: true;
+  /**
+   * Present and `true` for a leaf declared `RETAIN` (or inherited from a
+   * retained function-block instance). Omitted otherwise — a project's map
+   * holds thousands of leaves and the flag is rare.
+   */
+  retain?: true;
 }
 
 export interface DebugMapV2 {
@@ -206,6 +263,26 @@ export interface DebugMapV2 {
   typeTags: Record<string, number>;
   arrays: Array<{ index: number; count: number }>;
   leaves: DebugLeaf[];
+  /**
+   * The retained leaves, in the order the retain blob packs them. Additive, so
+   * `version` stays at 2 — the editor's `debug-parser.ts` rejects anything else
+   * outright, and an older editor simply ignores this field.
+   */
+  retainVars?: Array<{
+    arrayIdx: number;
+    elemIdx: number;
+    path: string;
+    size: number;
+  }>;
+  /**
+   * Identity of the retain LAYOUT, not of the program.
+   *
+   * FNV-1a over `path|typeTag` for each retained leaf in table order, so a body
+   * edit keeps retained values while adding, removing, retyping or reordering a
+   * retained variable invalidates them. Keying on the program MD5 instead would
+   * discard retained state on every unrelated edit.
+   */
+  retainLayoutHash?: string;
 }
 
 export interface DebugTableResult {
@@ -326,6 +403,14 @@ export function generateDebugTable(
   // Buckets of entries — grown in order, flushed at program boundary or size cap.
   const arrays: Entry[][] = [[]];
   const leaves: DebugLeaf[] = [];
+  /** Retained leaves in walk order — the order the blob packs them. */
+  const retainVars: Array<{
+    arrayIdx: number;
+    elemIdx: number;
+    path: string;
+    size: number;
+    tagName: TagName;
+  }> = [];
   const skipped: Array<{ path: string; reason: string }> = [];
 
   const tail = (): Entry[] => arrays[arrays.length - 1]!;
@@ -358,7 +443,11 @@ export function generateDebugTable(
       type: tagName,
       size,
       ...(flags & LEAF_FLAG_READONLY ? { readOnly: true as const } : {}),
+      ...(flags & LEAF_FLAG_RETAIN ? { retain: true as const } : {}),
     });
+    if (flags & LEAF_FLAG_RETAIN) {
+      retainVars.push({ arrayIdx: arrIdx, elemIdx, path, size, tagName });
+    }
   };
 
   // visitTypeRef walks a TypeReference: elementary type → leaf, inline array
@@ -513,11 +602,10 @@ export function generateDebugTable(
             block.blockType === "VAR_IN_OUT"
           ) {
             // A `VAR CONSTANT` inside a function block is read-only for every
-            // instance of it, so the bit is OR-ed in here rather than only at
-            // the program level — otherwise `fb.LIMIT` stays writable while
-            // the program's own `LIMIT` is gated.
-            const memberFlags =
-              flags | (block.isConstant ? LEAF_FLAG_READONLY : 0);
+            // instance of it, and a `VAR RETAIN` member is retained in every
+            // instance, so the block's own qualifiers are folded in here rather
+            // than only at the program level.
+            const memberFlags = applyBlockFlags(flags, block);
             for (const fieldDecl of block.declarations) {
               for (const fieldName of fieldDecl.names) {
                 visitTypeRef(
@@ -685,7 +773,7 @@ export function generateDebugTable(
             key,
             `${varName}.value`,
             decl.type,
-            block.isConstant ? LEAF_FLAG_READONLY : 0,
+            applyBlockFlags(0, block),
           );
         }
       }
@@ -718,7 +806,7 @@ export function generateDebugTable(
             ) {
               continue;
             }
-            const declFlags = block.isConstant ? LEAF_FLAG_READONLY : 0;
+            const declFlags = applyBlockFlags(0, block);
             for (const decl of block.declarations) {
               visitVarDecl(basePath, baseCpp, decl, declFlags);
             }
@@ -736,13 +824,33 @@ export function generateDebugTable(
   if (arrays.length === 0) arrays.push([]);
 
   const configName = projectModel.configurations[0]?.name ?? "CONFIG0";
-  const debugTableCpp = renderCpp(arrays, configGlobal, configName);
+  const debugTableCpp = renderCpp(
+    arrays,
+    configGlobal,
+    configName,
+    retainVars,
+    retainLayoutHashOf(retainVars),
+  );
   const debugMap: DebugMapV2 = {
     version: 2,
     md5,
     typeTags: { ...TAG },
     arrays: arrays.map((a, i) => ({ index: i, count: a.length })),
     leaves,
+    // Omitted entirely when nothing is retained, so a project that uses no
+    // RETAIN carries no retain fields at all and the runtime's `count == 0`
+    // fast path is the only thing it ever sees.
+    ...(retainVars.length > 0
+      ? {
+          retainVars: retainVars.map(({ arrayIdx, elemIdx, path, size }) => ({
+            arrayIdx,
+            elemIdx,
+            path,
+            size,
+          })),
+          retainLayoutHash: retainLayoutHashOf(retainVars),
+        }
+      : {}),
   };
 
   return { debugTableCpp, debugMap, skipped };
@@ -756,6 +864,8 @@ function renderCpp(
   arrays: Entry[][],
   configGlobal: string,
   configName: string,
+  retainVars: Array<{ arrayIdx: number; elemIdx: number; path: string }>,
+  retainLayoutHash: string,
 ): string {
   const lines: string[] = [];
   lines.push("// SPDX-License-Identifier: GPL-3.0-or-later");
@@ -823,6 +933,40 @@ function renderCpp(
   lines.push("");
 
   lines.push(`const uint8_t debug_array_count = ${arrays.length};`);
+  lines.push("");
+
+  // --- Retain table --------------------------------------------------------
+  //
+  // Retained leaves addressed the same way the debugger addresses everything
+  // else: (arr, elem) into the tables above. No offsets, no sizeof — the host
+  // reads and writes each leaf through `handle_read` / `handle_write`, so it
+  // moves the VALUE and never the IECVar wrapper's forcing state, and a nested
+  // function-block member or a configuration global needs no special case.
+  //
+  // Order is the walk order, and it IS the blob's packing order.
+  lines.push("// Retained leaves, in the order the retain blob packs them.");
+  lines.push(
+    `const RetainVar retain_vars[${retainVars.length || 1}] STRUCPP_DEBUG_FLASH = {`,
+  );
+  if (retainVars.length === 0) {
+    lines.push("    { 0, 0 },  // placeholder — nothing is retained");
+  } else {
+    for (const v of retainVars) {
+      lines.push(`    { ${v.arrayIdx}, ${v.elemIdx} },  // ${v.path}`);
+    }
+  }
+  lines.push("};");
+  lines.push("");
+  lines.push(`const uint16_t retain_var_count = ${retainVars.length};`);
+  lines.push("");
+  lines.push(
+    "// Identity of the retain LAYOUT (ordered path|typeTag), not of the",
+  );
+  lines.push(
+    "// program: a body edit keeps retained values, a declaration change",
+  );
+  lines.push("// invalidates them.");
+  lines.push(`const uint32_t retain_layout_hash = 0x${retainLayoutHash};`);
   lines.push("");
   lines.push("} } // namespace strucpp::debug");
   return lines.join("\n") + "\n";

--- a/src/runtime/include/debug_table.hpp
+++ b/src/runtime/include/debug_table.hpp
@@ -103,6 +103,18 @@ enum TypeTag : uint8_t {
 // ---------------------------------------------------------------------------
 constexpr uint8_t LEAF_FLAG_READONLY = 1 << 0;
 
+// RETAIN marks a leaf whose value must survive a power cycle. Set for a
+// variable declared under `VAR RETAIN` (or PERSISTENT), and inherited by every
+// leaf beneath a retained function-block instance unless that member spells
+// NON_RETAIN.
+//
+// The retain walk does not read this bit — `retainVars[]` already lists exactly
+// the retained leaves, which is cheaper than scanning the whole table. It is
+// emitted because it costs nothing (the byte exists either way) and it makes a
+// generated table self-describing: a reviewer or a diagnostic dump can see
+// which leaves are retained without cross-referencing a second array.
+constexpr uint8_t LEAF_FLAG_RETAIN = 1 << 1;
+
 // ---------------------------------------------------------------------------
 // Debug entry: one per leaf variable.  Layout is ABI; see notes in
 // debug_dispatch.hpp's runtime dispatch for the per-platform size:
@@ -146,5 +158,31 @@ struct Entry {
 extern const Entry* const debug_arrays[]       STRUCPP_DEBUG_FLASH;
 extern const uint16_t     debug_array_counts[] STRUCPP_DEBUG_FLASH;
 extern const uint8_t      debug_array_count;
+
+// ---------------------------------------------------------------------------
+// Retain table.
+//
+// A retained leaf is addressed the same way the debugger addresses everything
+// else: by (arr, elem) into the tables above. No offsets and no sizeof, which
+// is what keeps the retain path correct where an offset-based descriptor was
+// not — the host moves the VALUE through `handle_read` / `handle_write` rather
+// than a memory region, so the IECVar wrapper's forcing state is never
+// persisted, and a nested function-block member or a configuration global
+// needs no special case.
+//
+// Order is the codegen's leaf-walk order, and it IS the order the retain blob
+// packs values in. Never reorder without changing the layout hash.
+// ---------------------------------------------------------------------------
+struct RetainVar {
+    uint8_t  arr;
+    uint16_t elem;
+};
+
+extern const RetainVar retain_vars[]      STRUCPP_DEBUG_FLASH;
+extern const uint16_t  retain_var_count;
+
+// Identity of the retain LAYOUT (ordered path|typeTag), not of the program: a
+// body edit keeps retained values, a declaration change invalidates them.
+extern const uint32_t  retain_layout_hash;
 
 } } // namespace strucpp::debug

--- a/src/runtime/include/iec_retain.hpp
+++ b/src/runtime/include/iec_retain.hpp
@@ -3,81 +3,300 @@
 // This file is part of the STruC++ Runtime Library and is covered by the
 // STruC++ Runtime Library Exception. See COPYING.RUNTIME for details.
 /**
- * STruC++ Runtime - Retain Variable Support
+ * STruC++ Runtime — retain-variable marshalling.
  *
- * This header defines the types and structures needed for retain variables
- * that preserve their values across power cycles.
+ * One implementation of the blob format and the pack/unpack walk, shared by
+ * every host. Both the Arduino firmware and the OpenPLC v4 daemon already
+ * vendor this directory, so neither writes packing code of its own and the two
+ * cannot drift: a blob written by a firmware is readable by a daemon built from
+ * the same compiler.
  *
- * The compiler generates a descriptor array for each program/function block
- * containing retain variables. The runtime uses this array to save/restore
- * values to non-volatile storage.
+ * WHAT THIS IS NOT
+ * ----------------
+ * It is not storage, and it decides nothing about persistence. It turns the
+ * retained leaves into a byte array and back. Where those bytes live — EEPROM,
+ * NVS, FRAM, battery-backed SRAM, a file — and how often they are written is
+ * entirely the platform driver's business.
+ *
+ * WHY (arr, elem) AND NOT AN OFFSET
+ * ---------------------------------
+ * An earlier design described each retained variable as
+ * `{ name, offsetof(Class, member), sizeof(IECVar<T>) }`. Three things were
+ * wrong with it, and all three go away here:
+ *
+ *   - `sizeof(IECVar<T>)` is the whole wrapper. A DINT measures 12 bytes, not
+ *     4, and the extra bytes are `forced_` and `forced_value_` — so persisting
+ *     that region carried the debugger's forcing state across a power cycle.
+ *     Here every value moves through `handle_read` / `handle_write`, which
+ *     touch the value and nothing else.
+ *   - `offsetof` on a program class is `offsetof` on a non-standard-layout type
+ *     (it derives from ProgramBase and has virtuals) — conditionally supported,
+ *     and it warns.
+ *   - It could only describe members of a PROGRAM. A retained variable inside a
+ *     nested function block, or a retained CONFIGURATION global, had no
+ *     representation at all. Leaf indices already cover both.
+ *
+ * ORDER IS THE CONTRACT. `retain_vars[]` is emitted in the codegen's leaf-walk
+ * order and the payload packs values in exactly that order, so the blob needs
+ * no per-entry addressing. `retain_layout_hash` is what makes that safe: it
+ * changes when the ordered set of retained leaves changes, and a blob whose
+ * hash disagrees is refused rather than unpacked into the wrong variables.
+ *
+ * WIDTHS COME FROM THE RUNTIME, NEVER FROM A MANIFEST. `size_of(arr, elem)`
+ * reports what the debug transport actually moves for that leaf, which is not
+ * the declared width: a STRING is a fixed 127 bytes regardless of `STRING(20)`.
+ * Sizing the payload from anything else desynchronises it from what the target
+ * can read and write.
  */
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "debug_table.hpp"
 
 namespace strucpp {
+namespace retain {
 
 // =============================================================================
-// Retain Variable Descriptor
+// Blob format
+// =============================================================================
+//
+//   off  size  field
+//   ---  ----  -----------------------------------------------------------
+//     0     2  magic         0x4F52 ('O','R'), little-endian
+//     2     1  format        FORMAT_VERSION
+//     3     1  flags         reserved, must be 0
+//     4     4  layout_hash   strucpp::debug::retain_layout_hash
+//     8     2  payload_len   packed value bytes that follow
+//    10     4  crc32         over bytes [0,10) + payload
+//   ---  ----  -----------------------------------------------------------
+//    14     N  payload       values in retain_vars[] order, natural width,
+//                            no padding and no per-entry addressing
+//
+// Fourteen bytes of overhead, once. Everything after it is payload — no paths,
+// no indices, no type tags. The mapping from byte range to variable lives in
+// the compiled program, where storage is free, and not in the retain region,
+// where it is scarce: a 4 KB EEPROM holds around a thousand retained DINTs.
+
+constexpr uint16_t MAGIC          = 0x4F52;
+constexpr uint8_t  FORMAT_VERSION = 1;
+constexpr uint16_t HEADER_SIZE    = 14;
+
+/** Outcome of a load. Anything other than `Ok` leaves every variable at its
+ *  declared initial value, which is the correct cold-start behaviour. */
+enum class LoadResult : uint8_t {
+    Ok = 0,
+    /** Nothing stored yet, or the store was cleared. First boot looks like this. */
+    Empty,
+    /** Not a retain blob (or a torn write that lost the header). */
+    BadMagic,
+    /** Written by a different format version. */
+    BadFormat,
+    /** Header and payload disagree — a torn or corrupted write. */
+    BadCrc,
+    /** Written by a program whose retained variables differ. Refused, not
+     *  unpacked: the bytes would land in the wrong variables. */
+    StaleLayout,
+    /** Payload shorter than this program's retained leaves need. */
+    Truncated,
+};
+
+// -----------------------------------------------------------------------------
+// Host-supplied leaf accessors.
+//
+// Function pointers, so one implementation serves both hosts. The Arduino glue
+// passes `strucpp::debug::handle_*` directly. The v4 daemon passes its dlsym'd
+// thunks — and for the write it passes the path that routes a LOCATED leaf
+// through the image journal, because poking such a leaf's IECVar directly is
+// undone by the next copy-in from the process image.
+// -----------------------------------------------------------------------------
+
+/** Read one leaf's value. Returns bytes written, 0 on failure. */
+using ReadLeaf = uint16_t (*)(uint8_t arr, uint16_t elem, uint8_t* dest);
+
+/** Write one leaf's value. Must be a plain write — NEVER a force. Restoring a
+ *  retained value must not pin it: the program has to be able to move it on the
+ *  very next scan, and an operator's force must stay authoritative. */
+using WriteLeaf = uint8_t (*)(uint8_t arr, uint16_t elem, const uint8_t* bytes, uint16_t len);
+
+/** Bytes this leaf occupies on the debug transport. */
+using SizeLeaf = uint16_t (*)(uint8_t arr, uint16_t elem);
+
+// =============================================================================
+// crc32
 // =============================================================================
 
 /**
- * Metadata for a retain variable.
- * Used by runtime to save/restore values across power cycles.
- *
- * The descriptor uses offset instead of pointer to allow:
- * - constexpr initialization (compile-time constant)
- * - Correct behavior with multiple instances of the same class
- * - Simple serialization (offset + size = memory region)
+ * Bitwise CRC-32 (IEEE 802.3, reflected). No lookup table on purpose: a 1 KB
+ * table is real money on a 2 KB-SRAM part, and this runs once per save over a
+ * blob measured in tens or hundreds of bytes.
  */
-struct RetainVarInfo {
-    const char* name;      ///< Variable name (for diagnostics/debugging)
-    size_t offset;         ///< Offset from object base (use with offsetof)
-    size_t size;           ///< Size in bytes for serialization
-};
+inline uint32_t crc32(const uint8_t* data, size_t len, uint32_t seed = 0xFFFFFFFFu) noexcept {
+    uint32_t crc = seed;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (uint8_t bit = 0; bit < 8; ++bit) {
+            crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+        }
+    }
+    return crc;
+}
 
 // =============================================================================
-// Retain Storage Interface (for Phase 6 implementation)
+// Little-endian field access
+// =============================================================================
+//
+// Explicit byte-at-a-time, not a struct cast: the blob may be handed over
+// unaligned (a driver's read buffer, an offset into a flash page), and AVR and
+// ARM disagree about what that costs. Little-endian is fixed by the format so a
+// blob stays portable between a target and a host-side tool.
+
+inline void put_u16(uint8_t* p, uint16_t v) noexcept {
+    p[0] = static_cast<uint8_t>(v & 0xFFu);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFFu);
+}
+
+inline void put_u32(uint8_t* p, uint32_t v) noexcept {
+    p[0] = static_cast<uint8_t>(v & 0xFFu);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFFu);
+    p[2] = static_cast<uint8_t>((v >> 16) & 0xFFu);
+    p[3] = static_cast<uint8_t>((v >> 24) & 0xFFu);
+}
+
+inline uint16_t get_u16(const uint8_t* p) noexcept {
+    return static_cast<uint16_t>(static_cast<uint16_t>(p[0]) |
+                                 static_cast<uint16_t>(static_cast<uint16_t>(p[1]) << 8));
+}
+
+inline uint32_t get_u32(const uint8_t* p) noexcept {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// =============================================================================
+// Sizing
+// =============================================================================
+
+/** Packed payload size for this program's retained leaves. */
+inline size_t payload_size(SizeLeaf size_of) noexcept {
+    size_t total = 0;
+    for (uint16_t i = 0; i < debug::retain_var_count; ++i) {
+        total += size_of(debug::retain_vars[i].arr, debug::retain_vars[i].elem);
+    }
+    return total;
+}
+
+/**
+ * Total blob size, header included. Zero when nothing is retained — a host can
+ * use that to skip the whole path, and a driver to skip provisioning storage.
+ */
+inline size_t blob_size(SizeLeaf size_of) noexcept {
+    if (debug::retain_var_count == 0) return 0;
+    return HEADER_SIZE + payload_size(size_of);
+}
+
+// =============================================================================
+// Pack
 // =============================================================================
 
 /**
- * Abstract interface for retain variable persistence.
- * Implemented by the runtime (Phase 6) to provide actual storage.
+ * Serialise every retained leaf into `out`.
  *
- * Example implementations:
- * - File-based storage for development/testing
- * - NVRAM for embedded systems
- * - Battery-backed RAM for industrial PLCs
+ * Returns bytes written, or 0 if `cap` is too small or nothing is retained.
+ * Allocation-free and safe to call from a scan-cycle context: a bounded walk
+ * plus one crc pass.
  */
-class RetainStorage {
-public:
-    virtual ~RetainStorage() = default;
+inline size_t pack(uint8_t* out, size_t cap, ReadLeaf read_leaf, SizeLeaf size_of) noexcept {
+    if (debug::retain_var_count == 0) return 0;
 
-    /**
-     * Save retain variables to persistent storage.
-     *
-     * @param instance  Pointer to the program/FB instance
-     * @param vars      Array of retain variable descriptors
-     * @param count     Number of retain variables
-     */
-    virtual void save(const void* instance,
-                      const RetainVarInfo* vars,
-                      size_t count) = 0;
+    const size_t payload = payload_size(size_of);
+    const size_t total   = static_cast<size_t>(HEADER_SIZE) + payload;
+    if (out == nullptr || cap < total) return 0;
 
-    /**
-     * Restore retain variables from persistent storage.
-     *
-     * @param instance  Pointer to the program/FB instance
-     * @param vars      Array of retain variable descriptors
-     * @param count     Number of retain variables
-     * @return true if restore was successful, false if no saved data
-     */
-    virtual bool restore(void* instance,
-                         const RetainVarInfo* vars,
-                         size_t count) = 0;
-};
+    size_t at = HEADER_SIZE;
+    for (uint16_t i = 0; i < debug::retain_var_count; ++i) {
+        const uint8_t  arr   = debug::retain_vars[i].arr;
+        const uint16_t elem  = debug::retain_vars[i].elem;
+        const uint16_t width = size_of(arr, elem);
+        if (width == 0) continue;
+        // A short read leaves that leaf's bytes zeroed rather than aborting the
+        // whole save: one unreadable leaf must not cost every other retained
+        // value in the blob.
+        if (read_leaf(arr, elem, out + at) != width) {
+            memset(out + at, 0, width);
+        }
+        at += width;
+    }
 
+    put_u16(out + 0, MAGIC);
+    out[2] = FORMAT_VERSION;
+    out[3] = 0;  // flags, reserved
+    put_u32(out + 4, debug::retain_layout_hash);
+    put_u16(out + 8, static_cast<uint16_t>(payload));
+    // crc covers the header so far plus the payload; the crc field itself
+    // (offset 10..13) is excluded, which is why it sits last in the header.
+    uint32_t crc = crc32(out, 10);
+    crc          = crc32(out + HEADER_SIZE, payload, crc);
+    put_u32(out + 10, crc ^ 0xFFFFFFFFu);
+
+    return total;
+}
+
+// =============================================================================
+// Unpack
+// =============================================================================
+
+/**
+ * Restore every retained leaf from `blob`.
+ *
+ * Validates before writing anything, so a corrupt or stale store degrades to a
+ * cold start rather than to plausible-looking garbage in a running machine.
+ *
+ * `write_leaf` must be a plain write. See {@link WriteLeaf}.
+ */
+inline LoadResult unpack(const uint8_t* blob,
+                         size_t          len,
+                         WriteLeaf       write_leaf,
+                         SizeLeaf        size_of) noexcept {
+    if (debug::retain_var_count == 0) return LoadResult::Ok;  // nothing to do
+    if (blob == nullptr || len == 0) return LoadResult::Empty;
+    if (len < HEADER_SIZE) return LoadResult::Truncated;
+
+    if (get_u16(blob) != MAGIC) return LoadResult::BadMagic;
+    if (blob[2] != FORMAT_VERSION) return LoadResult::BadFormat;
+
+    const uint16_t payload = get_u16(blob + 8);
+    if (len < static_cast<size_t>(HEADER_SIZE) + payload) return LoadResult::Truncated;
+
+    uint32_t crc = crc32(blob, 10);
+    crc          = crc32(blob + HEADER_SIZE, payload, crc);
+    if ((crc ^ 0xFFFFFFFFu) != get_u32(blob + 10)) return LoadResult::BadCrc;
+
+    // Checked AFTER the crc: a stale-layout answer only means something once
+    // the bytes are known to be intact, and reporting StaleLayout for a torn
+    // write would send someone looking for a program change that never
+    // happened.
+    if (get_u32(blob + 4) != debug::retain_layout_hash) return LoadResult::StaleLayout;
+
+    if (payload != payload_size(size_of)) return LoadResult::Truncated;
+
+    size_t at = HEADER_SIZE;
+    for (uint16_t i = 0; i < debug::retain_var_count; ++i) {
+        const uint8_t  arr   = debug::retain_vars[i].arr;
+        const uint16_t elem  = debug::retain_vars[i].elem;
+        const uint16_t width = size_of(arr, elem);
+        if (width == 0) continue;
+        // A refused write is tolerated, not fatal: a leaf that became read-only
+        // (declared CONSTANT since, with the layout otherwise unchanged) must
+        // not stop the remaining values from being restored.
+        write_leaf(arr, elem, blob + at, width);
+        at += width;
+    }
+    return LoadResult::Ok;
+}
+
+}  // namespace retain
 }  // namespace strucpp

--- a/src/runtime/include/iec_std_lib.hpp
+++ b/src/runtime/include/iec_std_lib.hpp
@@ -73,7 +73,10 @@ namespace strucpp {
 // Base Classes for Runtime
 // =============================================================================
 
-// Forward declaration for retain support
+// Forward-declared for the two RESERVED vtable slots below. The type no longer
+// exists as a definition anywhere — retained leaves are listed project-wide in
+// generated_debug.cpp's `retain_vars[]` (see iec_retain.hpp) — but the
+// declaration has to stay so the slots keep their signatures and positions.
 struct RetainVarInfo;
 
 /**
@@ -86,18 +89,18 @@ struct ProgramBase {
     /** Execute one cycle of the program */
     virtual void run() = 0;
 
-    /**
-     * Get the array of retain variable descriptors.
-     * Override in generated code if the program has RETAIN variables.
-     * @return Pointer to static array, or nullptr if no retain variables
-     */
+    // RESERVED vtable slots 2 and 3, formerly the per-program retain
+    // descriptor table. Retained leaves now live in one project-wide
+    // `retain_vars[]` addressed by debug-table (arr, elem) — see
+    // iec_retain.hpp for why offsets could not work — so generated code no
+    // longer overrides these and nothing calls them.
+    //
+    // They are KEPT, not deleted. The OpenPLC v4 runtime mirrors this vtable
+    // by position (core/src/lib/strucpp_abi.hpp) to dispatch run() across a
+    // .so boundary; removing a slot would shift every slot after it and
+    // mis-dispatch run() for any program built against a different version.
+    // Same reasoning as the dead sync_in / sync_out slots below.
     virtual const RetainVarInfo* getRetainVars() const { return nullptr; }
-
-    /**
-     * Get the number of retain variables.
-     * Override in generated code if the program has RETAIN variables.
-     * @return Count of retain variables
-     */
     virtual size_t getRetainCount() const { return 0; }
 
     // -------------------------------------------------------------------------

--- a/tests/backend/debug-table-gen.test.ts
+++ b/tests/backend/debug-table-gen.test.ts
@@ -757,3 +757,170 @@ END_PROGRAM${CFG_RO}`,
     expect(map.version).toBe(2);
   });
 });
+
+describe("retain table", () => {
+  const CFG_R = `
+CONFIGURATION Config0
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`;
+
+  const mapOf = (src: string) => {
+    const r = compile(src, { headerFileName: "generated.hpp" });
+    expect(r.errors.map((e) => e.message)).toEqual([]);
+    const byPath = new Map(r.debugMap!.leaves.map((l) => [l.path, l]));
+    return { map: r.debugMap!, byPath, cpp: r.debugTableCpp! };
+  };
+
+  it("lists retained leaves in walk order, and nothing else", () => {
+    const { map, cpp } = mapOf(
+      `PROGRAM Main
+VAR RETAIN boots : DINT; END_VAR
+VAR live : DINT; END_VAR
+  live := boots;
+END_PROGRAM${CFG_R}`,
+    );
+    expect(map.retainVars?.map((v) => v.path)).toEqual(["INSTANCE0.BOOTS"]);
+    expect(cpp).toContain("const uint16_t retain_var_count = 1;");
+    // Addressed by (arr, elem) — no offsetof, no sizeof.
+    expect(cpp).not.toContain("offsetof");
+    expect(cpp).toMatch(/\{ 0, 0 \},\s*\/\/ INSTANCE0\.BOOTS/);
+  });
+
+  it("omits every retain field when nothing is retained", () => {
+    // A project with no RETAIN must carry no retain manifest at all, so the
+    // runtime's `count == 0` fast path is the only thing it ever sees.
+    const { map } = mapOf(
+      `PROGRAM Main
+VAR live : DINT; END_VAR
+  live := 1;
+END_PROGRAM${CFG_R}`,
+    );
+    expect(map.retainVars).toBeUndefined();
+    expect(map.retainLayoutHash).toBeUndefined();
+  });
+
+  it("retains a whole function-block subtree when the instance is RETAIN", () => {
+    const { byPath } = mapOf(
+      `FUNCTION_BLOCK Inner
+VAR_INPUT en : BOOL; END_VAR
+VAR ticks : DINT; END_VAR
+  IF en THEN ticks := ticks + 1; END_IF;
+END_FUNCTION_BLOCK
+PROGRAM Main
+VAR RETAIN held : Inner; END_VAR
+VAR loose : Inner; END_VAR
+  held(); loose();
+END_PROGRAM${CFG_R}`,
+    );
+    // Inherited two members deep…
+    expect(byPath.get("INSTANCE0.HELD.EN")?.retain).toBe(true);
+    expect(byPath.get("INSTANCE0.HELD.TICKS")?.retain).toBe(true);
+    // …and not leaked to a sibling instance that was not declared RETAIN.
+    expect(byPath.get("INSTANCE0.LOOSE.EN")).not.toHaveProperty("retain");
+    expect(byPath.get("INSTANCE0.LOOSE.TICKS")).not.toHaveProperty("retain");
+  });
+
+  it("retains a function block's own VAR RETAIN in every instance", () => {
+    const { byPath } = mapOf(
+      `FUNCTION_BLOCK Counter
+VAR RETAIN total : DINT; END_VAR
+VAR scratch : DINT; END_VAR
+  total := total + 1; scratch := 0;
+END_FUNCTION_BLOCK
+PROGRAM Main
+VAR c : Counter; END_VAR
+  c();
+END_PROGRAM${CFG_R}`,
+    );
+    expect(byPath.get("INSTANCE0.C.TOTAL")?.retain).toBe(true);
+    expect(byPath.get("INSTANCE0.C.SCRATCH")).not.toHaveProperty("retain");
+  });
+
+  it("lets NON_RETAIN opt a member out of a retained container", () => {
+    // The case the walk threads flags as a PARAMETER for: the bit is cleared
+    // partway down a subtree, and must not leak into the following sibling.
+    const { byPath } = mapOf(
+      `FUNCTION_BLOCK Inner
+VAR NON_RETAIN scratch : DINT; END_VAR
+VAR kept : DINT; END_VAR
+  scratch := 1; kept := 2;
+END_FUNCTION_BLOCK
+PROGRAM Main
+VAR RETAIN held : Inner; END_VAR
+VAR RETAIN after : DINT; END_VAR
+  held();
+END_PROGRAM${CFG_R}`,
+    );
+    expect(byPath.get("INSTANCE0.HELD.SCRATCH")).not.toHaveProperty("retain");
+    expect(byPath.get("INSTANCE0.HELD.KEPT")?.retain).toBe(true);
+    // The sibling declared after the opt-out is still retained.
+    expect(byPath.get("INSTANCE0.AFTER")?.retain).toBe(true);
+  });
+
+  it("retains a CONFIGURATION VAR_GLOBAL and not its plain sibling", () => {
+    const { byPath } = mapOf(
+      `PROGRAM Main
+VAR_EXTERNAL g_hours : DINT; g_live : DINT; END_VAR
+  g_live := g_hours;
+END_PROGRAM
+CONFIGURATION Config0
+  VAR_GLOBAL RETAIN g_hours : DINT; END_VAR
+  VAR_GLOBAL g_live : DINT; END_VAR
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`,
+    );
+    expect(byPath.get("G_HOURS")?.retain).toBe(true);
+    expect(byPath.get("G_LIVE")).not.toHaveProperty("retain");
+  });
+
+  it("expands every element of a retained array", () => {
+    const { byPath, map } = mapOf(
+      `PROGRAM Main
+VAR RETAIN log : ARRAY[0..2] OF DINT; END_VAR
+  log[0] := 1;
+END_PROGRAM${CFG_R}`,
+    );
+    for (const i of [0, 1, 2]) {
+      expect(byPath.get(`INSTANCE0.LOG[${i}]`)?.retain).toBe(true);
+    }
+    expect(map.retainVars).toHaveLength(3);
+  });
+
+  describe("layout hash", () => {
+    const hashOf = (vars: string, body: string) =>
+      mapOf(`PROGRAM Main
+${vars}
+  ${body}
+END_PROGRAM${CFG_R}`).map.retainLayoutHash;
+
+    it("is stable across a body-only edit — retained values survive it", () => {
+      const vars = "VAR RETAIN a : DINT; b : DINT; END_VAR";
+      expect(hashOf(vars, "a := 1;")).toBe(hashOf(vars, "a := 2; b := 3;"));
+    });
+
+    it("changes when a retained variable is added", () => {
+      expect(hashOf("VAR RETAIN a : DINT; END_VAR", "a := 1;")).not.toBe(
+        hashOf("VAR RETAIN a : DINT; b : DINT; END_VAR", "a := 1;"),
+      );
+    });
+
+    it("changes when a retained variable is retyped", () => {
+      expect(hashOf("VAR RETAIN a : DINT; END_VAR", "a := 1;")).not.toBe(
+        hashOf("VAR RETAIN a : INT; END_VAR", "a := 1;"),
+      );
+    });
+
+    it("changes when retained variables are reordered", () => {
+      // Order is the blob's packing order, so a swap has to invalidate it.
+      expect(hashOf("VAR RETAIN a : DINT; b : INT; END_VAR", "a := 1;")).not.toBe(
+        hashOf("VAR RETAIN b : INT; a : DINT; END_VAR", "a := 1;"),
+      );
+    });
+  });
+});

--- a/tests/integration/cpp-compile.test.ts
+++ b/tests/integration/cpp-compile.test.ts
@@ -584,12 +584,13 @@ describeIfGpp('C++ Compilation Tests', () => {
     const result = compile(source);
     expect(result.success).toBe(true);
 
-    // Verify retain table is generated
-    expect(result.headerCode).toContain('__retain_vars');
-    expect(result.headerCode).toContain('getRetainVars');
-    expect(result.headerCode).toContain('getRetainCount');
-    expect(result.cppCode).toContain('RetainVarInfo');
-    // Variable names in retain table are uppercased (COUNTER, LAST_STATE)
+    // The per-program `RetainVarInfo __retain_vars[]` is gone — retained
+    // leaves are listed project-wide in generated_debug.cpp now (see
+    // iec_retain.hpp for why offsets could not work). What this test still
+    // guards is that a program declaring RETAIN produces C++ that COMPILES;
+    // the retain table's own contents and round-trip are covered in
+    // debug-table-gen.test.ts and the retain round-trip test below.
+    expect(result.headerCode).not.toContain('__retain_vars');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'retain_vars');
     expect(cppResult.success).toBe(true);
@@ -614,9 +615,11 @@ describeIfGpp('C++ Compilation Tests', () => {
 
     // Verify const qualifier
     expect(result.headerCode).toContain('const IEC_INT MAX_VALUE');
-    // Verify retain table (only for retained vars)
-    expect(result.headerCode).toContain('__retain_vars[1]');
-    expect(result.cppCode).toContain('ACCUMULATED');
+    // Both members are plain declarations now: CONSTANT is a `const`
+    // qualifier, and RETAIN adds nothing to the class — the retained leaf is
+    // listed in generated_debug.cpp instead.
+    expect(result.headerCode).toContain('IEC_DINT ACCUMULATED;');
+    expect(result.headerCode).not.toContain('__retain_vars');
 
     const cppResult = compileWithGpp(result.headerCode, result.cppCode, 'mixed_modifiers');
     expect(cppResult.success).toBe(true);

--- a/tests/integration/debug-table-cpp.test.ts
+++ b/tests/integration/debug-table-cpp.test.ts
@@ -413,3 +413,139 @@ int main() {
     expect(execSync(`"${bin}"`, { encoding: "utf-8" }).trim()).toBe("ALL_OK");
   });
 });
+
+/**
+ * The retain marshaller has to WORK, not just compile.
+ *
+ * `iec_retain.hpp` is shared source: the Arduino firmware and the OpenPLC v4
+ * daemon both vendor it, so a bug here is a bug on every target at once, and a
+ * blob written by one has to be readable by the other. That makes a real
+ * pack → wipe → unpack round-trip the only test worth having — and it is also
+ * the only way to check the properties that matter most and are invisible to a
+ * compile: that a non-retained variable is left alone, that restore does not
+ * FORCE anything, and that a corrupt or stale blob is refused rather than
+ * unpacked into the wrong variables.
+ */
+describeIfGpp("retain blob round-trips through the real runtime", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "strucpp-retain-"));
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("saves, wipes and restores every retained leaf and nothing more", () => {
+    const result = compile(
+      `FUNCTION_BLOCK Inner
+VAR_INPUT en : BOOL; END_VAR
+VAR RETAIN ticks : DINT; END_VAR
+VAR NON_RETAIN scratch : DINT; END_VAR
+  IF en THEN ticks := ticks + 1; END_IF;
+  scratch := 1;
+END_FUNCTION_BLOCK
+PROGRAM Main
+VAR RETAIN held : Inner; END_VAR
+VAR loose : Inner; END_VAR
+VAR RETAIN boots : DINT; END_VAR
+  held(); loose();
+END_PROGRAM
+CONFIGURATION Config0
+  VAR_GLOBAL RETAIN g_hours : DINT; END_VAR
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`,
+      { headerFileName: "generated.hpp" },
+    );
+    expect(result.errors.map((e) => e.message)).toEqual([]);
+
+    const dir = path.join(tempDir, "roundtrip");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "generated.hpp"), result.headerCode);
+    fs.writeFileSync(path.join(dir, "generated.cpp"), result.cppCode);
+    fs.writeFileSync(path.join(dir, "generated_debug.cpp"), result.debugTableCpp!);
+
+    fs.writeFileSync(
+      path.join(dir, "main.cpp"),
+      `#include "generated.hpp"
+#include "debug_dispatch.hpp"
+#include "iec_retain.hpp"
+#include <cstdio>
+#include <cstring>
+strucpp::Configuration_CONFIG0 g_config;
+using namespace strucpp;
+static int fails = 0;
+static void chk(const char* what, bool ok) { if (!ok) { printf("FAIL %s\\n", what); ++fails; } }
+static uint16_t rd(uint8_t a, uint16_t e, uint8_t* d) { return debug::handle_read(a, e, d); }
+static uint8_t  wr(uint8_t a, uint16_t e, const uint8_t* b, uint16_t n) { return debug::handle_write(a, e, b, n); }
+static uint16_t sz(uint8_t a, uint16_t e) { return debug::handle_size(a, e); }
+
+int main() {
+  chk("something is retained", debug::retain_var_count > 0);
+  chk("blob is header + payload", retain::blob_size(sz) == retain::HEADER_SIZE + retain::payload_size(sz));
+
+  g_config.INSTANCE0.BOOTS = 4242;
+  g_config.INSTANCE0.HELD.TICKS = 777;
+  g_config.INSTANCE0.LOOSE.TICKS = 555;   // FB-local RETAIN in a NON-retained instance
+  G_HOURS.value = 99;
+
+  unsigned char blob[512] = {0};
+  size_t n = retain::pack(blob, sizeof(blob), rd, sz);
+  chk("packed", n == retain::blob_size(sz));
+
+  // A power cycle: every value back to zero.
+  g_config.INSTANCE0.BOOTS = 0;
+  g_config.INSTANCE0.HELD.TICKS = 0;
+  g_config.INSTANCE0.LOOSE.TICKS = 0;
+  G_HOURS.value = 0;
+  // Not retained — must NOT be resurrected.
+  g_config.INSTANCE0.HELD.SCRATCH = 31337;
+
+  chk("unpack ok", retain::unpack(blob, n, wr, sz) == retain::LoadResult::Ok);
+  chk("program local", (int)g_config.INSTANCE0.BOOTS == 4242);
+  chk("inherited fb member", (int)g_config.INSTANCE0.HELD.TICKS == 777);
+  chk("fb-local retain in non-retained instance", (int)g_config.INSTANCE0.LOOSE.TICKS == 555);
+  chk("configuration global", (int)G_HOURS.value == 99);
+  chk("NON_RETAIN left alone", (int)g_config.INSTANCE0.HELD.SCRATCH == 31337);
+  // Restore is a plain write: forcing would pin the value and stop the program
+  // moving it on the next scan.
+  chk("restore did not force", !g_config.INSTANCE0.BOOTS.is_forced());
+
+  unsigned char bad[512];
+  memcpy(bad, blob, n); bad[retain::HEADER_SIZE] ^= 0xFF;
+  chk("corrupt payload refused", retain::unpack(bad, n, wr, sz) == retain::LoadResult::BadCrc);
+
+  // Flip the layout hash and re-crc, so ONLY the layout differs.
+  memcpy(bad, blob, n); bad[4] ^= 0x01;
+  { uint32_t c = retain::crc32(bad, 10);
+    c = retain::crc32(bad + retain::HEADER_SIZE, retain::get_u16(bad + 8), c);
+    retain::put_u32(bad + 10, c ^ 0xFFFFFFFFu); }
+  chk("stale layout refused", retain::unpack(bad, n, wr, sz) == retain::LoadResult::StaleLayout);
+
+  memcpy(bad, blob, n); bad[0] ^= 0xFF;
+  chk("bad magic refused", retain::unpack(bad, n, wr, sz) == retain::LoadResult::BadMagic);
+  chk("empty store is Empty", retain::unpack(blob, 0, wr, sz) == retain::LoadResult::Empty);
+  chk("short blob is Truncated", retain::unpack(blob, retain::HEADER_SIZE - 1, wr, sz) == retain::LoadResult::Truncated);
+
+  printf(fails ? "FAILURES=%d\\n" : "ALL_OK\\n", fails);
+  return fails ? 1 : 0;
+}
+`,
+    );
+
+    const bin = path.join(dir, "retain");
+    execSync(
+      `g++ -std=c++17 -I"${RUNTIME_INCLUDE}" -I"${dir}" -o "${bin}" ` +
+        `"${path.join(dir, "main.cpp")}" "${path.join(dir, "generated.cpp")}" ` +
+        `"${path.join(dir, "generated_debug.cpp")}"`,
+      { encoding: "utf-8" },
+    );
+    expect(execSync(`"${bin}"`, { encoding: "utf-8" }).trim()).toBe("ALL_OK");
+  });
+});

--- a/tests/semantic/variable-modifiers.test.ts
+++ b/tests/semantic/variable-modifiers.test.ts
@@ -272,17 +272,31 @@ describe('Phase 2.6 - Variable Modifiers', () => {
             counter : DINT;
           END_VAR
         END_PROGRAM
+
+        CONFIGURATION Config0
+          RESOURCE Res0 ON PLC
+            TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+            PROGRAM instance0 WITH task0 : Main;
+          END_RESOURCE
+        END_CONFIGURATION
       `;
-      const result = compile(source);
+      // Rewritten for the leaf-addressed retain table. The per-program
+      // `RetainVarInfo __retain_vars[]` this asserted is gone: it described
+      // members by `offsetof` and `sizeof(IECVar<T>)`, which persisted the
+      // debugger's forcing state and could not name a variable inside a nested
+      // function block or a configuration global at all. Retained leaves are
+      // listed once, project-wide, in generated_debug.cpp.
+      //
+      // The source gained a CONFIGURATION because retained storage exists in an
+      // INSTANCE: the leaf walk goes configurations -> resources -> tasks ->
+      // instances, so an uninstantiated program has nothing to retain.
+      const result = compile(source, { headerFileName: 'generated.hpp' });
       expect(result.success).toBe(true);
-      // Check for retain table declaration in header
-      expect(result.headerCode).toContain('__retain_vars');
-      expect(result.headerCode).toContain('getRetainVars');
-      expect(result.headerCode).toContain('getRetainCount');
-      // Check for retain table definition in source
-      expect(result.cppCode).toContain('RetainVarInfo');
-      expect(result.cppCode).toContain('COUNTER');
-      expect(result.cppCode).toContain('offsetof');
+      expect(result.debugTableCpp).toContain('const uint16_t retain_var_count = 1;');
+      expect(result.debugTableCpp).toContain('INSTANCE0.COUNTER');
+      expect(result.debugTableCpp).toContain('retain_layout_hash');
+      expect(result.headerCode).not.toContain('__retain_vars');
+      expect(result.debugTableCpp).not.toContain('offsetof');
     });
 
     it('should generate retain table with multiple variables', () => {
@@ -293,12 +307,19 @@ describe('Phase 2.6 - Variable Modifiers', () => {
             last_state : BOOL;
           END_VAR
         END_PROGRAM
+
+        CONFIGURATION Config0
+          RESOURCE Res0 ON PLC
+            TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+            PROGRAM instance0 WITH task0 : Main;
+          END_RESOURCE
+        END_CONFIGURATION
       `;
-      const result = compile(source);
+      const result = compile(source, { headerFileName: 'generated.hpp' });
       expect(result.success).toBe(true);
-      expect(result.headerCode).toContain('__retain_vars[2]');
-      expect(result.cppCode).toContain('TOTAL_COUNT');
-      expect(result.cppCode).toContain('LAST_STATE');
+      expect(result.debugTableCpp).toContain('const uint16_t retain_var_count = 2;');
+      expect(result.debugTableCpp).toContain('INSTANCE0.TOTAL_COUNT');
+      expect(result.debugTableCpp).toContain('INSTANCE0.LAST_STATE');
     });
 
     it('should not generate retain table when no RETAIN variables', () => {
@@ -309,10 +330,12 @@ describe('Phase 2.6 - Variable Modifiers', () => {
           END_VAR
         END_PROGRAM
       `;
-      const result = compile(source);
+      const result = compile(source, { headerFileName: 'generated.hpp' });
       expect(result.success).toBe(true);
+      // The table is still emitted (with a placeholder) so the runtime links
+      // unconditionally; the COUNT is what says nothing is retained.
+      expect(result.debugTableCpp).toContain('const uint16_t retain_var_count = 0;');
       expect(result.headerCode).not.toContain('__retain_vars');
-      expect(result.headerCode).not.toContain('getRetainVars');
     });
   });
 });


### PR DESCRIPTION
Phase 2 of NODE-94. Replaces the Phase 2.6 retain scaffolding with something a runtime can use, and adds the marshaller both hosts will share. Phases 3 (baremetal) and 4 (v4 daemon) build directly on this.

## The old descriptor could not work

Each retained variable was `{ name, offsetof(Class, member), sizeof(IECVar<T>) }`, and all three fields were wrong for the job:

- **`sizeof(IECVar<T>)` is the whole wrapper.** A DINT measures **12** bytes, not 4 — the extra 8 are `forced_` and `forced_value_`. Persisting that region carried the debugger's forcing state across a power cycle: force a variable during commissioning, power-cycle, and it returns forced with no debugger attached.
- **`offsetof` on a program class** is `offsetof` on a non-standard-layout type (derives from `ProgramBase`, has virtuals) — conditionally supported, and it warns. The table also used the **unmangled** member name while the class definition went through `mangleMemberIfNeeded`, so a retained variable colliding with its own type name failed to compile.
- **It could only describe PROGRAM members.** A retained variable inside a function block, or a retained CONFIGURATION global, compiled clean and was silently dropped.

## What replaces it

Retained leaves are addressed by debug-table `(arr, elem)` — the index the debugger already uses. That walk already covers nested FB members, struct fields, array elements and configuration globals, and already reports each leaf's transport width, so the three problems above *disappear* rather than get fixed. Values move through `handle_read` / `handle_write`, which touch the value and never the wrapper.

**`iec_retain.hpp` becomes the shared marshaller.** The abstract `RetainStorage` class it held could never have crossed a `.so` or plugin boundary; it is replaced by the blob format plus a pack/unpack walk parameterised by read/write/size function pointers, so the firmware and the daemon share one implementation and cannot drift.

```
off  size  field                    14-byte header, then values packed in
  0     2  magic 0x4F52             retain_vars[] order — no paths, no indices,
  2     1  format version           no type tags in the retain region, because
  3     1  flags (reserved)         that region is the scarce one. The mapping
  4     4  layout_hash              lives in the compiled program, where
  8     2  payload_len              storage is free.
 10     4  crc32
```

## Notes for review

**Selection rides the flags parameter from Phase 0**, which is why the container rules fall out cleanly. `applyBlockFlags` ORs a block's own qualifiers into what it inherited, and **NON_RETAIN clears the bit** — the one case that makes a shared mutable wrong, since a cleared bit must not leak into the following sibling. That is what the parameter-threading in #218 was for.

**`retain_layout_hash` is identity of the LAYOUT, not the program.** FNV-1a over ordered `path|typeTag`: a body edit keeps retained values, while adding/removing/retyping/reordering a retained variable invalidates them. Keying on the project MD5 would discard retained state on every unrelated edit — there are tests for all four cases.

**Widths come from `size_of()` at runtime, never the manifest.** A STRING moves as a fixed 127 bytes regardless of `STRING(20)`; sizing the payload from anything else desynchronises it from what the target can read.

**`getRetainVars` / `getRetainCount` are kept as no-op base slots** and deliberately no longer overridden — the v4 runtime mirrors that vtable *by position* to dispatch `run()` across a `.so` boundary, so removing a slot would mis-dispatch every program built against a different version.

## Verified by running it, not just compiling

A real pack → wipe → unpack, now a test:

```
retained leaves : 6      payload 21 B + 14 B header = 35 B
restored: boots=4242 held.ticks=777 loose.ticks=555 g_hours=99 loose.hist=31337
```

- a program local, an **inherited FB member**, an **FB-local RETAIN inside a NON-retained instance**, and a configuration global all restore
- a NON_RETAIN member is left alone (`loose.hist` keeps its pre-restore value)
- restore does **not** force
- corrupt payload → `BadCrc`, stale layout → `StaleLayout`, bad magic → `BadMagic`, empty → `Empty`, short → `Truncated`

Inheritance verified independently across a two-level nesting, including the opt-out:

```
RET  INST0.HELD.PLAIN.TICKS         retained container, two levels down
     INST0.HELD.PLAIN.SCRATCH       NON_RETAIN opts out of a retained container
RET  INST0.LOOSE.PLAIN.TICKS        FB-local RETAIN in a NON-retained instance
     INST0.LOOSE.HIST               plain member of a plain instance
```

## Four old tests rewritten, not deleted

They asserted the removed table. Two also gained a `CONFIGURATION`, because retained storage exists in an **instance** — an uninstantiated program has nothing to retain, which the old per-program table obscured.

Suite: **92 files, 2273 passed / 7 skipped** (up 12). No lint errors.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3