### PR TITLE
feat(retain): retain a library FB's internal state, not just its interface [NODE-94 phase 5]

### DIFF
--- a/src/backend/debug-leaf-types.ts
+++ b/src/backend/debug-leaf-types.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Leaf primitives shared by everything that flattens IEC state into debug
+ * leaves.
+ *
+ * Split out of `debug-table-gen.ts` so the library compiler can flatten a
+ * library's function blocks with the SAME tables and the SAME flag rules the
+ * debug table uses, without the two importing each other. Nothing here knows
+ * about buckets, addresses or manifests — those stay with their generators.
+ */
+
+// Type tags — MUST match TypeTag enum in runtime/include/debug_dispatch.hpp.
+// ---------------------------------------------------------------------------
+export const TAG = {
+  BOOL: 0,
+  SINT: 1,
+  USINT: 2,
+  INT: 3,
+  UINT: 4,
+  DINT: 5,
+  UDINT: 6,
+  LINT: 7,
+  ULINT: 8,
+  REAL: 9,
+  LREAL: 10,
+  BYTE: 11,
+  WORD: 12,
+  DWORD: 13,
+  LWORD: 14,
+  TIME: 15,
+  DATE: 16,
+  TOD: 17,
+  DT: 18,
+  STRING: 19,
+  WSTRING: 20,
+} as const;
+
+export type TagName = keyof typeof TAG;
+
+// ---------------------------------------------------------------------------
+// Per-leaf flag bits — MUST match LEAF_FLAG_* in
+// runtime/include/debug_table.hpp. ABI: append only, never renumber.
+//
+// Carried down the leaf walk as an explicit parameter rather than a mutable
+// `currentFlags`, because a bit can be *cleared* partway down a subtree —
+// today nothing does, but the retain work adds exactly that (a NON_RETAIN
+// member inside a RETAIN function-block instance), and a shared mutable
+// would leak the cleared value into the following sibling.
+// ---------------------------------------------------------------------------
+export const LEAF_FLAG_READONLY = 1 << 0;
+/** Mirrors LEAF_FLAG_RETAIN in runtime/include/debug_table.hpp. */
+export const LEAF_FLAG_RETAIN = 1 << 1;
+
+/**
+ * Apply one var block's qualifiers to the flags inherited from its container.
+ *
+ * RETAIN is inherited: declaring `VAR RETAIN inst : FB;` retains every leaf
+ * inside `inst`, which is the CODESYS rule. NON_RETAIN is how a member opts
+ * back out, so it CLEARS the bit rather than merely failing to set it — and
+ * that is exactly why the walk passes flags down as a parameter instead of
+ * mutating shared state: a cleared bit must not leak into the next sibling.
+ */
+export function applyBlockFlags(
+  inherited: number,
+  block: { isConstant: boolean; isRetain: boolean; isNonRetain: boolean },
+): number {
+  let flags = inherited;
+  if (block.isConstant) flags |= LEAF_FLAG_READONLY;
+  if (block.isRetain) flags |= LEAF_FLAG_RETAIN;
+  if (block.isNonRetain) flags &= ~LEAF_FLAG_RETAIN;
+  return flags;
+}
+
+/**
+ * Render an entry's flags byte as C++.
+ *
+ * Emits the named constant rather than a literal so `generated_debug.cpp`
+ * reads as intent — a reviewer scanning the table sees which leaves are
+ * gated without decoding a bitmask — and so a stale generated file fails to
+ * compile against a header that renamed the flag instead of silently setting
+ * the wrong bit.
+ */
+export function flagsLiteral(flags: number): string {
+  const names: string[] = [];
+  if (flags & LEAF_FLAG_READONLY) names.push("LEAF_FLAG_READONLY");
+  if (flags & LEAF_FLAG_RETAIN) names.push("LEAF_FLAG_RETAIN");
+  return names.length > 0 ? names.join(" | ") : "0";
+}
+
+export const TAG_NAME_BY_VALUE: Record<number, TagName> = Object.fromEntries(
+  Object.entries(TAG).map(([k, v]) => [v, k as TagName]),
+) as Record<number, TagName>;
+
+/** Map IEC type name (upper case) → TagName (canonical). Handles aliases. */
+export const IEC_NAME_TO_TAG: Record<string, TagName> = {
+  BOOL: "BOOL",
+  SINT: "SINT",
+  USINT: "USINT",
+  INT: "INT",
+  UINT: "UINT",
+  DINT: "DINT",
+  UDINT: "UDINT",
+  LINT: "LINT",
+  ULINT: "ULINT",
+  REAL: "REAL",
+  LREAL: "LREAL",
+  BYTE: "BYTE",
+  WORD: "WORD",
+  DWORD: "DWORD",
+  LWORD: "LWORD",
+  // __XWORD is platform-width; the debug surface targets the native host
+  // (where pointers are 64-bit), so it reads as an LWORD-tagged 8-byte value.
+  __XWORD: "LWORD",
+  TIME: "TIME",
+  LTIME: "TIME",
+  DATE: "DATE",
+  LDATE: "DATE",
+  TOD: "TOD",
+  TIME_OF_DAY: "TOD",
+  LTOD: "TOD",
+  DT: "DT",
+  DATE_AND_TIME: "DT",
+  LDT: "DT",
+  STRING: "STRING",
+  WSTRING: "WSTRING",
+};
+
+/** Byte size for each IEC elementary type — authoritative for debug. */
+export const IEC_NAME_TO_SIZE: Record<string, number> = {
+  BOOL: 1,
+  SINT: 1,
+  USINT: 1,
+  INT: 2,
+  UINT: 2,
+  DINT: 4,
+  UDINT: 4,
+  LINT: 8,
+  ULINT: 8,
+  REAL: 4,
+  LREAL: 8,
+  BYTE: 1,
+  WORD: 2,
+  DWORD: 4,
+  LWORD: 8,
+  __XWORD: 8,
+  TIME: 8,
+  LTIME: 8,
+  DATE: 8,
+  LDATE: 8,
+  TOD: 8,
+  TIME_OF_DAY: 8,
+  LTOD: 8,
+  DT: 8,
+  DATE_AND_TIME: 8,
+  LDT: 8,
+  // STRING / WSTRING wire widths match `DEBUG_STRING_WIDTH` /
+  // `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`.
+  // The runtime always writes a full fixed-width window
+  // (1 byte length + 126 bytes UTF-8 / 252 bytes UTF-16LE); the
+  // editor decoder reads `min(length, 126)` from the prefix and
+  // skips the remainder.  Pinning the same constants here keeps the
+  // editor's batch-byte arithmetic aligned with what the runtime
+  // actually sends per entry.
+  STRING: 127,
+  WSTRING: 253,
+};

--- a/src/backend/debug-table-gen.ts
+++ b/src/backend/debug-table-gen.ts
@@ -20,91 +20,38 @@
  * boundary so per-program edits don't cascade down the table.
  */
 
-import type {
-  CompilationUnit,
-  ProgramDeclaration,
-  TypeReference,
-  StructDefinition,
-  VarDeclaration,
-} from "../frontend/ast.js";
+import type { CompilationUnit, ProgramDeclaration } from "../frontend/ast.js";
 import type { ProjectModel } from "../project-model.js";
 import type { SymbolTables } from "../semantic/symbol-table.js";
-import { isElementaryType } from "../semantic/type-registry.js";
-import { evalIntConst } from "../semantic/type-utils.js";
-import { formatArrayElementAccess } from "./codegen-utils.js";
-import { mangledMemberName } from "./member-mangling.js";
+import {
+  applyBlockFlags,
+  flagsLiteral,
+  IEC_NAME_TO_SIZE,
+  IEC_NAME_TO_TAG,
+  LEAF_FLAG_READONLY,
+  LEAF_FLAG_RETAIN,
+  TAG,
+  TAG_NAME_BY_VALUE,
+  type TagName,
+} from "./debug-leaf-types.js";
+import { createLeafWalker } from "./leaf-walker.js";
 
 // ---------------------------------------------------------------------------
-// Type tags — MUST match TypeTag enum in runtime/include/debug_dispatch.hpp.
+// Leaf primitives (tags, flag bits, the flag-inheritance rule, the IEC type
+// tables) live in debug-leaf-types.ts, shared with the library compiler so the
+// two flatteners cannot drift. Re-exported here because callers have always
+// imported them from this module.
 // ---------------------------------------------------------------------------
-export const TAG = {
-  BOOL: 0,
-  SINT: 1,
-  USINT: 2,
-  INT: 3,
-  UINT: 4,
-  DINT: 5,
-  UDINT: 6,
-  LINT: 7,
-  ULINT: 8,
-  REAL: 9,
-  LREAL: 10,
-  BYTE: 11,
-  WORD: 12,
-  DWORD: 13,
-  LWORD: 14,
-  TIME: 15,
-  DATE: 16,
-  TOD: 17,
-  DT: 18,
-  STRING: 19,
-  WSTRING: 20,
-} as const;
-
-export type TagName = keyof typeof TAG;
+export {
+  LEAF_FLAG_READONLY,
+  LEAF_FLAG_RETAIN,
+  TAG,
+  type TagName,
+} from "./debug-leaf-types.js";
 
 // ---------------------------------------------------------------------------
-// Per-leaf flag bits — MUST match LEAF_FLAG_* in
-// runtime/include/debug_table.hpp. ABI: append only, never renumber.
-//
-// Carried down the leaf walk as an explicit parameter rather than a mutable
-// `currentFlags`, because a bit can be *cleared* partway down a subtree —
-// today nothing does, but the retain work adds exactly that (a NON_RETAIN
-// member inside a RETAIN function-block instance), and a shared mutable
-// would leak the cleared value into the following sibling.
+// Public types
 // ---------------------------------------------------------------------------
-export const LEAF_FLAG_READONLY = 1 << 0;
-/** Mirrors LEAF_FLAG_RETAIN in runtime/include/debug_table.hpp. */
-export const LEAF_FLAG_RETAIN = 1 << 1;
-
-/**
- * Render an entry's flags byte as C++.
- *
- * Emits the named constant rather than a literal so `generated_debug.cpp`
- * reads as intent — a reviewer scanning the table sees which leaves are
- * gated without decoding a bitmask — and so a stale generated file fails to
- * compile against a header that renamed the flag instead of silently setting
- * the wrong bit.
- */
-/**
- * Apply one var block's qualifiers to the flags inherited from its container.
- *
- * RETAIN is inherited: declaring `VAR RETAIN inst : FB;` retains every leaf
- * inside `inst`, which is the CODESYS rule. NON_RETAIN is how a member opts
- * back out, so it CLEARS the bit rather than merely failing to set it — and
- * that is exactly why the walk passes flags down as a parameter instead of
- * mutating shared state: a cleared bit must not leak into the next sibling.
- */
-function applyBlockFlags(
-  inherited: number,
-  block: { isConstant: boolean; isRetain: boolean; isNonRetain: boolean },
-): number {
-  let flags = inherited;
-  if (block.isConstant) flags |= LEAF_FLAG_READONLY;
-  if (block.isRetain) flags |= LEAF_FLAG_RETAIN;
-  if (block.isNonRetain) flags &= ~LEAF_FLAG_RETAIN;
-  return flags;
-}
 
 /**
  * FNV-1a (32-bit) over the retain layout — the ordered `path|typeTag` of every
@@ -119,6 +66,13 @@ function applyBlockFlags(
  * against accident, not against an attacker, and it has to be computable in a
  * few lines on an AVR as well as here.
  */
+/**
+ * Mirrors `strucpp::retain::HEADER_SIZE` in runtime/include/iec_retain.hpp.
+ * Changing one without the other makes the editor's capacity gate disagree
+ * with the firmware's own arithmetic.
+ */
+const RETAIN_HEADER_SIZE = 14;
+
 function retainLayoutHashOf(
   vars: Array<{ path: string; tagName: TagName }>,
 ): string {
@@ -133,95 +87,6 @@ function retainLayoutHashOf(
   }
   return hash.toString(16).padStart(8, "0");
 }
-
-function flagsLiteral(flags: number): string {
-  const names: string[] = [];
-  if (flags & LEAF_FLAG_READONLY) names.push("LEAF_FLAG_READONLY");
-  if (flags & LEAF_FLAG_RETAIN) names.push("LEAF_FLAG_RETAIN");
-  return names.length > 0 ? names.join(" | ") : "0";
-}
-
-const TAG_NAME_BY_VALUE: Record<number, TagName> = Object.fromEntries(
-  Object.entries(TAG).map(([k, v]) => [v, k as TagName]),
-) as Record<number, TagName>;
-
-/** Map IEC type name (upper case) → TagName (canonical). Handles aliases. */
-const IEC_NAME_TO_TAG: Record<string, TagName> = {
-  BOOL: "BOOL",
-  SINT: "SINT",
-  USINT: "USINT",
-  INT: "INT",
-  UINT: "UINT",
-  DINT: "DINT",
-  UDINT: "UDINT",
-  LINT: "LINT",
-  ULINT: "ULINT",
-  REAL: "REAL",
-  LREAL: "LREAL",
-  BYTE: "BYTE",
-  WORD: "WORD",
-  DWORD: "DWORD",
-  LWORD: "LWORD",
-  // __XWORD is platform-width; the debug surface targets the native host
-  // (where pointers are 64-bit), so it reads as an LWORD-tagged 8-byte value.
-  __XWORD: "LWORD",
-  TIME: "TIME",
-  LTIME: "TIME",
-  DATE: "DATE",
-  LDATE: "DATE",
-  TOD: "TOD",
-  TIME_OF_DAY: "TOD",
-  LTOD: "TOD",
-  DT: "DT",
-  DATE_AND_TIME: "DT",
-  LDT: "DT",
-  STRING: "STRING",
-  WSTRING: "WSTRING",
-};
-
-/** Byte size for each IEC elementary type — authoritative for debug. */
-const IEC_NAME_TO_SIZE: Record<string, number> = {
-  BOOL: 1,
-  SINT: 1,
-  USINT: 1,
-  INT: 2,
-  UINT: 2,
-  DINT: 4,
-  UDINT: 4,
-  LINT: 8,
-  ULINT: 8,
-  REAL: 4,
-  LREAL: 8,
-  BYTE: 1,
-  WORD: 2,
-  DWORD: 4,
-  LWORD: 8,
-  __XWORD: 8,
-  TIME: 8,
-  LTIME: 8,
-  DATE: 8,
-  LDATE: 8,
-  TOD: 8,
-  TIME_OF_DAY: 8,
-  LTOD: 8,
-  DT: 8,
-  DATE_AND_TIME: 8,
-  LDT: 8,
-  // STRING / WSTRING wire widths match `DEBUG_STRING_WIDTH` /
-  // `DEBUG_WSTRING_WIDTH` in `runtime/include/debug_dispatch.hpp`.
-  // The runtime always writes a full fixed-width window
-  // (1 byte length + 126 bytes UTF-8 / 252 bytes UTF-16LE); the
-  // editor decoder reads `min(length, 126)` from the prefix and
-  // skips the remainder.  Pinning the same constants here keeps the
-  // editor's batch-byte arithmetic aligned with what the runtime
-  // actually sends per entry.
-  STRING: 127,
-  WSTRING: 253,
-};
-
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
 
 export interface DebugLeaf {
   arrayIdx: number;
@@ -275,6 +140,18 @@ export interface DebugMapV2 {
     size: number;
   }>;
   /**
+   * Total bytes the retain blob occupies: the 14-byte header plus one payload
+   * slot per retained leaf. Matches `strucpp::retain::blob_size()` exactly.
+   *
+   * Emitted so a build can be REFUSED when the target cannot hold it. Without
+   * it the firmware links, runs, finds the blob too large for its buffer and
+   * degrades to NON_RETAIN in silence — the same class of failure as retaining
+   * half a function block. A retained TON is 36 bytes, so a 512-byte board
+   * cap is reached at around fourteen of them; this is a limit real programs
+   * meet.
+   */
+  retainBlobSize?: number;
+  /**
    * Identity of the retain LAYOUT, not of the program.
    *
    * FNV-1a over `path|typeTag` for each retained leaf in table order, so a body
@@ -293,6 +170,17 @@ export interface DebugTableResult {
   /** Any leaves that couldn't be classified (unsupported type construct,
    *  user-defined enum, reference, etc.). Useful for warnings. */
   skipped: Array<{ path: string; reason: string }>;
+  /**
+   * State the walk was asked to retain and could not reach.
+   *
+   * Separate from `skipped` because the caller must FAIL on these rather than
+   * warn. A skipped leaf is merely invisible to the debugger; an unreachable
+   * retained leaf produces firmware that runs, restores part of a function
+   * block, and leaves it in a state it could never have reached by running —
+   * a fault that shows up as inexplicable behaviour after a power cycle, with
+   * nothing in the build to point at.
+   */
+  incomplete: Array<{ path: string; reason: string }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -340,66 +228,6 @@ export function generateDebugTable(
   const configGlobal = opts.configGlobalName ?? DEFAULTS.configGlobalName;
   const md5 = opts.md5 ?? "";
 
-  // Programs only live in the user AST (libraries don't ship PROGRAM blocks),
-  // so we index them locally. Types and function blocks come from the symbol
-  // table — that's the unified source covering both user-defined declarations
-  // and library-loaded entries.
-  const programByName = new Map<string, ProgramDeclaration>();
-  for (const p of ast.programs) programByName.set(p.name.toUpperCase(), p);
-
-  // --- Inputs to the shared member-mangling rule (see member-mangling.ts) ----
-  // The table addresses members by the name codegen declared them under, so
-  // both predicates have to resolve the same way codegen's do.
-
-  const interfaceNames = new Set(
-    ast.interfaces.map((i) => i.name.toUpperCase()),
-  );
-
-  /**
-   * Mirrors `CodeGenerator.isUserDefinedType`: a function block, interface,
-   * STRUCT/UDT, or program. Elementary types are excluded explicitly — codegen
-   * leaves `Time : TIME` unmangled, so mangling it here would name a member
-   * that does not exist.
-   */
-  const isUserDefinedType = (typeName: string): boolean => {
-    const upper = typeName.toUpperCase();
-    if (isElementaryType(upper)) return false;
-    return (
-      symbolTables.lookupType(upper) !== undefined ||
-      symbolTables.lookupFunctionBlock(upper) !== undefined ||
-      interfaceNames.has(upper) ||
-      programByName.has(upper)
-    );
-  };
-
-  /**
-   * FB type name → upper-cased method names of every interface it implements,
-   * mirroring `CodeGenerator.fbInterfaceMethodNames`. Directly implemented
-   * interfaces only, which is what codegen consults.
-   */
-  const fbInterfaceMethods = new Map<string, Set<string>>();
-  {
-    const methodsByInterface = new Map<string, Set<string>>();
-    for (const iface of ast.interfaces) {
-      methodsByInterface.set(
-        iface.name.toUpperCase(),
-        new Set(iface.methods.map((m) => m.name.toUpperCase())),
-      );
-    }
-    for (const fb of ast.functionBlocks) {
-      if (!fb.implements || fb.implements.length === 0) continue;
-      const methods = new Set<string>();
-      for (const ifaceName of fb.implements) {
-        for (const m of methodsByInterface.get(ifaceName.toUpperCase()) ?? []) {
-          methods.add(m);
-        }
-      }
-      if (methods.size > 0) {
-        fbInterfaceMethods.set(fb.name.toUpperCase(), methods);
-      }
-    }
-  }
-
   // Buckets of entries — grown in order, flushed at program boundary or size cap.
   const arrays: Entry[][] = [[]];
   const leaves: DebugLeaf[] = [];
@@ -412,6 +240,17 @@ export function generateDebugTable(
     tagName: TagName;
   }> = [];
   const skipped: Array<{ path: string; reason: string }> = [];
+  /**
+   * State the walk was asked to cover and could not — today only a RETAIN that
+   * reaches into a library archive built before flattened leaves existed.
+   *
+   * Kept apart from `skipped`, which is a normal and expected list (opaque
+   * library types, variable-length arrays) that nobody reads on a good build.
+   * These are promoted to compile errors by the caller, because the failure
+   * they describe is invisible at runtime: the program builds, runs, and
+   * restores a function block into a state it could never have reached.
+   */
+  const incomplete: Array<{ path: string; reason: string }> = [];
 
   const tail = (): Entry[] => arrays[arrays.length - 1]!;
 
@@ -450,314 +289,19 @@ export function generateDebugTable(
     }
   };
 
-  // visitTypeRef walks a TypeReference: elementary type → leaf, inline array
-  // → per-element recursion, named user type (struct / FB / elementary alias)
-  // → recurse into definition.
-  const visitTypeRef = (
-    path: string,
-    cppExpr: string,
-    typeRef: TypeReference,
-    flags: number,
-  ): void => {
-    // Inline array: `ARRAY[0..4] OF INT` → has arrayDimensions + elementTypeName
-    if (typeRef.arrayDimensions && typeRef.elementTypeName) {
-      walkArrayDims(
-        path,
-        cppExpr,
-        typeRef.arrayDimensions,
-        0,
-        typeRef.elementTypeName,
-        flags,
-      );
-      return;
-    }
+  // Programs live only in the user AST (libraries ship no PROGRAM blocks), and
+  // the instance walk below resolves each instance's program type through here.
+  const programByName = new Map<string, ProgramDeclaration>();
+  for (const p of ast.programs) programByName.set(p.name.toUpperCase(), p);
 
-    const name = typeRef.name.toUpperCase();
-
-    // Named elementary type (or alias thereof).
-    if (IEC_NAME_TO_TAG[name] !== undefined) {
-      addLeaf(path, cppExpr, name, flags);
-      return;
-    }
-
-    // Named type — covers user-defined TYPE..END_TYPE and library-registered
-    // types (struct/enum/alias). The symbol table is the unified source.
-    const ts = symbolTables.lookupType(name);
-    if (ts) {
-      const def = ts.declaration.definition;
-      if (def.kind === "StructDefinition") {
-        visitStructFields(path, cppExpr, def, flags);
-        return;
-      }
-      if (def.kind === "ArrayDefinition") {
-        // TYPE MyArr: ARRAY[0..9] OF INT; END_TYPE
-        const dims = def.dimensions
-          .filter((d) => !d.isVariableLength)
-          .map((d) => ({
-            start: evalIntConst(d.start),
-            end: evalIntConst(d.end),
-          }));
-        if (dims.some((d) => d.start === undefined || d.end === undefined)) {
-          skipped.push({ path, reason: `array bounds not constant` });
-          return;
-        }
-        walkArrayDims(
-          path,
-          cppExpr,
-          dims as Array<{ start: number; end: number }>,
-          0,
-          def.elementType.name,
-          flags,
-        );
-        return;
-      }
-      if (def.kind === "EnumDefinition") {
-        // Enums are stored as their base type; treat as a scalar whose tag
-        // matches the base. Default INT if no baseType.
-        const baseName = def.baseType?.name?.toUpperCase() ?? "INT";
-        if (IEC_NAME_TO_TAG[baseName] !== undefined) {
-          addLeaf(path, cppExpr, baseName, flags);
-          return;
-        }
-        skipped.push({ path, reason: `enum base type ${baseName} unknown` });
-        return;
-      }
-      if (def.kind === "SubrangeDefinition") {
-        const baseName = def.baseType.name.toUpperCase();
-        if (IEC_NAME_TO_TAG[baseName] !== undefined) {
-          addLeaf(path, cppExpr, baseName, flags);
-          return;
-        }
-        skipped.push({ path, reason: `subrange base ${baseName} unknown` });
-        return;
-      }
-      // TypeReference alias. The library loader registers library types
-      // with `definition: TypeReference{ name: baseType ?? typeName }` —
-      // an alias points at its base, but a struct with no baseType points
-      // at itself (the manifest doesn't expose struct fields, so the
-      // symbol carries only the type name). Treat self-referential
-      // aliases as opaque library types: the debugger doesn't recurse
-      // into them, just like it doesn't recurse into library FB locals.
-      if (def.kind === "TypeReference") {
-        if (def.name.toUpperCase() === name) {
-          skipped.push({
-            path,
-            reason: `library type ${typeRef.name} is opaque to the debugger`,
-          });
-          return;
-        }
-        visitTypeRef(path, cppExpr, def, flags);
-        return;
-      }
-      skipped.push({
-        path,
-        reason: `unsupported TYPE kind: ${(def as { kind: string }).kind}`,
-      });
-      return;
-    }
-
-    // Function block instance. The symbol table holds both user-defined
-    // FBs (populated by the semantic analyzer from `ast.functionBlocks`)
-    // and library FBs (populated by `registerLibrarySymbols` from the
-    // .stlib manifest). The two paths intentionally surface different
-    // amounts of state:
-    //
-    //   • Library FBs — only the public interface (inputs/outputs/inouts).
-    //     Locals are implementation details that stay inside the
-    //     compiled archive; the debugger treats library FBs as black
-    //     boxes. The library loader leaves `locals` empty for this
-    //     reason, so iterating the flat arrays gives just the
-    //     interface.
-    //
-    //   • User-defined FBs — every persistent member, including VAR
-    //     locals. The analyzer leaves the symbol's flat arrays empty
-    //     and keeps the declarations in `declaration.varBlocks`, so we
-    //     fall through to the AST walk and surface VAR alongside the
-    //     interface blocks. VAR_TEMP / VAR_EXTERNAL are excluded —
-    //     those are not persistent state.
-    const fbSym = symbolTables.lookupFunctionBlock(name);
-    if (fbSym) {
-      const interfaceVars = [
-        ...fbSym.inputs,
-        ...fbSym.outputs,
-        ...fbSym.inouts,
-      ];
-      // `name` is the FB type declaring these members, so it is the owner for
-      // both mangling collisions.
-      if (interfaceVars.length > 0) {
-        for (const v of interfaceVars) {
-          visitTypeRef(
-            `${path}.${v.name.toUpperCase()}`,
-            `${cppExpr}.${memberCppName(v.name, v.declaration.type, name)}`,
-            v.declaration.type,
-            flags,
-          );
-        }
-      } else {
-        for (const block of fbSym.declaration.varBlocks) {
-          if (
-            block.blockType === "VAR" ||
-            block.blockType === "VAR_INPUT" ||
-            block.blockType === "VAR_OUTPUT" ||
-            block.blockType === "VAR_IN_OUT"
-          ) {
-            // A `VAR CONSTANT` inside a function block is read-only for every
-            // instance of it, and a `VAR RETAIN` member is retained in every
-            // instance, so the block's own qualifiers are folded in here rather
-            // than only at the program level.
-            const memberFlags = applyBlockFlags(flags, block);
-            for (const fieldDecl of block.declarations) {
-              for (const fieldName of fieldDecl.names) {
-                visitTypeRef(
-                  `${path}.${fieldName.toUpperCase()}`,
-                  `${cppExpr}.${memberCppName(fieldName, fieldDecl.type, name)}`,
-                  fieldDecl.type,
-                  memberFlags,
-                );
-              }
-            }
-          }
-        }
-      }
-      return;
-    }
-
-    skipped.push({ path, reason: `unresolved type name: ${typeRef.name}` });
-  };
-
-  const visitStructFields = (
-    path: string,
-    cppExpr: string,
-    def: StructDefinition,
-    flags: number,
-  ): void => {
-    // `flags` passes straight through: IEC puts CONSTANT on a var *block*, and
-    // a STRUCT declares fields without blocks, so a struct field can never
-    // introduce or clear the bit — it only inherits whatever the declaration
-    // that named the struct carried.
-    for (const fieldDecl of def.fields) {
-      for (const fieldName of fieldDecl.names) {
-        visitTypeRef(
-          `${path}.${fieldName.toUpperCase()}`,
-          // No owner: a STRUCT implements no interfaces, so only the
-          // field-name-matches-its-type collision can apply.
-          `${cppExpr}.${memberCppName(fieldName, fieldDecl.type)}`,
-          fieldDecl.type,
-          flags,
-        );
-      }
-    }
-  };
-
-  /**
-   * Enumerate every element of an array, emitting one debug entry per element.
-   *
-   * Indices are collected across all dimensions and only turned into C++ at the
-   * innermost level, because the accessor depends on the array's rank:
-   * `Array2D`/`Array3D` take every index in one `operator()` call, so emitting a
-   * subscript per dimension as we descend would produce `arr[i][j]` — which has
-   * no matching operator on those containers and fails to compile.
-   * {@link formatArrayElementAccess} owns that rank rule. The IEC display path
-   * stays `[i][j]`, which is what the debug UI shows.
-   */
-  const walkArrayDims = (
-    path: string,
-    cppExpr: string,
-    dims: Array<{ start: number; end: number }>,
-    dimIdx: number,
-    elementTypeName: string,
-    flags: number,
-    indices: number[] = [],
-  ): void => {
-    if (dimIdx >= dims.length) {
-      // Innermost element — visit as a TypeReference with the element type
-      // name. Manufacture a minimal TypeReference for recursion.
-      visitTypeRef(
-        path,
-        formatArrayElementAccess(cppExpr, indices),
-        {
-          kind: "TypeReference",
-          name: elementTypeName,
-          isReference: false,
-          referenceKind: "none",
-        } as TypeReference,
-        flags,
-      );
-      return;
-    }
-    const { start, end } = dims[dimIdx]!;
-    for (let i = start; i <= end; i++) {
-      walkArrayDims(
-        `${path}[${i}]`,
-        cppExpr,
-        dims,
-        dimIdx + 1,
-        elementTypeName,
-        flags,
-        [...indices, i],
-      );
-    }
-  };
-
-  /**
-   * C++ member name for a declaration, by the same rule codegen used to emit it
-   * (see `member-mangling.ts`).
-   *
-   * The table addresses members by name, so it has to agree with the class
-   * definition exactly, in *both* directions. Mangling too little named a member
-   * that does not exist (`RunningLights : RunningLights` is declared
-   * `RUNNINGLIGHTS_`); mangling too much would do the same in reverse, since
-   * `Time : TIME` is declared plain `TIME`. Either way `generated_debug.cpp`
-   * fails to compile and takes the whole firmware build with it — and nothing
-   * catches it earlier, because `strucpp file.st` emits no debug table.
-   *
-   * `ownerTypeName` is the type declaring the member, needed for the
-   * interface-method collision; undefined for a PROGRAM or a STRUCT, neither of
-   * which can implement an interface.
-   */
-  const memberCppName = (
-    varName: string,
-    typeRef: TypeReference | undefined,
-    ownerTypeName?: string,
-  ): string =>
-    mangledMemberName(varName, typeRef?.name, {
-      isUserDefinedType,
-      interfaceMethods:
-        ownerTypeName !== undefined
-          ? fbInterfaceMethods.get(ownerTypeName.toUpperCase())
-          : undefined,
-    });
-
-  const visitVarDecl = (
-    path: string,
-    cppExpr: string,
-    decl: VarDeclaration,
-    flags: number,
-    ownerTypeName?: string,
-  ): void => {
-    for (const varName of decl.names) {
-      visitTypeRef(
-        `${path}.${varName.toUpperCase()}`,
-        `${cppExpr}.${memberCppName(varName, decl.type, ownerTypeName)}`,
-        decl.type,
-        flags,
-      );
-    }
-  };
-
-  // Configurations carry both VAR_GLOBAL declarations and the
-  // resource → task → program-instance tree. Globals go first so they own
-  // a dedicated bucket at the head of the table — that way edits to a
-  // program don't shift global addresses around.
-  //
-  // Path convention is bare uppercase name (no instance prefix): the
-  // editor's `buildGlobalDebugPath()` returns `name.toUpperCase()` and
-  // OPC-UA `GVL:foo` references resolve against the same key.
-  // C++ expression is `${name}.value`: each global is emitted as a file-scope
-  // `inline GlobalVar<V>` singleton (value + per-global mutex), so `.value`
-  // reaches the underlying IEC storage the debugger reads/writes directly —
-  // no configuration-instance prefix (see codegen.ts emitFileScopeGlobals,
-  // iec_global.hpp).
+  // The walk itself lives in leaf-walker.ts — see that module for why it is
+  // shared rather than duplicated. Here it is wired to a sink that turns each
+  // leaf into a table entry.
+  const { visitTypeRef, visitVarDecl } = createLeafWalker(ast, symbolTables, {
+    leaf: addLeaf,
+    skip: (path, reason) => skipped.push({ path, reason }),
+    incomplete: (path, reason) => incomplete.push({ path, reason }),
+  });
   const seenGlobals = new Set<string>();
   for (const config of ast.configurations) {
     for (const block of config.varBlocks) {
@@ -849,11 +393,15 @@ export function generateDebugTable(
             size,
           })),
           retainLayoutHash: retainLayoutHashOf(retainVars),
+          // 14 == strucpp::retain::HEADER_SIZE (iec_retain.hpp).
+          retainBlobSize:
+            RETAIN_HEADER_SIZE +
+            retainVars.reduce((total, v) => total + v.size, 0),
         }
       : {}),
   };
 
-  return { debugTableCpp, debugMap, skipped };
+  return { debugTableCpp, debugMap, skipped, incomplete };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/backend/leaf-walker.ts
+++ b/src/backend/leaf-walker.ts
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * The one walk that flattens IEC declarations into elementary leaves.
+ *
+ * Two callers need it and must agree exactly:
+ *
+ *   • `debug-table-gen.ts` — turns each leaf into a `{ptr, tag, flags}` entry
+ *     in `generated_debug.cpp` and an address in the debug map.
+ *   • `library-compiler.ts` — turns each leaf of a library function block into
+ *     a `LibraryFBLeaf` in the .stlib manifest, so a program that instantiates
+ *     the block can address its insides without being able to see them.
+ *
+ * They agreed by copy before this module existed, which is a bad way to agree:
+ * the walk decides the C++ member name of every entry, and a table that names
+ * a member the class does not declare fails to compile `generated_debug.cpp`
+ * and takes the whole firmware build with it — with nothing catching it
+ * earlier, since `strucpp file.st` emits no debug table.
+ *
+ * The walk itself is: elementary type → leaf; inline array → per-element
+ * recursion; named type → recurse into its definition; FB instance → recurse
+ * into its persistent members. Flags (CONSTANT / RETAIN) travel down as a
+ * parameter, never as shared mutable state — see `applyBlockFlags`.
+ */
+
+import type {
+  CompilationUnit,
+  ProgramDeclaration,
+  StructDefinition,
+  TypeReference,
+  VarDeclaration,
+} from "../frontend/ast.js";
+import type { SymbolTables } from "../semantic/symbol-table.js";
+import { isElementaryType } from "../semantic/type-registry.js";
+import { evalIntConst } from "../semantic/type-utils.js";
+import { formatArrayElementAccess } from "./codegen-utils.js";
+import {
+  applyBlockFlags,
+  IEC_NAME_TO_TAG,
+  LEAF_FLAG_READONLY,
+  LEAF_FLAG_RETAIN,
+} from "./debug-leaf-types.js";
+import { mangledMemberName } from "./member-mangling.js";
+
+/**
+ * Where the walk's output goes. Both callers implement all three.
+ */
+export interface LeafSink {
+  /** One elementary leaf: its dotted ST path, the C++ expression that reaches
+   *  its storage, its IEC type name, and the accumulated flag bits. */
+  leaf: (path: string, cppExpr: string, iecName: string, flags: number) => void;
+  /** Something the debugger cannot address — an opaque library type, a
+   *  non-constant array bound. Informational: the rest of the walk continues
+   *  and the program still compiles and runs. */
+  skip: (path: string, reason: string) => void;
+  /**
+   * Something the walk was ASKED to cover and could not.
+   *
+   * Distinct from `skip` because the consequence is different: a skipped leaf
+   * is invisible to the debugger, whereas an incomplete RETAIN silently
+   * restores a block into a state it could never have reached by running. The
+   * debug-table caller turns these into compile diagnostics.
+   */
+  incomplete: (path: string, reason: string) => void;
+}
+
+/**
+ * Declared as function-typed PROPERTIES rather than methods: callers destructure
+ * these, and a method shorthand would make every such call an unbound-method
+ * reference. They close over the walker's state and never use `this`.
+ */
+export interface LeafWalker {
+  /** Walk a type reference rooted at `path` / `cppExpr`. */
+  visitTypeRef: (
+    path: string,
+    cppExpr: string,
+    typeRef: TypeReference,
+    flags: number,
+  ) => void;
+  /** Walk every name in one declaration. `ownerTypeName` is the type declaring
+   *  it, needed for the interface-method mangling collision. */
+  visitVarDecl: (
+    path: string,
+    cppExpr: string,
+    decl: VarDeclaration,
+    flags: number,
+    ownerTypeName?: string,
+  ) => void;
+  /** The C++ member name a declaration was emitted under. Exposed because
+   *  callers build root expressions before entering the walk. */
+  memberCppName: (
+    varName: string,
+    typeRef: TypeReference | undefined,
+    ownerTypeName?: string,
+  ) => string;
+}
+
+/**
+ * Build a walker bound to one compilation unit and one sink.
+ */
+export function createLeafWalker(
+  ast: CompilationUnit,
+  symbolTables: SymbolTables,
+  sink: LeafSink,
+): LeafWalker {
+  // Programs only live in the user AST (libraries don't ship PROGRAM blocks),
+  // so we index them locally. Types and function blocks come from the symbol
+  // table — that's the unified source covering both user-defined declarations
+  // and library-loaded entries.
+  const programByName = new Map<string, ProgramDeclaration>();
+  for (const p of ast.programs) programByName.set(p.name.toUpperCase(), p);
+
+  // --- Inputs to the shared member-mangling rule (see member-mangling.ts) ----
+  // The table addresses members by the name codegen declared them under, so
+  // both predicates have to resolve the same way codegen's do.
+
+  const interfaceNames = new Set(
+    ast.interfaces.map((i) => i.name.toUpperCase()),
+  );
+
+  /**
+   * Mirrors `CodeGenerator.isUserDefinedType`: a function block, interface,
+   * STRUCT/UDT, or program. Elementary types are excluded explicitly — codegen
+   * leaves `Time : TIME` unmangled, so mangling it here would name a member
+   * that does not exist.
+   */
+  const isUserDefinedType = (typeName: string): boolean => {
+    const upper = typeName.toUpperCase();
+    if (isElementaryType(upper)) return false;
+    return (
+      symbolTables.lookupType(upper) !== undefined ||
+      symbolTables.lookupFunctionBlock(upper) !== undefined ||
+      interfaceNames.has(upper) ||
+      programByName.has(upper)
+    );
+  };
+
+  /**
+   * FB type name → upper-cased method names of every interface it implements,
+   * mirroring `CodeGenerator.fbInterfaceMethodNames`. Directly implemented
+   * interfaces only, which is what codegen consults.
+   */
+  const fbInterfaceMethods = new Map<string, Set<string>>();
+  {
+    const methodsByInterface = new Map<string, Set<string>>();
+    for (const iface of ast.interfaces) {
+      methodsByInterface.set(
+        iface.name.toUpperCase(),
+        new Set(iface.methods.map((m) => m.name.toUpperCase())),
+      );
+    }
+    for (const fb of ast.functionBlocks) {
+      if (!fb.implements || fb.implements.length === 0) continue;
+      const methods = new Set<string>();
+      for (const ifaceName of fb.implements) {
+        for (const m of methodsByInterface.get(ifaceName.toUpperCase()) ?? []) {
+          methods.add(m);
+        }
+      }
+      if (methods.size > 0) {
+        fbInterfaceMethods.set(fb.name.toUpperCase(), methods);
+      }
+    }
+  }
+
+  // visitTypeRef walks a TypeReference: elementary type → leaf, inline array
+  // → per-element recursion, named user type (struct / FB / elementary alias)
+  // → recurse into definition.
+  const visitTypeRef = (
+    path: string,
+    cppExpr: string,
+    typeRef: TypeReference,
+    flags: number,
+  ): void => {
+    // Inline array: `ARRAY[0..4] OF INT` → has arrayDimensions + elementTypeName
+    if (typeRef.arrayDimensions && typeRef.elementTypeName) {
+      walkArrayDims(
+        path,
+        cppExpr,
+        typeRef.arrayDimensions,
+        0,
+        typeRef.elementTypeName,
+        flags,
+      );
+      return;
+    }
+
+    const name = typeRef.name.toUpperCase();
+
+    // Named elementary type (or alias thereof).
+    if (IEC_NAME_TO_TAG[name] !== undefined) {
+      sink.leaf(path, cppExpr, name, flags);
+      return;
+    }
+
+    // Named type — covers user-defined TYPE..END_TYPE and library-registered
+    // types (struct/enum/alias). The symbol table is the unified source.
+    const ts = symbolTables.lookupType(name);
+    if (ts) {
+      const def = ts.declaration.definition;
+      if (def.kind === "StructDefinition") {
+        visitStructFields(path, cppExpr, def, flags);
+        return;
+      }
+      if (def.kind === "ArrayDefinition") {
+        // TYPE MyArr: ARRAY[0..9] OF INT; END_TYPE
+        const dims = def.dimensions
+          .filter((d) => !d.isVariableLength)
+          .map((d) => ({
+            start: evalIntConst(d.start),
+            end: evalIntConst(d.end),
+          }));
+        if (dims.some((d) => d.start === undefined || d.end === undefined)) {
+          sink.skip(path, `array bounds not constant`);
+          return;
+        }
+        walkArrayDims(
+          path,
+          cppExpr,
+          dims as Array<{ start: number; end: number }>,
+          0,
+          def.elementType.name,
+          flags,
+        );
+        return;
+      }
+      if (def.kind === "EnumDefinition") {
+        // Enums are stored as their base type; treat as a scalar whose tag
+        // matches the base. Default INT if no baseType.
+        const baseName = def.baseType?.name?.toUpperCase() ?? "INT";
+        if (IEC_NAME_TO_TAG[baseName] !== undefined) {
+          sink.leaf(path, cppExpr, baseName, flags);
+          return;
+        }
+        sink.skip(path, `enum base type ${baseName} unknown`);
+        return;
+      }
+      if (def.kind === "SubrangeDefinition") {
+        const baseName = def.baseType.name.toUpperCase();
+        if (IEC_NAME_TO_TAG[baseName] !== undefined) {
+          sink.leaf(path, cppExpr, baseName, flags);
+          return;
+        }
+        sink.skip(path, `subrange base ${baseName} unknown`);
+        return;
+      }
+      // TypeReference alias. The library loader registers library types
+      // with `definition: TypeReference{ name: baseType ?? typeName }` —
+      // an alias points at its base, but a struct with no baseType points
+      // at itself (the manifest doesn't expose struct fields, so the
+      // symbol carries only the type name). Treat self-referential
+      // aliases as opaque library types: the debugger doesn't recurse
+      // into them, just like it doesn't recurse into library FB locals.
+      if (def.kind === "TypeReference") {
+        if (def.name.toUpperCase() === name) {
+          sink.skip(
+            path,
+            `library type ${typeRef.name} is opaque to the debugger`,
+          );
+          return;
+        }
+        visitTypeRef(path, cppExpr, def, flags);
+        return;
+      }
+      sink.skip(
+        path,
+        `unsupported TYPE kind: ${(def as { kind: string }).kind}`,
+      );
+      return;
+    }
+
+    // Function block instance. The symbol table holds both user-defined FBs
+    // (populated by the semantic analyzer from `ast.functionBlocks`) and
+    // library FBs (populated by `registerLibrarySymbols` from the .stlib
+    // manifest). Only one of the two has its declarations in hand, so they are
+    // surfaced by different means — see below.
+    const fbSym = symbolTables.lookupFunctionBlock(name);
+    if (fbSym) {
+      // Library FB or user FB is decided by an explicit marker, never inferred
+      // from "are the flat arrays populated". They differ in what they can
+      // offer, and guessing wrong is silent: a retained user-defined FB
+      // mistaken for a library one loses its entire subtree.
+      if (fbSym.libraryName !== undefined) {
+        if (fbSym.libraryLeaves) {
+          // Locals only when the instance is retained. Otherwise the debugger
+          // keeps its black-box view of library blocks — the long-standing
+          // contract, and what stops a project instantiating a few hundred
+          // OSCAT blocks from growing a debug table several times its useful
+          // size. Retain overrides it because a block restored from half its
+          // state is worse than one not restored at all.
+          const wantLocals = (flags & LEAF_FLAG_RETAIN) !== 0;
+          for (const lf of fbSym.libraryLeaves) {
+            if (lf.local && !wantLocals) continue;
+            // The library recorded its own qualifiers; the instance's
+            // inherited flags are OR-ed on top. A `VAR RETAIN` member inside
+            // the library is retained however the instance was declared, and
+            // `VAR RETAIN inst : LibFB;` retains the whole instance.
+            let leafFlags = flags;
+            if (lf.readOnly) leafFlags |= LEAF_FLAG_READONLY;
+            if (lf.retain) leafFlags |= LEAF_FLAG_RETAIN;
+            sink.leaf(
+              `${path}.${lf.path}`,
+              `${cppExpr}${lf.cpp}`,
+              lf.type,
+              leafFlags,
+            );
+          }
+          return;
+        }
+
+        // An archive built before flattened leaves existed. Showing the
+        // interface alone is right for the DEBUGGER — that has always been the
+        // black-box contract — but it is not right for RETAIN, where dropping
+        // a block's internal state restores it into a configuration it could
+        // never have run into. A TON that keeps Q and ET but loses its start
+        // timestamp is the concrete case. Refuse loudly instead of half-doing
+        // it.
+        if (flags & LEAF_FLAG_RETAIN) {
+          sink.incomplete(
+            path,
+            `function block type ${typeRef.name} comes from a library built ` +
+              `before retain support, so its internal state cannot be ` +
+              `retained. Rebuild the library with the current STruC++, or ` +
+              `declare this instance NON_RETAIN.`,
+          );
+          return;
+        }
+
+        // `name` is the FB type declaring these members, so it is the owner
+        // for both mangling collisions.
+        for (const v of [...fbSym.inputs, ...fbSym.outputs, ...fbSym.inouts]) {
+          visitTypeRef(
+            `${path}.${v.name.toUpperCase()}`,
+            `${cppExpr}.${memberCppName(v.name, v.declaration.type, name)}`,
+            v.declaration.type,
+            flags,
+          );
+        }
+        return;
+      }
+
+      // User-defined FB: every persistent member, including VAR locals. The
+      // analyzer leaves the symbol's flat arrays empty and keeps the
+      // declarations here, so this is the whole story. VAR_TEMP and
+      // VAR_EXTERNAL are excluded — those are not persistent state.
+      for (const block of fbSym.declaration.varBlocks) {
+        if (
+          block.blockType === "VAR" ||
+          block.blockType === "VAR_INPUT" ||
+          block.blockType === "VAR_OUTPUT" ||
+          block.blockType === "VAR_IN_OUT"
+        ) {
+          // A `VAR CONSTANT` inside a function block is read-only for every
+          // instance of it, and a `VAR RETAIN` member is retained in every
+          // instance, so the block's own qualifiers are folded in here rather
+          // than only at the program level.
+          const memberFlags = applyBlockFlags(flags, block);
+          for (const fieldDecl of block.declarations) {
+            for (const fieldName of fieldDecl.names) {
+              visitTypeRef(
+                `${path}.${fieldName.toUpperCase()}`,
+                `${cppExpr}.${memberCppName(fieldName, fieldDecl.type, name)}`,
+                fieldDecl.type,
+                memberFlags,
+              );
+            }
+          }
+        }
+      }
+      return;
+    }
+
+    sink.skip(path, `unresolved type name: ${typeRef.name}`);
+  };
+
+  const visitStructFields = (
+    path: string,
+    cppExpr: string,
+    def: StructDefinition,
+    flags: number,
+  ): void => {
+    // `flags` passes straight through: IEC puts CONSTANT on a var *block*, and
+    // a STRUCT declares fields without blocks, so a struct field can never
+    // introduce or clear the bit — it only inherits whatever the declaration
+    // that named the struct carried.
+    for (const fieldDecl of def.fields) {
+      for (const fieldName of fieldDecl.names) {
+        visitTypeRef(
+          `${path}.${fieldName.toUpperCase()}`,
+          // No owner: a STRUCT implements no interfaces, so only the
+          // field-name-matches-its-type collision can apply.
+          `${cppExpr}.${memberCppName(fieldName, fieldDecl.type)}`,
+          fieldDecl.type,
+          flags,
+        );
+      }
+    }
+  };
+
+  /**
+   * Enumerate every element of an array, emitting one debug entry per element.
+   *
+   * Indices are collected across all dimensions and only turned into C++ at the
+   * innermost level, because the accessor depends on the array's rank:
+   * `Array2D`/`Array3D` take every index in one `operator()` call, so emitting a
+   * subscript per dimension as we descend would produce `arr[i][j]` — which has
+   * no matching operator on those containers and fails to compile.
+   * {@link formatArrayElementAccess} owns that rank rule. The IEC display path
+   * stays `[i][j]`, which is what the debug UI shows.
+   */
+  const walkArrayDims = (
+    path: string,
+    cppExpr: string,
+    dims: Array<{ start: number; end: number }>,
+    dimIdx: number,
+    elementTypeName: string,
+    flags: number,
+    indices: number[] = [],
+  ): void => {
+    if (dimIdx >= dims.length) {
+      // Innermost element — visit as a TypeReference with the element type
+      // name. Manufacture a minimal TypeReference for recursion.
+      visitTypeRef(
+        path,
+        formatArrayElementAccess(cppExpr, indices),
+        {
+          kind: "TypeReference",
+          name: elementTypeName,
+          isReference: false,
+          referenceKind: "none",
+        } as TypeReference,
+        flags,
+      );
+      return;
+    }
+    const { start, end } = dims[dimIdx]!;
+    for (let i = start; i <= end; i++) {
+      walkArrayDims(
+        `${path}[${i}]`,
+        cppExpr,
+        dims,
+        dimIdx + 1,
+        elementTypeName,
+        flags,
+        [...indices, i],
+      );
+    }
+  };
+
+  /**
+   * C++ member name for a declaration, by the same rule codegen used to emit it
+   * (see `member-mangling.ts`).
+   *
+   * The table addresses members by name, so it has to agree with the class
+   * definition exactly, in *both* directions. Mangling too little named a member
+   * that does not exist (`RunningLights : RunningLights` is declared
+   * `RUNNINGLIGHTS_`); mangling too much would do the same in reverse, since
+   * `Time : TIME` is declared plain `TIME`. Either way `generated_debug.cpp`
+   * fails to compile and takes the whole firmware build with it — and nothing
+   * catches it earlier, because `strucpp file.st` emits no debug table.
+   *
+   * `ownerTypeName` is the type declaring the member, needed for the
+   * interface-method collision; undefined for a PROGRAM or a STRUCT, neither of
+   * which can implement an interface.
+   */
+  const memberCppName = (
+    varName: string,
+    typeRef: TypeReference | undefined,
+    ownerTypeName?: string,
+  ): string =>
+    mangledMemberName(varName, typeRef?.name, {
+      isUserDefinedType,
+      interfaceMethods:
+        ownerTypeName !== undefined
+          ? fbInterfaceMethods.get(ownerTypeName.toUpperCase())
+          : undefined,
+    });
+
+  const visitVarDecl = (
+    path: string,
+    cppExpr: string,
+    decl: VarDeclaration,
+    flags: number,
+    ownerTypeName?: string,
+  ): void => {
+    for (const varName of decl.names) {
+      visitTypeRef(
+        `${path}.${varName.toUpperCase()}`,
+        `${cppExpr}.${memberCppName(varName, decl.type, ownerTypeName)}`,
+        decl.type,
+        flags,
+      );
+    }
+  };
+
+  return { visitTypeRef, visitVarDecl, memberCppName };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -806,6 +806,34 @@ export function compile(
     );
     debugTableCpp = dbg.debugTableCpp;
     debugMap = dbg.debugMap;
+
+    // A RETAIN the walk could not follow all the way down is a hard error, not
+    // a warning. Building it would produce firmware that restores a function
+    // block into a state it could never have run into — a fault that only
+    // appears after a power cycle and has nothing in the build to point at.
+    // Refusing here costs the user a rebuild of their library; not refusing
+    // costs them a machine that misbehaves once a week.
+    for (const item of dbg.incomplete) {
+      pipeline.errors.push({
+        message: `${item.path}: ${item.reason}`,
+        line: 0,
+        column: 0,
+        severity: "error",
+      });
+    }
+    if (pipeline.errors.length > 0) {
+      return {
+        success: false,
+        cppFiles: codeResult.cppFiles,
+        cppCode: codeResult.cppCode,
+        headerCode: codeResult.headerCode,
+        lineMap: codeResult.lineMap,
+        headerLineMap: codeResult.headerLineMap,
+        errors: pipeline.errors,
+        warnings: pipeline.warnings,
+        ast: pipeline.ast,
+      };
+    }
   }
 
   return {

--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -14,7 +14,13 @@ import type {
 } from "./library-manifest.js";
 import { compile } from "../index.js";
 import { buildChunks } from "./library-chunks.js";
-import type { LibraryVarType } from "./library-manifest.js";
+import {
+  applyBlockFlags,
+  LEAF_FLAG_READONLY,
+  LEAF_FLAG_RETAIN,
+} from "../backend/debug-leaf-types.js";
+import { createLeafWalker } from "../backend/leaf-walker.js";
+import type { LibraryFBLeaf, LibraryVarType } from "./library-manifest.js";
 import type { Expression, TypeReference } from "../frontend/ast.js";
 
 /**
@@ -284,6 +290,74 @@ export function compileLibrary(
 
   // Extract manifest entries from the AST
   const ast = result.ast!;
+
+  /** FB types whose flattening hit something the walk could not address. */
+  const incompleteFBs = new Set<string>();
+
+  /**
+   * Flatten one function block's persistent state into manifest leaves.
+   *
+   * Runs the SAME walk the debug table runs (`leaf-walker.ts`), against the
+   * library's own AST and symbol tables — which is the entire point. Mangling
+   * and type visibility are properties of the declaring unit: only here is it
+   * known that a local's type is user-defined, or that the block implements an
+   * interface whose method name collides with a member. A consumer re-deriving
+   * any of this names members the class does not declare, and
+   * `generated_debug.cpp` then fails to compile.
+   *
+   * Paths and C++ expressions come back RELATIVE to the instance ("" root), so
+   * a consumer concatenates and nothing more.
+   */
+  const flattenFB = (fbName: string): LibraryFBLeaf[] | undefined => {
+    const symbolTables = result.symbolTables;
+    if (!symbolTables) return undefined;
+    const leaves: LibraryFBLeaf[] = [];
+    // Set for the duration of one top-level declaration's walk, so every leaf
+    // below a VAR is marked local however deep it sits.
+    let inLocalBlock = false;
+    const walker = createLeafWalker(ast, symbolTables, {
+      leaf: (path, cppExpr, iecName, flags) => {
+        leaves.push({
+          // Drop the leading "." both roots carry from the walk.
+          path: path.slice(1),
+          cpp: cppExpr,
+          type: iecName.toUpperCase(),
+          ...(inLocalBlock ? { local: true as const } : {}),
+          ...(flags & LEAF_FLAG_READONLY ? { readOnly: true as const } : {}),
+          ...(flags & LEAF_FLAG_RETAIN ? { retain: true as const } : {}),
+        });
+      },
+      // A library may legitimately contain state the debugger cannot address
+      // (an opaque dependency type, a variable-length array). Recording it
+      // here would claim the leaf list is complete when it is not, so those
+      // blocks simply do not offer leaves — and the consumer's RETAIN gate
+      // reports it against the instance, where the user can act on it.
+      skip: () => {
+        incompleteFBs.add(fbName.toUpperCase());
+      },
+      incomplete: () => {
+        incompleteFBs.add(fbName.toUpperCase());
+      },
+    });
+    const fb = ast.functionBlocks.find((f) => f.name === fbName);
+    if (!fb) return undefined;
+    for (const block of fb.varBlocks) {
+      if (
+        block.blockType !== "VAR" &&
+        block.blockType !== "VAR_INPUT" &&
+        block.blockType !== "VAR_OUTPUT" &&
+        block.blockType !== "VAR_IN_OUT"
+      ) {
+        continue;
+      }
+      const memberFlags = applyBlockFlags(0, block);
+      inLocalBlock = block.blockType === "VAR";
+      for (const decl of block.declarations) {
+        walker.visitVarDecl("", "", decl, memberFlags, fb.name);
+      }
+    }
+    return incompleteFBs.has(fbName.toUpperCase()) ? undefined : leaves;
+  };
   const headerFileName = `${options.name}.hpp`;
 
   // Slice emitted code into per-symbol chunks via the boundary
@@ -363,6 +437,14 @@ export function compileLibrary(
                     d.names.map((n) => serializeVarType(n, d.type)),
                   ),
                 ),
+              // Every persistent leaf of one instance, interface and locals
+              // alike. Omitted when the walk could not reach all of it, so
+              // "present" always means "complete" — a consumer never has to
+              // wonder whether a short list is the whole story.
+              ...((): { leaves?: LibraryFBLeaf[] } => {
+                const leaves = flattenFB(fb.name);
+                return leaves ? { leaves } : {};
+              })(),
             },
             catByName,
           ),

--- a/src/library/library-loader.ts
+++ b/src/library/library-loader.ts
@@ -357,10 +357,17 @@ export function registerLibrarySymbols(
     }
   }
 
-  // Register function blocks. The library only ships its public interface
-  // (inputs/outputs/inouts) — locals are implementation details and stay
-  // inside the compiled archive. The debugger treats library FBs as
-  // black boxes for the same reason: only the user-facing API is exposed.
+  // Register function blocks.
+  //
+  // The interface (inputs/outputs/inouts) is what a consuming compilation
+  // type-checks against, and what the debugger shows: library FBs stay black
+  // boxes, because their locals are implementation details.
+  //
+  // `leaves` is the exception, and only retain uses it. It carries every
+  // persistent leaf inside the block, already flattened and already mangled by
+  // the library that compiled it, because a consumer can do neither for itself
+  // — see `LibraryFBLeaf`. It does not widen what the debugger displays; it is
+  // what lets a retained instance keep the state it actually runs on.
   for (const fb of manifest.functionBlocks) {
     try {
       symbolTables.globalScope.define({
@@ -381,6 +388,10 @@ export function registerLibrarySymbols(
         outputs: fb.outputs.map((o) => makeVarSymbol(o, "output")),
         inouts: fb.inouts.map((io) => makeVarSymbol(io, "inout")),
         locals: [],
+        libraryName: manifest.name,
+        // Present from archives built with retain support; undefined for
+        // older ones, which the leaf walk reports rather than papers over.
+        ...(fb.leaves ? { libraryLeaves: fb.leaves } : {}),
       });
     } catch (e) {
       if (!(e instanceof DuplicateSymbolError)) throw e;

--- a/src/library/library-manifest.ts
+++ b/src/library/library-manifest.ts
@@ -81,6 +81,68 @@ export interface LibraryVarType {
 }
 
 /**
+ * One elementary leaf of a library function block's persistent state, flattened.
+ *
+ * WHY THE LIBRARY HAS TO SHIP THESE RATHER THAN THE CONSUMER DERIVING THEM
+ * ----------------------------------------------------------------------
+ * A consuming compilation cannot work out the C++ member name of anything
+ * inside a library FB, and cannot see far enough to find every leaf:
+ *
+ *   • Mangling is decided against the DECLARING unit. `mangledMemberName()`
+ *     adds a trailing underscore when a member's name matches its own type's
+ *     name *and that type is user-defined*, or when it collides with a method
+ *     of an interface the owning FB implements. Both predicates are answered
+ *     from the library's own AST and symbol tables. A library-internal type
+ *     never reaches the manifest, so the consumer resolves it as "not
+ *     user-defined" and names an unmangled member the class does not declare —
+ *     `generated_debug.cpp` then fails to compile and takes the firmware build
+ *     with it.
+ *
+ *   • Depth is invisible. A local may be a library-internal STRUCT, or another
+ *     FB instance, neither of which is exported. Walking only what the manifest
+ *     exports would silently stop at the first such member, which is how you
+ *     get a retained instance that restores half its state.
+ *
+ * So the library compiler runs the same leaf walk the debug table runs, against
+ * the sources it is compiling, and writes the answer down. Paths and C++
+ * expressions here are RELATIVE to the instance, and the consumer only
+ * concatenates.
+ */
+export interface LibraryFBLeaf {
+  /** Dotted ST path below the instance, upper-cased, array elements spelled
+   *  `NAME[i]` — exactly the debug table's own path grammar, so a consumer
+   *  builds a full path with `${instancePath}.${leaf.path}` and nothing else. */
+  path: string;
+  /** C++ member expression below the instance, already mangled, starting with
+   *  a `.` (e.g. `.STATE.COUNT_`, `.BUF[3]`). Appended verbatim to the
+   *  instance expression. */
+  cpp: string;
+  /** Elementary IEC type name of the leaf (`BOOL`, `TIME`, …). */
+  type: string;
+  /**
+   * The leaf lives under a VAR block — a local, not part of the block's public
+   * interface.
+   *
+   * Set from the TOP-LEVEL declaring block and inherited by the whole subtree,
+   * so every leaf of a `VAR cu_t : R_TRIG;` is local even though `Q` is an
+   * output of R_TRIG itself.
+   *
+   * What it gates: the debugger keeps treating library blocks as black boxes
+   * and addresses only the interface, which is the long-standing contract and
+   * keeps the debug table from ballooning on a project that instantiates a few
+   * hundred OSCAT blocks. RETAIN is the one case that overrides it, because
+   * there correctness demands the whole instance.
+   */
+  local?: true;
+  /** The declaring VAR block was CONSTANT. */
+  readOnly?: true;
+  /** The declaring VAR block was RETAIN — the library author marked this member
+   *  retained, so it is retained in every instance regardless of how the
+   *  instance itself is declared. */
+  retain?: true;
+}
+
+/**
  * Library function block entry in a manifest.
  */
 export interface LibraryFBEntry {
@@ -92,6 +154,17 @@ export interface LibraryFBEntry {
   outputs: LibraryVarType[];
   /** In-out variables */
   inouts: LibraryVarType[];
+  /** Every persistent leaf of one instance — interface AND locals, flattened
+   *  through structs, arrays and nested FB instances. See {@link LibraryFBLeaf}
+   *  for why this cannot be reconstructed by the consumer.
+   *
+   *  Optional because archives compiled before NODE-94 do not carry it. A
+   *  consumer that needs complete state (only the retain path does) must treat
+   *  its absence as an ERROR and say so, never fall back to the interface
+   *  quietly: retaining a TON's Q and ET while dropping the internal start
+   *  timestamp produces a block that restores into a state it could never have
+   *  reached by running. */
+  leaves?: LibraryFBLeaf[];
   /** Block-level help text shown in editor hover dialogs. Authored in
    *  the library's `library.json` and merged into the manifest at build
    *  time (see scripts/generate-*.mjs). Optional so existing archives

--- a/src/semantic/symbol-table.ts
+++ b/src/semantic/symbol-table.ts
@@ -15,6 +15,7 @@ import type {
   VarDeclaration,
   IECType,
 } from "../frontend/ast.js";
+import type { LibraryFBLeaf } from "../library/library-manifest.js";
 import { ELEMENTARY_TYPES } from "./type-utils.js";
 
 // =============================================================================
@@ -96,6 +97,29 @@ export interface FunctionBlockSymbol extends BaseSymbol {
   outputs: VariableSymbol[];
   inouts: VariableSymbol[];
   locals: VariableSymbol[];
+  /**
+   * Name of the library this function block came from, set only by
+   * `registerLibrarySymbols`.
+   *
+   * The explicit marker that tells a library FB from a user-defined one. The
+   * leaf walk used to infer it from "are the flat arrays populated", which is
+   * a proxy that fails quietly in both directions — a user FB read as a
+   * library one loses its whole subtree, and vice versa names members that do
+   * not exist.
+   */
+  libraryName?: string;
+  /**
+   * For a function block registered from a .stlib manifest: every persistent
+   * leaf of one instance, already flattened and already mangled by the library
+   * that compiled it.
+   *
+   * Undefined for user-defined FBs (their declarations are right here in
+   * `declaration.varBlocks`) and for archives built before NODE-94. The leaf
+   * walk needs it because a consuming compilation cannot name a
+   * library-internal member or see through a library-internal type — see
+   * `LibraryFBLeaf` for the full argument.
+   */
+  libraryLeaves?: readonly LibraryFBLeaf[];
 }
 
 /**

--- a/tests/backend/debug-table-gen.test.ts
+++ b/tests/backend/debug-table-gen.test.ts
@@ -860,6 +860,157 @@ END_PROGRAM${CFG_R}`,
     expect(byPath.get("INSTANCE0.AFTER")?.retain).toBe(true);
   });
 
+  // The gap this closes: a retained library FB used to keep its interface and
+  // silently drop everything the block actually runs on. A TON restored with Q
+  // and ET but without START_TIME comes back in a state it could never have
+  // reached by running.
+  it("retains every internal leaf of a library FB instance", () => {
+    const r = compile(
+      `PROGRAM Main
+VAR RETAIN t : TON; END_VAR
+VAR go : BOOL; END_VAR
+  t(IN := go, PT := T#5s);
+END_PROGRAM${CFG_R}`,
+      { libraries: discoverStlibs("libs") },
+    );
+    expect(r.errors.map((e) => e.message)).toEqual([]);
+    const retained = (r.debugMap!.retainVars ?? []).map((v) => v.path);
+    // The interface…
+    expect(retained).toContain("INSTANCE0.T.IN");
+    expect(retained).toContain("INSTANCE0.T.PT");
+    expect(retained).toContain("INSTANCE0.T.Q");
+    expect(retained).toContain("INSTANCE0.T.ET");
+    // …and the state that makes the interface meaningful.
+    expect(retained).toContain("INSTANCE0.T.STATE");
+    expect(retained).toContain("INSTANCE0.T.PREV_IN");
+    expect(retained).toContain("INSTANCE0.T.CURRENT_TIME");
+    expect(retained).toContain("INSTANCE0.T.START_TIME");
+    // The un-retained sibling stays out of the blob.
+    expect(retained).not.toContain("INSTANCE0.GO");
+  });
+
+  it("recurses into an FB nested inside a retained library FB", () => {
+    // CTU holds `VAR cu_t : R_TRIG`. Its edge-detect state is two levels down
+    // and invisible to the consuming compilation — only the archive knows it
+    // is there.
+    const r = compile(
+      `PROGRAM Main
+VAR RETAIN c : CTU; END_VAR
+VAR pulse : BOOL; END_VAR
+  c(CU := pulse, PV := 10);
+END_PROGRAM${CFG_R}`,
+      { libraries: discoverStlibs("libs") },
+    );
+    expect(r.errors.map((e) => e.message)).toEqual([]);
+    const retained = (r.debugMap!.retainVars ?? []).map((v) => v.path);
+    expect(retained).toContain("INSTANCE0.C.CV");
+    expect(retained).toContain("INSTANCE0.C.CU_T.CLK");
+    expect(retained).toContain("INSTANCE0.C.CU_T.Q");
+    expect(retained).toContain("INSTANCE0.C.CU_T.M");
+  });
+
+  it("keeps library FB locals out of the table when the instance is not retained", () => {
+    // The black-box contract still holds everywhere retain is not involved —
+    // otherwise every project instantiating a few hundred OSCAT blocks pays
+    // for internals nobody addresses.
+    const r = compile(
+      `PROGRAM Main
+VAR t : TON; END_VAR
+VAR go : BOOL; END_VAR
+  t(IN := go, PT := T#5s);
+END_PROGRAM${CFG_R}`,
+      { libraries: discoverStlibs("libs") },
+    );
+    const paths = r.debugMap!.leaves.map((l) => l.path);
+    expect(paths).toContain("INSTANCE0.T.Q");
+    expect(paths).not.toContain("INSTANCE0.T.START_TIME");
+    expect(paths).not.toContain("INSTANCE0.T.STATE");
+  });
+
+  it("lets NON_RETAIN opt a library FB instance out again", () => {
+    const r = compile(
+      `PROGRAM Main
+VAR NON_RETAIN t : TON; END_VAR
+VAR RETAIN boots : DINT; END_VAR
+  t(IN := FALSE, PT := T#5s);
+END_PROGRAM${CFG_R}`,
+      { libraries: discoverStlibs("libs") },
+    );
+    const retained = (r.debugMap!.retainVars ?? []).map((v) => v.path);
+    expect(retained).toEqual(["INSTANCE0.BOOTS"]);
+  });
+
+  it("refuses a RETAIN that reaches into a library built without leaves", () => {
+    // The honest failure. Before this, the same program compiled and produced
+    // a block that restored half its state — the fault only visible after a
+    // power cycle, with nothing in the build to point at.
+    const archives = discoverStlibs("libs").map((a) => ({
+      ...a,
+      manifest: {
+        ...a.manifest,
+        functionBlocks: a.manifest.functionBlocks.map(
+          ({ leaves: _leaves, ...rest }) => rest,
+        ),
+      },
+    }));
+    const r = compile(
+      `PROGRAM Main
+VAR RETAIN t : TON; END_VAR
+  t(IN := FALSE, PT := T#5s);
+END_PROGRAM${CFG_R}`,
+      { libraries: archives },
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toMatch(
+      /INSTANCE0\.T:.*built before retain support/,
+    );
+  });
+
+  it("still compiles that program when the instance is not retained", () => {
+    const archives = discoverStlibs("libs").map((a) => ({
+      ...a,
+      manifest: {
+        ...a.manifest,
+        functionBlocks: a.manifest.functionBlocks.map(
+          ({ leaves: _leaves, ...rest }) => rest,
+        ),
+      },
+    }));
+    const r = compile(
+      `PROGRAM Main
+VAR t : TON; END_VAR
+  t(IN := FALSE, PT := T#5s);
+END_PROGRAM${CFG_R}`,
+      { libraries: archives },
+    );
+    expect(r.success).toBe(true);
+    expect(r.debugMap!.leaves.map((l) => l.path)).toContain("INSTANCE0.T.Q");
+  });
+
+  it("reports the blob size the target has to be able to hold", () => {
+    // 14-byte header + DINT(4) + BOOL(1). The editor gates a build on this;
+    // getting it wrong there means firmware that silently drops retain.
+    const { map } = mapOf(
+      `PROGRAM Main
+VAR RETAIN boots : DINT; END_VAR
+VAR RETAIN armed : BOOL; END_VAR
+VAR live : DINT; END_VAR
+  live := boots;
+END_PROGRAM${CFG_R}`,
+    );
+    expect(map.retainBlobSize).toBe(14 + 4 + 1);
+  });
+
+  it("omits the blob size when nothing is retained", () => {
+    const { map } = mapOf(
+      `PROGRAM Main
+VAR live : DINT; END_VAR
+  live := 1;
+END_PROGRAM${CFG_R}`,
+    );
+    expect(map.retainBlobSize).toBeUndefined();
+  });
+
   it("retains a CONFIGURATION VAR_GLOBAL and not its plain sibling", () => {
     const { byPath } = mapOf(
       `PROGRAM Main

--- a/tests/integration/debug-table-cpp.test.ts
+++ b/tests/integration/debug-table-cpp.test.ts
@@ -22,7 +22,62 @@ import * as path from "path";
 import * as os from "os";
 import { execSync } from "child_process";
 import { compile } from "../../src/index.js";
+import { discoverStlibs } from "../../src/node/library-loader.js";
 import { hasGpp } from "./test-helpers.js";
+/**
+ * Harness for the retained-library-FB round trip. Kept out of the test body so
+ * the C++ is readable as C++ rather than as an escaped template literal.
+ */
+const MAIN_CPP_LIBFB_RETAIN = `#include "generated.hpp"
+#include "debug_dispatch.hpp"
+#include "iec_retain.hpp"
+#include <cstdio>
+strucpp::Configuration_CONFIG0 g_config;
+using namespace strucpp;
+static int fails = 0;
+static void chk(const char* what, bool ok) { if (!ok) { printf("FAIL %s\\n", what); ++fails; } }
+static uint16_t rd(uint8_t a, uint16_t e, uint8_t* d) { return debug::handle_read(a, e, d); }
+static uint8_t  wr(uint8_t a, uint16_t e, const uint8_t* b, uint16_t n) { return debug::handle_write(a, e, b, n); }
+static uint16_t sz(uint8_t a, uint16_t e) { return debug::handle_size(a, e); }
+
+int main() {
+  // A timer mid-count: the interface says "running", and START_TIME is the
+  // only thing that says since when.
+  g_config.INSTANCE0.T.IN = true;
+  g_config.INSTANCE0.T.PT = 5000;
+  g_config.INSTANCE0.T.Q  = false;
+  g_config.INSTANCE0.T.ET = 1234;
+  g_config.INSTANCE0.T.STATE = 1;
+  g_config.INSTANCE0.T.PREV_IN = true;
+  g_config.INSTANCE0.T.START_TIME = 987654;
+  g_config.INSTANCE0.LOOSE.START_TIME = 555;
+
+  unsigned char blob[1024] = {0};
+  size_t n = retain::pack(blob, sizeof(blob), rd, sz);
+  chk("packed", n == retain::blob_size(sz));
+
+  // Power cycle.
+  g_config.INSTANCE0.T.IN = false;
+  g_config.INSTANCE0.T.PT = 0;
+  g_config.INSTANCE0.T.ET = 0;
+  g_config.INSTANCE0.T.STATE = 0;
+  g_config.INSTANCE0.T.PREV_IN = false;
+  g_config.INSTANCE0.T.START_TIME = 0;
+  g_config.INSTANCE0.LOOSE.START_TIME = 0;
+
+  chk("unpack ok", retain::unpack(blob, n, wr, sz) == retain::LoadResult::Ok);
+  chk("interface ET", (long long)g_config.INSTANCE0.T.ET == 1234);
+  chk("internal STATE", (int)g_config.INSTANCE0.T.STATE == 1);
+  chk("internal PREV_IN", (bool)g_config.INSTANCE0.T.PREV_IN == true);
+  chk("internal START_TIME", (long long)g_config.INSTANCE0.T.START_TIME == 987654);
+  // The whole point: the un-retained instance stays cold.
+  chk("non-retained instance untouched", (long long)g_config.INSTANCE0.LOOSE.START_TIME == 0);
+
+  printf(fails ? "FAILURES=%d\\n" : "ALL_OK\\n", fails);
+  return fails ? 1 : 0;
+}
+`;
+
 
 const RUNTIME_INCLUDE = path.resolve(__dirname, "../../src/runtime/include");
 
@@ -544,6 +599,61 @@ int main() {
       `g++ -std=c++17 -I"${RUNTIME_INCLUDE}" -I"${dir}" -o "${bin}" ` +
         `"${path.join(dir, "main.cpp")}" "${path.join(dir, "generated.cpp")}" ` +
         `"${path.join(dir, "generated_debug.cpp")}"`,
+      { encoding: "utf-8" },
+    );
+    expect(execSync(`"${bin}"`, { encoding: "utf-8" }).trim()).toBe("ALL_OK");
+  });
+
+  // The gap this closes, proved against the real generated C++ rather than the
+  // manifest: a retained TON used to come back with Q and ET but without
+  // START_TIME, i.e. in a state the block could never have run into.
+  it("restores a retained library FB's internal state, not just its interface", () => {
+    const result = compile(
+      `PROGRAM Main
+VAR RETAIN t : TON; END_VAR
+VAR loose : TON; END_VAR
+  t(IN := TRUE, PT := T#5s);
+  loose(IN := TRUE, PT := T#5s);
+END_PROGRAM
+CONFIGURATION Config0
+  RESOURCE Res0 ON PLC
+    TASK task0(INTERVAL := T#20ms, PRIORITY := 0);
+    PROGRAM instance0 WITH task0 : Main;
+  END_RESOURCE
+END_CONFIGURATION`,
+      { headerFileName: "generated.hpp", libraries: discoverStlibs("libs") },
+    );
+    expect(result.errors.map((e) => e.message)).toEqual([]);
+
+    // Every internal leaf is in the blob…
+    const retained = (result.debugMap!.retainVars ?? []).map((v) => v.path);
+    expect(retained).toContain("INSTANCE0.T.START_TIME");
+    // …and the un-retained sibling contributes nothing.
+    expect(retained.filter((p) => p.startsWith("INSTANCE0.LOOSE."))).toEqual([]);
+
+    const dir = path.join(tempDir, "libfb-retain");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "generated.hpp"), result.headerCode);
+    fs.writeFileSync(
+      path.join(dir, "generated_debug.cpp"),
+      result.debugTableCpp!,
+    );
+    fs.writeFileSync(path.join(dir, "main.cpp"), MAIN_CPP_LIBFB_RETAIN);
+
+    // Per-file, not the concatenated `cppCode`: a compilation that pulls in a
+    // library emits the library's POUs as their own translation units, and
+    // linking both forms duplicates every symbol in them.
+    const sources = (result.cppFiles ?? []).map((f) => {
+      const fp = path.join(dir, f.name);
+      fs.writeFileSync(fp, f.content);
+      return `"${fp}"`;
+    });
+
+    const bin = path.join(dir, "libfb-retain");
+    execSync(
+      `g++ -std=c++17 -I"${RUNTIME_INCLUDE}" -I"${dir}" -o "${bin}" ` +
+        `"${path.join(dir, "main.cpp")}" ` +
+        `"${path.join(dir, "generated_debug.cpp")}" ${sources.join(" ")}`,
       { encoding: "utf-8" },
     );
     expect(execSync(`"${bin}"`, { encoding: "utf-8" }).trim()).toBe("ALL_OK");


### PR DESCRIPTION
## The gap

A retained library function block kept only what the `.stlib` manifest exposed — inputs, outputs, in-outs. Everything the block actually runs on stayed behind.

A retained `TON` came back with `Q` and `ET` but without `STATE`, `PREV_IN` or `START_TIME`. On the next start it saw no rising edge to explain the values it was holding, and restarted its wait: a block restored into a configuration it could never have reached by running. That is worse than not retaining it, because it looks like it worked.

## Why the consumer cannot fix this for itself

Two things stop it, and both are properties of the *declaring* unit:

- **Mangling.** `mangledMemberName` adds a trailing underscore when a member's name matches its own type's name *and that type is user-defined*, or when it collides with a method of an interface the owning FB implements. Both predicates are answered from the library's own AST and symbol tables. A library-internal type never reaches the manifest, so a consumer resolves it as "not user-defined" and names a member the class does not declare — `generated_debug.cpp` then fails to compile and takes the firmware build with it.
- **Depth.** A local may be a library-internal `STRUCT` or another FB instance, neither exported. Walking only what the manifest exports stops at the first one — the same partial retain, one level down.

So the library compiler runs the walk itself and writes the answer down.

## What changed

`LibraryFBEntry.leaves` carries every persistent leaf of one instance — flattened through structs, arrays and nested instances — each with its path, its already-mangled C++ expression, and its type.

**Coverage across the five bundled archives: 224 of 224 function blocks**, OSCAT's 172 included.

```
TON:  IN PT Q ET  +  STATE PREV_IN CURRENT_TIME START_TIME
CTU:  CU R PV Q CV  +  CU_T.CLK CU_T.Q CU_T.M      ← nested R_TRIG, two levels down
```

**One walk, not two.** The flattening moved to `leaf-walker.ts`, shared by the debug table and the library compiler. They decide the C++ member name of every entry and had agreed only by copy; a disagreement there breaks the firmware build with nothing catching it earlier. `TAG`, the flag bits and the IEC tables moved to `debug-leaf-types.ts` so neither module imports the other.

**Locals only when retained.** The debugger keeps its black-box view of library blocks everywhere else — the long-standing contract, and what stops a project instantiating a few hundred OSCAT blocks from growing a debug table several times its useful size.

**Old archives are refused, not half-honoured.** `VAR RETAIN t : SomeOldLibFB` now fails the compile with a message naming the block and the fix. Silently keeping half of it is the behaviour this PR exists to remove.

**`retainBlobSize`** joins the debug map so the editor can refuse a program the target cannot hold — it matters more now, since a retained `TON` is 36 bytes and the baremetal 512-byte cap is reached at about fourteen of them.

## Verification

`2280 passed | 7 skipped`, including a new compiled round-trip that packs, wipes and restores a retained `TON` through the real runtime C++.

On an SLM-RP4 — two identical `TON`s, 10-second preset, differing only in `RETAIN`; both left to elapse, then the program reloaded:

```
before reload   dwell(RETAIN): Q=True  ET=10s      STATE=2  |  loose: Q=True  ET=10s
2s after        dwell(RETAIN): Q=True  ET=10s      STATE=2  |  loose: Q=False ET=3s160ms
6s after        dwell(RETAIN): Q=True  ET=10s      STATE=2  |  loose: Q=False ET=8s400ms
```

The retained timer comes back already elapsed. The identical un-retained one restarts its ten-second wait. Before this PR, both restarted.

## Note for reviewers

`.stlib` archives are gitignored build artifacts. `prepack` runs `npm run build` and `files` ships `libs/`, so every release carries freshly-built archives — no separate rebuild step is needed for this format to reach the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3