### PR TITLE
feat(library): carry C/C++ and Python blocks in the .stlib

### DIFF
--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -22,7 +22,6 @@ import {
 } from "./native-sources.js";
 import type {
   LibraryFBEntry,
-  LibraryFunctionEntry,
   LibraryManifest,
   LibraryVarType,
 } from "./library-manifest.js";
@@ -276,10 +275,11 @@ function compileNativeEntries(
   },
 ): {
   functionBlocks: LibraryFBEntry[];
-  functions: LibraryFunctionEntry[];
   errors: Array<{ message: string; file?: string; line?: number }>;
 } {
-  const empty = { functionBlocks: [], functions: [], errors: [] };
+  // Native blocks are always FUNCTION_BLOCKs — `projectNativeHeaderToSt`
+  // rejects FUNCTION and PROGRAM — so there is no function list to return.
+  const empty = { functionBlocks: [], errors: [] };
   if (native.length === 0) return empty;
 
   const projected: string[] = [];
@@ -346,9 +346,56 @@ function compileNativeEntries(
     functionBlocks: result.ast.functionBlocks.map((fb) =>
       tagNative(buildFBEntry(fb)),
     ),
-    functions: [],
     errors: [],
   };
+}
+
+/**
+ * Every exported name in a manifest that is claimed by more than one symbol.
+ *
+ * A library exports one thing per name. STruC++'s own duplicate detection only
+ * fires within a single kind and a single translation unit — two
+ * `FUNCTION_BLOCK Foo` in one compile is caught, but `FUNCTION Foo` beside
+ * `FUNCTION_BLOCK Foo` is not, and native headers compile in a separate unit
+ * so nothing there is compared against the ST at all.
+ *
+ * The result is a manifest with two entries under one name, no error, and a
+ * consumer picking whichever it happens to read last. Nothing downstream
+ * currently validates against these entries, so today it goes unnoticed — but
+ * a published `.stlib` is immutable, and the next reader that does validate
+ * inherits the ambiguity. Cheaper to refuse to emit it.
+ */
+function findDuplicateExports(manifest: LibraryManifest): string[] {
+  const kindsByName = new Map<string, string[]>();
+  const claim = (name: string, kind: string): void => {
+    const key = name.toUpperCase();
+    const kinds = kindsByName.get(key);
+    if (kinds) kinds.push(kind);
+    else kindsByName.set(key, [kind]);
+  };
+
+  for (const fn of manifest.functions) claim(fn.name, "function");
+  for (const fb of manifest.functionBlocks) {
+    claim(
+      fb.name,
+      fb.implementation
+        ? `${fb.implementation} function block`
+        : "function block",
+    );
+  }
+  for (const type of manifest.types) claim(type.name, "type");
+  for (const global of manifest.globals ?? [])
+    claim(global.name, "global variable");
+
+  const messages: string[] = [];
+  for (const [name, kinds] of kindsByName) {
+    if (kinds.length < 2) continue;
+    messages.push(
+      `"${name}" is exported ${kinds.length} times by this library (as ${kinds.join(", ")}). ` +
+        "A library exports one symbol per name — rename or remove one of them.",
+    );
+  }
+  return messages;
 }
 
 export function compileLibrary(
@@ -404,15 +451,25 @@ export function compileLibrary(
   // unit would fail, which is what used to make an all-native library
   // unbuildable.
   if (stSources.length === 0) {
+    const nativeOnlyManifest: LibraryManifest = {
+      ...emptyManifest(options),
+      functionBlocks: nativeEntries.functionBlocks,
+      headers: [`${options.name}.hpp`],
+      sourceFiles: sources.map((s) => s.fileName),
+    };
+    const duplicates = findDuplicateExports(nativeOnlyManifest);
+    if (duplicates.length > 0) {
+      return {
+        success: false,
+        manifest: emptyManifest(options),
+        headerCode: "",
+        cppCode: "",
+        errors: duplicates.map((message) => ({ message })),
+      };
+    }
     return {
       success: true,
-      manifest: {
-        ...emptyManifest(options),
-        functionBlocks: nativeEntries.functionBlocks,
-        functions: nativeEntries.functions,
-        headers: [`${options.name}.hpp`],
-        sourceFiles: sources.map((s) => s.fileName),
-      },
+      manifest: nativeOnlyManifest,
       headerCode: "",
       cppCode: "",
       chunks: [],
@@ -486,93 +543,109 @@ export function compileLibrary(
     options.dependencies ?? [],
   );
 
-  return {
-    success: true,
-    manifest: {
-      name: options.name,
-      version: options.version,
-      namespace: options.namespace,
-      functions: ast.functions.map((fn) =>
-        tagDocumentation(
+  const builtManifest: LibraryManifest = {
+    name: options.name,
+    version: options.version,
+    namespace: options.namespace,
+    functions: ast.functions.map((fn) =>
+      tagDocumentation(
+        tagCategory(
+          {
+            name: fn.name,
+            returnType: fn.returnType.name,
+            parameters: fn.varBlocks.flatMap((block) =>
+              block.declarations.flatMap((decl) => {
+                const initialValue =
+                  decl.initialValue !== undefined
+                    ? serializeInitialValue(decl.initialValue)
+                    : undefined;
+                return decl.names.map((name) => ({
+                  name,
+                  type: decl.type.name,
+                  direction:
+                    block.blockType === "VAR_OUTPUT"
+                      ? "output"
+                      : block.blockType === "VAR_IN_OUT"
+                        ? "inout"
+                        : "input",
+                  // Present ⇒ optional input (default supplied); absent ⇒
+                  // mandatory. Preserved from user ST and CODESYS-imported ST.
+                  ...(initialValue !== undefined ? { initialValue } : {}),
+                }));
+              }),
+            ),
+          },
+          catByName,
+        ),
+        docByName,
+      ),
+    ),
+    functionBlocks: [
+      ...ast.functionBlocks.map((fb) =>
+        tagDocumentation(tagCategory(buildFBEntry(fb), catByName), docByName),
+      ),
+      ...nativeEntries.functionBlocks,
+    ],
+    types: ast.types.map((t) => {
+      const kind: "struct" | "enum" | "alias" =
+        t.definition.kind === "StructDefinition"
+          ? "struct"
+          : t.definition.kind === "EnumDefinition"
+            ? "enum"
+            : "alias";
+      const entry: {
+        name: string;
+        kind: typeof kind;
+        fields?: Array<{ name: string; type: string }>;
+      } = { name: t.name, kind };
+      // Export struct member fields so consumers can type `x.field` access
+      // on a dependency struct.
+      if (t.definition.kind === "StructDefinition") {
+        entry.fields = t.definition.fields.flatMap((decl) =>
+          decl.names.map((name) => ({ name, type: decl.type.name })),
+        );
+      }
+      return tagDocumentation(tagCategory(entry, catByName), docByName);
+    }),
+    // Exported VAR_GLOBAL variables — their storage is emitted as inlineGlobal
+    // chunks; this list lets consumers' analyzers resolve the symbols. Every
+    // importing program merges all libraries' globals into one global scope.
+    globals: ast.globalVarBlocks.flatMap((block) =>
+      block.declarations.flatMap((decl) =>
+        decl.names.map((name) =>
           tagCategory(
             {
-              name: fn.name,
-              returnType: fn.returnType.name,
-              parameters: fn.varBlocks.flatMap((block) =>
-                block.declarations.flatMap((decl) => {
-                  const initialValue =
-                    decl.initialValue !== undefined
-                      ? serializeInitialValue(decl.initialValue)
-                      : undefined;
-                  return decl.names.map((name) => ({
-                    name,
-                    type: decl.type.name,
-                    direction:
-                      block.blockType === "VAR_OUTPUT"
-                        ? "output"
-                        : block.blockType === "VAR_IN_OUT"
-                          ? "inout"
-                          : "input",
-                    // Present ⇒ optional input (default supplied); absent ⇒
-                    // mandatory. Preserved from user ST and CODESYS-imported ST.
-                    ...(initialValue !== undefined ? { initialValue } : {}),
-                  }));
-                }),
-              ),
+              name,
+              type: decl.type.name,
+              ...(block.isConstant ? { constant: true } : {}),
             },
             catByName,
           ),
-          docByName,
         ),
       ),
-      functionBlocks: [
-        ...ast.functionBlocks.map((fb) =>
-          tagDocumentation(tagCategory(buildFBEntry(fb), catByName), docByName),
-        ),
-        ...nativeEntries.functionBlocks,
-      ],
-      types: ast.types.map((t) => {
-        const kind: "struct" | "enum" | "alias" =
-          t.definition.kind === "StructDefinition"
-            ? "struct"
-            : t.definition.kind === "EnumDefinition"
-              ? "enum"
-              : "alias";
-        const entry: {
-          name: string;
-          kind: typeof kind;
-          fields?: Array<{ name: string; type: string }>;
-        } = { name: t.name, kind };
-        // Export struct member fields so consumers can type `x.field` access
-        // on a dependency struct.
-        if (t.definition.kind === "StructDefinition") {
-          entry.fields = t.definition.fields.flatMap((decl) =>
-            decl.names.map((name) => ({ name, type: decl.type.name })),
-          );
-        }
-        return tagDocumentation(tagCategory(entry, catByName), docByName);
-      }),
-      // Exported VAR_GLOBAL variables — their storage is emitted as inlineGlobal
-      // chunks; this list lets consumers' analyzers resolve the symbols. Every
-      // importing program merges all libraries' globals into one global scope.
-      globals: ast.globalVarBlocks.flatMap((block) =>
-        block.declarations.flatMap((decl) =>
-          decl.names.map((name) =>
-            tagCategory(
-              {
-                name,
-                type: decl.type.name,
-                ...(block.isConstant ? { constant: true } : {}),
-              },
-              catByName,
-            ),
-          ),
-        ),
-      ),
-      headers: [headerFileName],
-      isBuiltin: false,
-      sourceFiles: sources.map((s) => s.fileName),
-    },
+    ),
+    headers: [headerFileName],
+    isBuiltin: false,
+    sourceFiles: sources.map((s) => s.fileName),
+  };
+
+  // Guard AFTER both lists are assembled: the ST symbols and the native ones
+  // come from separate compiles, so this is the first point where a collision
+  // between them is visible.
+  const duplicates = findDuplicateExports(builtManifest);
+  if (duplicates.length > 0) {
+    return {
+      success: false,
+      manifest: emptyManifest(options),
+      headerCode: "",
+      cppCode: "",
+      errors: duplicates.map((message) => ({ message })),
+    };
+  }
+
+  return {
+    success: true,
+    manifest: builtManifest,
     headerCode: cleanHeader,
     cppCode: cleanCpp,
     chunks,

--- a/src/library/library-compiler.ts
+++ b/src/library/library-compiler.ts
@@ -14,7 +14,18 @@ import type {
 } from "./library-manifest.js";
 import { compile } from "../index.js";
 import { buildChunks } from "./library-chunks.js";
-import type { LibraryVarType } from "./library-manifest.js";
+import {
+  nativeLanguageFor,
+  type NativeSource,
+  partitionLibrarySources,
+  projectNativeHeaderToSt,
+} from "./native-sources.js";
+import type {
+  LibraryFBEntry,
+  LibraryFunctionEntry,
+  LibraryManifest,
+  LibraryVarType,
+} from "./library-manifest.js";
 import type { Expression, TypeReference } from "../frontend/ast.js";
 
 /**
@@ -194,6 +205,152 @@ function tagDocumentation<T extends { name: string; documentation?: string }>(
  * @param options - Library metadata
  * @returns The compiled library with manifest and C++ code
  */
+/** Manifest for a library that produced no symbols — used on the error paths. */
+function emptyManifest(options: {
+  name: string;
+  version: string;
+  namespace: string;
+}): LibraryManifest {
+  return {
+    name: options.name,
+    version: options.version,
+    namespace: options.namespace,
+    functions: [],
+    functionBlocks: [],
+    types: [],
+    headers: [],
+    isBuiltin: false,
+  };
+}
+
+/**
+ * Build a manifest entry for one function block from its AST node.
+ *
+ * Shared by the ST pass and the native-header pass so both describe an
+ * interface identically — the native path differs only in what it adds
+ * afterwards (`implementation`, `sourceFile`).
+ */
+function buildFBEntry(fb: {
+  name: string;
+  varBlocks: Array<{
+    blockType: string;
+    declarations: Array<{ names: string[]; type: TypeReference }>;
+  }>;
+}): LibraryFBEntry {
+  const varsOfBlock = (blockType: string): LibraryVarType[] =>
+    fb.varBlocks
+      .filter((b) => b.blockType === blockType)
+      .flatMap((b) =>
+        b.declarations.flatMap((d) =>
+          d.names.map((n) => serializeVarType(n, d.type)),
+        ),
+      );
+
+  return {
+    name: fb.name,
+    inputs: varsOfBlock("VAR_INPUT"),
+    outputs: varsOfBlock("VAR_OUTPUT"),
+    inouts: varsOfBlock("VAR_IN_OUT"),
+  };
+}
+
+/**
+ * Recover manifest entries for native (C/C++, Python) library sources.
+ *
+ * Each file is projected down to its ST header and run through the ordinary
+ * front end, so the interface is parsed and type-checked by exactly the code
+ * that handles an ST block — there is no second declaration parser to drift.
+ * The native body never reaches the parser, and no chunk is produced: the body
+ * is transported in `sources` and lowered by the consumer. See
+ * `native-sources.ts`.
+ *
+ * All headers are projected into ONE synthetic translation unit so a native
+ * block may reference a type another native block declares, matching how ST
+ * sources in the same library already see each other.
+ */
+function compileNativeEntries(
+  native: readonly NativeSource[],
+  options: {
+    dependencies?: StlibArchive[];
+    globalConstants?: Record<string, number>;
+  },
+): {
+  functionBlocks: LibraryFBEntry[];
+  functions: LibraryFunctionEntry[];
+  errors: Array<{ message: string; file?: string; line?: number }>;
+} {
+  const empty = { functionBlocks: [], functions: [], errors: [] };
+  if (native.length === 0) return empty;
+
+  const projected: string[] = [];
+  const languageByName = new Map<string, NativeSource>();
+  const docByFile = new Map<string, string>();
+  const errors: Array<{ message: string; file?: string; line?: number }> = [];
+
+  for (const source of native) {
+    const outcome = projectNativeHeaderToSt(source);
+    if ("message" in outcome) {
+      errors.push({ message: outcome.message, file: outcome.fileName });
+      continue;
+    }
+    projected.push(outcome.st);
+    // Upper-cased: the front end normalises identifiers, so that is the key
+    // the AST will come back with.
+    languageByName.set(outcome.name.toUpperCase(), source);
+    if (outcome.documentation !== undefined) {
+      docByFile.set(source.fileName, outcome.documentation);
+    }
+  }
+
+  if (errors.length > 0) return { ...empty, errors };
+  if (projected.length === 0) return empty;
+
+  const compileOpts: Partial<import("../types.js").CompileOptions> = {};
+  if (options.dependencies) compileOpts.libraries = options.dependencies;
+  if (options.globalConstants)
+    compileOpts.globalConstants = options.globalConstants;
+
+  // Codegen output is discarded — this pass exists only for the AST. Running
+  // the full `compile` (rather than parsing alone) means a native block with a
+  // bad declaration fails here, with the same diagnostics an ST block gets.
+  const result = compile(projected.join("\n"), compileOpts);
+  if (!result.success || !result.ast) {
+    return {
+      ...empty,
+      errors: result.errors.map((e) => {
+        const entry: { message: string; file?: string; line?: number } = {
+          message: `native block header: ${e.message}`,
+          line: e.line,
+        };
+        return entry;
+      }),
+    };
+  }
+
+  const tagNative = <T extends { name: string }>(entry: T): T => {
+    const source = languageByName.get(entry.name.toUpperCase());
+    if (!source) return entry;
+    const documentation = docByFile.get(source.fileName);
+    return {
+      ...entry,
+      implementation: source.language,
+      sourceFile: source.fileName,
+      ...(source.category !== undefined ? { category: source.category } : {}),
+      ...(documentation !== undefined && documentation.length > 0
+        ? { documentation }
+        : {}),
+    };
+  };
+
+  return {
+    functionBlocks: result.ast.functionBlocks.map((fb) =>
+      tagNative(buildFBEntry(fb)),
+    ),
+    functions: [],
+    errors: [],
+  };
+}
+
 export function compileLibrary(
   sources: Array<{
     source: string;
@@ -213,28 +370,59 @@ export function compileLibrary(
 ): LibraryCompileResult {
   const catByName = buildCategoryByPouName(sources);
   const docByName = buildDocByPouName(sources);
+
+  // Native (C/C++, Python) sources are transported, not compiled: their ST
+  // header yields a manifest entry and their body rides in `sources`. Only
+  // the ST/IL inputs go to the compiler below, so a library may legitimately
+  // consist entirely of native blocks and hand the compiler nothing.
+  const { st: stSources, native: nativeSources } =
+    partitionLibrarySources(sources);
+  const nativeEntries = compileNativeEntries(nativeSources, options);
+  if (nativeEntries.errors.length > 0) {
+    return {
+      success: false,
+      manifest: emptyManifest(options),
+      headerCode: "",
+      cppCode: "",
+      errors: nativeEntries.errors,
+    };
+  }
+
   if (sources.length === 0) {
     return {
       success: false,
-      manifest: {
-        name: options.name,
-        version: options.version,
-        namespace: options.namespace,
-        functions: [],
-        functionBlocks: [],
-        types: [],
-        headers: [],
-        isBuiltin: false,
-      },
+      manifest: emptyManifest(options),
       headerCode: "",
       cppCode: "",
       errors: [{ message: "No source files provided" }],
     };
   }
 
-  // Compile all sources together
-  const primarySource = sources[0]!;
-  const additionalSources = sources.slice(1);
+  // Every input was a native block. There is nothing for the compiler to do,
+  // so it is not called: the manifest is the native entries, and the bodies
+  // ride in `sources`. Asking the compiler to compile an empty translation
+  // unit would fail, which is what used to make an all-native library
+  // unbuildable.
+  if (stSources.length === 0) {
+    return {
+      success: true,
+      manifest: {
+        ...emptyManifest(options),
+        functionBlocks: nativeEntries.functionBlocks,
+        functions: nativeEntries.functions,
+        headers: [`${options.name}.hpp`],
+        sourceFiles: sources.map((s) => s.fileName),
+      },
+      headerCode: "",
+      cppCode: "",
+      chunks: [],
+      errors: [],
+    };
+  }
+
+  // Compile the ST sources together
+  const primarySource = stSources[0]!;
+  const additionalSources = stSources.slice(1);
 
   const compileOpts: Partial<import("../types.js").CompileOptions> = {
     additionalSources,
@@ -337,38 +525,12 @@ export function compileLibrary(
           docByName,
         ),
       ),
-      functionBlocks: ast.functionBlocks.map((fb) =>
-        tagDocumentation(
-          tagCategory(
-            {
-              name: fb.name,
-              inputs: fb.varBlocks
-                .filter((b) => b.blockType === "VAR_INPUT")
-                .flatMap((b) =>
-                  b.declarations.flatMap((d) =>
-                    d.names.map((n) => serializeVarType(n, d.type)),
-                  ),
-                ),
-              outputs: fb.varBlocks
-                .filter((b) => b.blockType === "VAR_OUTPUT")
-                .flatMap((b) =>
-                  b.declarations.flatMap((d) =>
-                    d.names.map((n) => serializeVarType(n, d.type)),
-                  ),
-                ),
-              inouts: fb.varBlocks
-                .filter((b) => b.blockType === "VAR_IN_OUT")
-                .flatMap((b) =>
-                  b.declarations.flatMap((d) =>
-                    d.names.map((n) => serializeVarType(n, d.type)),
-                  ),
-                ),
-            },
-            catByName,
-          ),
-          docByName,
+      functionBlocks: [
+        ...ast.functionBlocks.map((fb) =>
+          tagDocumentation(tagCategory(buildFBEntry(fb), catByName), docByName),
         ),
-      ),
+        ...nativeEntries.functionBlocks,
+      ],
       types: ast.types.map((t) => {
         const kind: "struct" | "enum" | "alias" =
           t.definition.kind === "StructDefinition"
@@ -484,8 +646,18 @@ export function compileStlib(
       version: d.manifest.version,
     })),
   };
-  if (!options.noSource) {
-    archive.sources = sources.map((s) => {
+  // `noSource` is closed-source distribution: drop the ST, whose symbols are
+  // already compiled into `chunks` and usable without it.
+  //
+  // Native (C/C++, Python) bodies are exempt, and must be. They have no chunk
+  // — nothing compiled them — so the source IS the deliverable, and stripping
+  // it would produce an archive no consumer can build against. A native block
+  // simply cannot be shipped closed-source in this format.
+  const persisted = options.noSource
+    ? sources.filter((s) => nativeLanguageFor(s.fileName) !== null)
+    : sources;
+  if (persisted.length > 0) {
+    archive.sources = persisted.map((s) => {
       const entry: { fileName: string; source: string; category?: string } = {
         fileName: s.fileName,
         source: s.source,

--- a/src/library/library-manifest.ts
+++ b/src/library/library-manifest.ts
@@ -86,6 +86,26 @@ export interface LibraryVarType {
 export interface LibraryFBEntry {
   /** Function block name */
   name: string;
+  /**
+   * Body language, when the block is NOT compiled by STruC++.
+   *
+   * Absent on every ordinary ST/IL block — those are compiled here and their
+   * C++ rides in `chunks`. Present on a block whose body is C/C++ or Python:
+   * STruC++ recovered this interface from the file's ST header but never
+   * parsed the body, emitted no chunk for it, and carried the authored file
+   * verbatim in `sources`. A consumer seeing this field must lower the source
+   * itself (through whatever native bridge it implements) instead of linking
+   * a chunk; see `native-sources.ts` for why the body is transported rather
+   * than compiled.
+   */
+  implementation?: "cpp" | "python";
+  /**
+   * File in `sources` holding this block's body. Set alongside
+   * `implementation` so a consumer can find the source without inferring the
+   * file name from the block name — the two need not match, and a
+   * case-insensitive guess would be wrong on a case-sensitive filesystem.
+   */
+  sourceFile?: string;
   /** Input variables */
   inputs: LibraryVarType[];
   /** Output variables */
@@ -286,7 +306,14 @@ export interface StlibArchive {
    *  (e.g. `iec-std-functions` is built from the std-function registry
    *  and contributes only symbol-table entries, no C++ output). */
   chunks: LibraryChunk[];
-  /** Original ST source files (omitted for closed-source distribution).
+  /** Original source files (ST omitted for closed-source distribution).
+   *
+   *  `--no-source` / `noSource` strips the ST entries, whose symbols are
+   *  already compiled into `chunks` and therefore usable without them. It
+   *  does NOT strip native (C/C++, Python) entries: those have no chunk, so
+   *  their source IS the deliverable and an archive without it is unbuildable
+   *  by any consumer. Closed-source distribution of a native block is not a
+   *  thing this format can express.
    *  `category` mirrors the manifest entry category for the POUs declared
    *  in this file so `--decompile-lib` can recreate the folder hierarchy
    *  on disk without re-parsing the source. Sources that span multiple

--- a/src/library/native-sources.ts
+++ b/src/library/native-sources.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Native (non-ST) library sources — C/C++ and Python function blocks.
+ *
+ * A library may ship function blocks whose bodies are written in C/C++ or
+ * Python rather than Structured Text. STruC++ does not compile those bodies:
+ * it **transports** them. The archive carries the authored file verbatim and
+ * the consuming toolchain lowers it at *its* build time, against whatever
+ * native bridge that toolchain implements.
+ *
+ * That distinction is the whole point and must not be optimised away. If a
+ * future version compiled these bodies instead, the resulting archive would
+ * encode one fixed bridge ABI, and every library published before a bridge
+ * change would stop building until it was recompiled. Transporting the source
+ * keeps a published library working across bridge revisions.
+ *
+ * What STruC++ *does* read is the ST header every such file carries — the
+ * `FUNCTION_BLOCK <name>` line plus its `VAR_*` blocks. That is ordinary ST,
+ * so the interface is recovered by the ordinary parser and the block lands in
+ * the manifest looking like any other, distinguished only by
+ * `implementation: "cpp" | "python"`. The body between the last `END_VAR` and
+ * the closing `END_FUNCTION_BLOCK` is never parsed.
+ */
+
+/** Body language a native library source is written in. */
+export type NativeLanguage = "cpp" | "python";
+
+/**
+ * File extensions recognised as native library sources, mapped to the
+ * language the consumer must lower them through. `.cpp`, `.c`, `.cc` and
+ * `.cxx` all land on `cpp` — the editor writes `.cpp`, but a hand-assembled
+ * library folder may not.
+ */
+const NATIVE_EXTENSIONS: ReadonlyMap<string, NativeLanguage> = new Map([
+  [".cpp", "cpp"],
+  [".c", "cpp"],
+  [".cc", "cpp"],
+  [".cxx", "cpp"],
+  [".py", "python"],
+]);
+
+/** Extensions STruC++ compiles as Structured Text. */
+const ST_EXTENSIONS: readonly string[] = [".st", ".il"];
+
+/** Every extension `--compile-lib` accepts, native and ST alike. */
+export const LIBRARY_SOURCE_EXTENSIONS: readonly string[] = [
+  ...ST_EXTENSIONS,
+  ...NATIVE_EXTENSIONS.keys(),
+];
+
+/**
+ * Language a file name implies, or `null` when it is not a native source.
+ * Case-insensitive: a folder assembled on a case-preserving filesystem may
+ * hold `Block.CPP`.
+ */
+export function nativeLanguageFor(fileName: string): NativeLanguage | null {
+  const lower = fileName.toLowerCase();
+  for (const [ext, language] of NATIVE_EXTENSIONS) {
+    if (lower.endsWith(ext)) return language;
+  }
+  return null;
+}
+
+/** One library input, before it has been sorted into ST or native. */
+export interface LibrarySourceInput {
+  source: string;
+  fileName: string;
+  category?: string;
+}
+
+/** A native source, paired with the language it must be lowered through. */
+export interface NativeSource extends LibrarySourceInput {
+  language: NativeLanguage;
+}
+
+/**
+ * Split library inputs into the ST sources STruC++ compiles and the native
+ * sources it only transports. Order within each group is preserved, so
+ * diagnostics and `sourceFiles` stay stable across runs.
+ */
+export function partitionLibrarySources(
+  sources: readonly LibrarySourceInput[],
+): {
+  st: LibrarySourceInput[];
+  native: NativeSource[];
+} {
+  const st: LibrarySourceInput[] = [];
+  const native: NativeSource[] = [];
+  for (const source of sources) {
+    const language = nativeLanguageFor(source.fileName);
+    if (language) native.push({ ...source, language });
+    else st.push(source);
+  }
+  return { st, native };
+}
+
+/**
+ * Index of the position just past the last `END_VAR` in `source`, or -1.
+ *
+ * Scans for every `END_VAR` and keeps the last, because a block declares
+ * several `VAR_*` sections and only the final one closes the header. Matching
+ * is word-boundary-anchored so an identifier such as `MY_END_VAR_COUNT` in the
+ * native body cannot be mistaken for the keyword.
+ */
+function lastEndVarIndex(source: string): number {
+  const pattern = /\bEND_VAR\b/gi;
+  let last = -1;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    last = match.index + match[0].length;
+  }
+  return last;
+}
+
+/** Failure to recover an interface from a native source. */
+export interface NativeHeaderError {
+  fileName: string;
+  message: string;
+}
+
+/**
+ * Project a native source down to the ST the parser can read: its declaration
+ * line, its `VAR_*` blocks, and a synthetic empty body.
+ *
+ * The result is valid ST for a block that does nothing, which is exactly what
+ * is wanted — it exists only so the normal front end can recover the
+ * interface. The native body is dropped here and never reaches the parser,
+ * which is what allows a Python body to sit in a library at all.
+ *
+ * Returns an error rather than throwing when the header is missing or
+ * malformed, so one bad file names itself in the build output instead of
+ * failing the whole library anonymously.
+ */
+export function projectNativeHeaderToSt(
+  source: NativeSource,
+): { st: string; name: string; documentation?: string } | NativeHeaderError {
+  // A POU file may open with an ST documentation comment before its
+  // declaration — the editor writes one there and reads it back the same way
+  // (`extractDocumentation` in its POU text parser). Strip it first so the
+  // declaration match stays anchored, and keep the text for the manifest.
+  const docMatch = /^\s*\(\*\s*([\s\S]*?)\s*\*\)\s*/.exec(source.source);
+  const documentation = docMatch ? docMatch[1]!.trim() : "";
+  const body = docMatch
+    ? source.source.slice(docMatch[0].length)
+    : source.source;
+
+  const declaration =
+    /^\s*(FUNCTION_BLOCK|FUNCTION|PROGRAM)\s+([A-Za-z_]\w*)/i.exec(body);
+  if (!declaration) {
+    return {
+      fileName: source.fileName,
+      message:
+        `${source.fileName}: missing the ST header. A ${source.language === "cpp" ? "C/C++" : "Python"} ` +
+        'library block must open with "FUNCTION_BLOCK <name>" followed by its VAR_* blocks.',
+    };
+  }
+
+  const kind = declaration[1]!.toUpperCase();
+  const name = declaration[2]!;
+
+  if (kind === "PROGRAM") {
+    return {
+      fileName: source.fileName,
+      message: `${source.fileName}: a library cannot export a PROGRAM ("${name}"). Declare it as a FUNCTION_BLOCK.`,
+    };
+  }
+
+  const headerEnd = lastEndVarIndex(body);
+  if (headerEnd === -1) {
+    return {
+      fileName: source.fileName,
+      message:
+        `${source.fileName}: "${name}" declares no variables. A native library block needs at least one ` +
+        "VAR_INPUT or VAR_OUTPUT block, or the consumer has no interface to call it through.",
+    };
+  }
+
+  const header = body.slice(declaration.index, headerEnd);
+  return {
+    st: `${header}\nEND_${kind}\n`,
+    name,
+    ...(documentation.length > 0 ? { documentation } : {}),
+  };
+}

--- a/src/library/native-sources.ts
+++ b/src/library/native-sources.ts
@@ -166,6 +166,30 @@ export function projectNativeHeaderToSt(
     };
   }
 
+  // A native block must be a FUNCTION_BLOCK. There is no such thing as a
+  // C/C++ or Python FUNCTION here: the bridge hands the body a pointer to
+  // per-instance storage and calls `setup` once before `loop` on every scan,
+  // which is function-block shape. A FUNCTION has no instance to hold that
+  // state in, so there is nothing for the consumer to lower it into.
+  //
+  // Rejecting rather than ignoring: the interface would otherwise land in the
+  // AST's function list, which nothing here reads, and the library would build
+  // "successfully" with the block missing from the manifest entirely. A
+  // published `.stlib` is immutable in the field, so that silence would only
+  // surface later as an undefined type in someone else's project.
+  //
+  // ST functions are unaffected — they compile through the normal path and
+  // keep their manifest entries and chunks. This is only about native files.
+  if (kind === "FUNCTION") {
+    return {
+      fileName: source.fileName,
+      message:
+        `${source.fileName}: a ${source.language === "cpp" ? "C/C++" : "Python"} library block must be a ` +
+        `FUNCTION_BLOCK, not a FUNCTION ("${name}"). A FUNCTION has no instance state for the consumer's ` +
+        "native bridge to hold. Declare it as a FUNCTION_BLOCK.",
+    };
+  }
+
   const headerEnd = lastEndVarIndex(body);
   if (headerEnd === -1) {
     return {
@@ -178,7 +202,7 @@ export function projectNativeHeaderToSt(
 
   const header = body.slice(declaration.index, headerEnd);
   return {
-    st: `${header}\nEND_${kind}\n`,
+    st: `${header}\nEND_FUNCTION_BLOCK\n`,
     name,
     ...(documentation.length > 0 ? { documentation } : {}),
   };

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -6,7 +6,7 @@
  *
  * Usage:
  *   strucpp <input.st> [input2.st ...] -o <output.cpp> [options]
- *   strucpp --compile-lib <input.st> [...] -o <dir> --lib-name <name> [options]
+ *   strucpp --compile-lib <input.st|.cpp|.py> [...] -o <dir> --lib-name <name> [options]
  *
  * Options:
  *   -o, --output <file>       Output file path or directory
@@ -298,7 +298,7 @@ STruC++ - IEC 61131-3 Structured Text to C++ Compiler
 
 Usage:
   strucpp <input.st> [input2.st ...] -o <output.cpp> [options]
-  strucpp --compile-lib <input.st|dir> [...] -o <dir> --lib-name <name> [options]
+  strucpp --compile-lib <input.st|.cpp|.py|dir> [...] -o <dir> --lib-name <name> [options]
 
 Options:
   -o, --output <file>       Output file path (default: <input>.cpp)
@@ -322,7 +322,9 @@ Library compilation:
   --lib-name <name>         Library name (required with --compile-lib)
   --lib-version <version>   Library version (default: "1.0.0")
   --lib-namespace <ns>      C++ namespace (default: derived from lib-name)
-  --no-source               Omit ST source from .stlib archive (closed-source)
+  --no-source               Omit ST source from .stlib archive (closed-source).
+                            C/C++ and Python bodies are always kept: they are
+                            not compiled, so their source is the deliverable.
   --decompile-lib <path>    Extract ST sources from a .stlib archive
 
 CODESYS import:
@@ -493,7 +495,7 @@ function compileLibraryMode(options: CLIOptions): void {
         const discovered = discoverSTFiles(inputPath);
         if (discovered.length === 0) {
           console.error(
-            `Error: No .st or .il files found in directory: ${inputPath}`,
+            `Error: No .st, .il, .cpp or .py files found in directory: ${inputPath}`,
           );
           process.exit(1);
         }

--- a/src/node/library-utils.ts
+++ b/src/node/library-utils.ts
@@ -9,11 +9,20 @@
 import { readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { LIBRARY_SOURCE_EXTENSIONS } from "../library/native-sources.js";
+
 /**
- * Recursively discover all `.st` and `.il` files in a directory.
+ * Recursively discover every library source file in a directory: the ST/IL
+ * files STruC++ compiles, plus the C/C++ and Python files it transports for
+ * the consumer to lower (see `library/native-sources.ts`).
+ *
+ * A native file is picked up on the same footing as an ST one — the author
+ * drops `Block.py` in the folder next to `Other.st` and both end up in the
+ * archive. Sorting the result keeps `sourceFiles` and diagnostics stable
+ * across filesystems that enumerate in different orders.
  *
  * @param dir - Directory to scan
- * @returns Array of absolute paths to `.st` and `.il` files
+ * @returns Sorted absolute paths of every recognised library source
  */
 export function discoverSTFiles(dir: string): string[] {
   const resolvedDir = resolve(dir);
@@ -21,17 +30,20 @@ export function discoverSTFiles(dir: string): string[] {
     withFileTypes: true,
     recursive: true,
   });
-  const stFiles: string[] = [];
+  const found: string[] = [];
   for (const entry of entries) {
     const lower = entry.name.toLowerCase();
-    if (entry.isFile() && (lower.endsWith(".st") || lower.endsWith(".il"))) {
+    if (
+      entry.isFile() &&
+      LIBRARY_SOURCE_EXTENSIONS.some((ext) => lower.endsWith(ext))
+    ) {
       // entry.parentPath is available in Node 20+; fallback to entry.path
       const parentPath =
         (entry as { parentPath?: string }).parentPath ??
         (entry as { path?: string }).path ??
         resolvedDir;
-      stFiles.push(join(parentPath, entry.name));
+      found.push(join(parentPath, entry.name));
     }
   }
-  return stFiles.sort();
+  return found.sort();
 }

--- a/tests/library/native-blocks.test.ts
+++ b/tests/library/native-blocks.test.ts
@@ -152,6 +152,35 @@ describe("projectNativeHeaderToSt", () => {
     expect("message" in out && out.message).toContain("declares no variables");
   });
 
+  // A native FUNCTION used to be accepted, projected, and then silently
+  // dropped: the interface landed in the AST's function list, which
+  // `compileNativeEntries` does not read, so the library built successfully
+  // with the block missing from the manifest entirely.
+  it("rejects a FUNCTION — a native block has no instance state", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "CPP_ADD.cpp",
+      source: "FUNCTION CPP_ADD : INT\nVAR_INPUT A : INT; END_VAR\nint add(){}\nEND_FUNCTION\n",
+      language: "cpp",
+    });
+    expect("message" in out && out.message).toContain("must be a FUNCTION_BLOCK, not a FUNCTION");
+    expect("message" in out && out.message).toContain("CPP_ADD.cpp");
+  });
+
+  it("names Python in the rejection when the file is a .py", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "PY_ADD.py",
+      source: "FUNCTION PY_ADD : INT\nVAR_INPUT A : INT; END_VAR\ndef f(): pass\nEND_FUNCTION\n",
+      language: "python",
+    });
+    expect("message" in out && out.message).toContain("Python library block");
+  });
+
+  it("closes the projected block as a FUNCTION_BLOCK", () => {
+    const out = projectNativeHeaderToSt({ fileName: "X.cpp", source: CPP_BLOCK, language: "cpp" });
+    if ("message" in out) throw new Error(out.message);
+    expect(out.st).toContain("END_FUNCTION_BLOCK");
+  });
+
   it("rejects a PROGRAM, which a library cannot export", () => {
     const out = projectNativeHeaderToSt({
       fileName: "Prog.cpp",
@@ -285,5 +314,79 @@ describe("compileStlib with native sources", () => {
     const loaded = loadStlibFromString(JSON.stringify(archive), "nativelib");
     expect(loaded.chunks).toEqual([]);
     expect(loaded.manifest.functionBlocks[0]?.sourceFile).toBe("PY_OFFSET.py");
+  });
+});
+
+describe("duplicate exports", () => {
+  const FN = (n: string) => `FUNCTION ${n} : INT\nVAR_INPUT A : INT; END_VAR\n${n} := A;\nEND_FUNCTION\n`;
+  const FB = (n: string) =>
+    `FUNCTION_BLOCK ${n}\nVAR_INPUT A : INT; END_VAR\nVAR_OUTPUT Q : INT; END_VAR\nQ := A;\nEND_FUNCTION_BLOCK\n`;
+  const TY = (n: string) => `TYPE\n  ${n} : STRUCT\n    f : INT;\n  END_STRUCT;\nEND_TYPE\n`;
+  const GV = (n: string) => `VAR_GLOBAL\n  ${n} : INT := 1;\nEND_VAR\n`;
+  const CFB = (n: string) =>
+    `FUNCTION_BLOCK ${n}\nVAR_INPUT Z : BOOL; END_VAR\nVAR_OUTPUT Q : INT; END_VAR\nvoid loop() {}\nEND_FUNCTION_BLOCK\n`;
+
+  const build = (files: Array<[string, string]>) =>
+    compileLibrary(
+      files.map(([fileName, source]) => ({ fileName, source })),
+      OPTS,
+    );
+
+  // A library exports one thing per name. STruC++'s own duplicate detection
+  // only fires within a single kind and a single translation unit, and native
+  // headers compile in a separate unit — so these are the collisions nothing
+  // used to catch. A published `.stlib` is immutable in the field, so emitting
+  // an ambiguous manifest costs more than refusing to.
+  it.each([
+    ["an ST function and an ST function block", [["a.st", FN("FOO") + FB("FOO")]]],
+    ["an ST type and an ST function block", [["a.st", TY("FOO") + FB("FOO")]]],
+    ["a native block and an ST function", [["a.st", FN("FOO")], ["FOO.cpp", CFB("FOO")]]],
+    ["a native block and an ST type", [["a.st", TY("FOO")], ["FOO.cpp", CFB("FOO")]]],
+    ["a native block and an ST global", [["a.st", GV("FOO")], ["FOO.cpp", CFB("FOO")]]],
+  ])("rejects a name claimed by %s", (_label, files) => {
+    const res = build(files as Array<[string, string]>);
+    expect(res.success).toBe(false);
+    expect(res.errors[0]?.message).toContain('"FOO" is exported 2 times');
+    expect(res.manifest.functionBlocks).toEqual([]);
+  });
+
+  it("rejects a duplicate in an all-native library too", () => {
+    // Both headers share one synthetic translation unit, so the front end's own
+    // duplicate detection fires first here — the message differs, the refusal
+    // does not.
+    const res = build([
+      ["FOO.cpp", CFB("FOO")],
+      ["FOO.py", `FUNCTION_BLOCK FOO\nVAR_INPUT P : INT; END_VAR\ndef block_loop():\n    pass\nEND_FUNCTION_BLOCK\n`],
+    ]);
+    expect(res.success).toBe(false);
+    expect(res.errors[0]?.message).toMatch(/Duplicate function block declaration|exported 2 times/);
+  });
+
+  it("names both kinds so the author knows which two files to look at", () => {
+    const res = build([
+      ["a.st", FN("FOO")],
+      ["FOO.cpp", CFB("FOO")],
+    ]);
+    expect(res.errors[0]?.message).toContain("as function, cpp function block");
+  });
+
+  it("leaves a library with distinct names alone", () => {
+    const res = build([
+      ["a.st", FN("ADD2") + FB("TANK") + TY("MODE")],
+      ["SCALE.cpp", CFB("SCALE")],
+    ]);
+    expect(res.errors).toEqual([]);
+    expect(res.success).toBe(true);
+    expect(res.manifest.functions.map((f) => f.name)).toEqual(["ADD2"]);
+    expect(res.manifest.functionBlocks.map((f) => f.name).sort()).toEqual(["SCALE", "TANK"]);
+  });
+
+  it("compares names case-insensitively, as the front end does", () => {
+    const res = build([
+      ["a.st", FB("Foo")],
+      ["FOO.cpp", CFB("FOO")],
+    ]);
+    expect(res.success).toBe(false);
+    expect(res.errors[0]?.message).toContain("exported 2 times");
   });
 });

--- a/tests/library/native-blocks.test.ts
+++ b/tests/library/native-blocks.test.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Native (C/C++, Python) library blocks.
+ *
+ * The contract under test: STruC++ recovers the interface from the file's ST
+ * header, emits NO chunk for it, and carries the authored file verbatim in
+ * `sources` — including under `--no-source`, because a native block has no
+ * compiled chunk and so its source is the whole deliverable.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  compileLibrary,
+  compileStlib,
+} from "../../src/library/library-compiler.js";
+import { loadStlibFromString } from "../../src/library/library-loader.js";
+import {
+  LIBRARY_SOURCE_EXTENSIONS,
+  nativeLanguageFor,
+  partitionLibrarySources,
+  projectNativeHeaderToSt,
+} from "../../src/library/native-sources.js";
+
+const CPP_BLOCK = `(* Scales an INT by a gain *)
+FUNCTION_BLOCK CPP_SCALE
+VAR_INPUT
+  RAW : INT;
+  GAIN : INT;
+END_VAR
+VAR_OUTPUT
+  SCALED : INT;
+END_VAR
+void setup()
+{
+}
+
+void loop()
+{
+    SCALED = RAW * GAIN;
+}
+END_FUNCTION_BLOCK
+`;
+
+const PY_BLOCK = `FUNCTION_BLOCK PY_OFFSET
+VAR_INPUT
+  IN_VAL : INT;
+  OFFSET : INT;
+END_VAR
+VAR_OUTPUT
+  OUT_VAL : INT;
+END_VAR
+def block_loop():
+    global OUT_VAL
+    OUT_VAL = IN_VAL + OFFSET
+END_FUNCTION_BLOCK
+`;
+
+const ST_BLOCK = `FUNCTION_BLOCK ST_ADD
+VAR_INPUT
+  A : INT;
+  B : INT;
+END_VAR
+VAR_OUTPUT
+  C : INT;
+END_VAR
+C := A + B;
+END_FUNCTION_BLOCK
+`;
+
+const OPTS = { name: "nativelib", version: "1.0.0", namespace: "nativelib" };
+
+describe("nativeLanguageFor", () => {
+  it.each([
+    ["Block.cpp", "cpp"],
+    ["Block.c", "cpp"],
+    ["Block.cc", "cpp"],
+    ["Block.cxx", "cpp"],
+    ["Block.CPP", "cpp"],
+    ["Block.py", "python"],
+    ["Block.PY", "python"],
+  ])("maps %s to %s", (fileName, expected) => {
+    expect(nativeLanguageFor(fileName)).toBe(expected);
+  });
+
+  it.each(["Block.st", "Block.il", "Block.txt", "Block"])(
+    "returns null for %s",
+    (fileName) => {
+      expect(nativeLanguageFor(fileName)).toBeNull();
+    },
+  );
+
+  it("lists ST and native extensions for CLI discovery", () => {
+    expect(LIBRARY_SOURCE_EXTENSIONS).toEqual(
+      expect.arrayContaining([".st", ".il", ".cpp", ".py"]),
+    );
+  });
+});
+
+describe("partitionLibrarySources", () => {
+  it("splits native from ST and preserves order within each group", () => {
+    const { st, native } = partitionLibrarySources([
+      { fileName: "a.st", source: "" },
+      { fileName: "b.cpp", source: "" },
+      { fileName: "c.il", source: "" },
+      { fileName: "d.py", source: "" },
+    ]);
+    expect(st.map((s) => s.fileName)).toEqual(["a.st", "c.il"]);
+    expect(native.map((s) => `${s.fileName}:${s.language}`)).toEqual([
+      "b.cpp:cpp",
+      "d.py:python",
+    ]);
+  });
+});
+
+describe("projectNativeHeaderToSt", () => {
+  it("keeps the header, drops the body, and closes the block", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "CPP_SCALE.cpp",
+      source: CPP_BLOCK,
+      language: "cpp",
+    });
+    if ("message" in out) throw new Error(out.message);
+
+    expect(out.name).toBe("CPP_SCALE");
+    expect(out.documentation).toBe("Scales an INT by a gain");
+    expect(out.st).toContain("VAR_INPUT");
+    expect(out.st).toContain("SCALED : INT;");
+    expect(out.st.trimEnd().endsWith("END_FUNCTION_BLOCK")).toBe(true);
+    // The body must never reach the parser — that is what lets a Python body
+    // live in a library at all.
+    expect(out.st).not.toContain("void loop");
+  });
+
+  it("rejects a file with no ST header, naming it", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "Bare.py",
+      source: "def block_loop():\n    pass\n",
+      language: "python",
+    });
+    expect("message" in out && out.message).toContain("Bare.py");
+    expect("message" in out && out.message).toContain("missing the ST header");
+  });
+
+  it("rejects a header that declares no variables", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "NoVars.cpp",
+      source: "FUNCTION_BLOCK NoVars\nvoid loop() {}\nEND_FUNCTION_BLOCK\n",
+      language: "cpp",
+    });
+    expect("message" in out && out.message).toContain("declares no variables");
+  });
+
+  it("rejects a PROGRAM, which a library cannot export", () => {
+    const out = projectNativeHeaderToSt({
+      fileName: "Prog.cpp",
+      source:
+        "PROGRAM Prog\nVAR x : INT; END_VAR\nvoid loop() {}\nEND_PROGRAM\n",
+      language: "cpp",
+    });
+    expect("message" in out && out.message).toContain(
+      "cannot export a PROGRAM",
+    );
+  });
+});
+
+describe("compileLibrary with native sources", () => {
+  it("builds a library made only of native blocks", () => {
+    const result = compileLibrary(
+      [
+        { fileName: "CPP_SCALE.cpp", source: CPP_BLOCK },
+        { fileName: "PY_OFFSET.py", source: PY_BLOCK },
+      ],
+      OPTS,
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.success).toBe(true);
+    // Nothing was compiled, so nothing was emitted.
+    expect(result.chunks).toEqual([]);
+    expect(result.cppCode).toBe("");
+
+    const byName = new Map(
+      result.manifest.functionBlocks.map((fb) => [fb.name, fb]),
+    );
+    expect([...byName.keys()].sort()).toEqual(["CPP_SCALE", "PY_OFFSET"]);
+
+    const cpp = byName.get("CPP_SCALE")!;
+    expect(cpp.implementation).toBe("cpp");
+    expect(cpp.sourceFile).toBe("CPP_SCALE.cpp");
+    expect(cpp.inputs.map((v) => v.name)).toEqual(["RAW", "GAIN"]);
+    expect(cpp.outputs.map((v) => v.name)).toEqual(["SCALED"]);
+    expect(cpp.documentation).toBe("Scales an INT by a gain");
+
+    expect(byName.get("PY_OFFSET")!.implementation).toBe("python");
+  });
+
+  it("compiles ST alongside native blocks, chunking only the ST", () => {
+    const result = compileLibrary(
+      [
+        { fileName: "ST_ADD.st", source: ST_BLOCK },
+        { fileName: "CPP_SCALE.cpp", source: CPP_BLOCK },
+      ],
+      OPTS,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.chunks?.map((c) => c.name)).toEqual(["ST_ADD"]);
+
+    const byName = new Map(
+      result.manifest.functionBlocks.map((fb) => [fb.name, fb]),
+    );
+    expect(byName.get("ST_ADD")!.implementation).toBeUndefined();
+    expect(byName.get("CPP_SCALE")!.implementation).toBe("cpp");
+  });
+
+  it("still refuses a library with no sources at all", () => {
+    const result = compileLibrary([], OPTS);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]?.message).toBe("No source files provided");
+  });
+
+  it("fails with the offending file when a native header is unusable", () => {
+    const result = compileLibrary(
+      [{ fileName: "Bare.py", source: "def block_loop(): pass\n" }],
+      OPTS,
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0]?.file).toBe("Bare.py");
+  });
+});
+
+describe("compileStlib with native sources", () => {
+  const build = (noSource: boolean) =>
+    compileStlib(
+      [
+        { fileName: "ST_ADD.st", source: ST_BLOCK },
+        { fileName: "CPP_SCALE.cpp", source: CPP_BLOCK },
+        { fileName: "PY_OFFSET.py", source: PY_BLOCK },
+      ],
+      { ...OPTS, noSource },
+    );
+
+  it("carries every source verbatim by default", () => {
+    const { success, archive } = build(false);
+    expect(success).toBe(true);
+    expect(archive.sources?.map((s) => s.fileName).sort()).toEqual([
+      "CPP_SCALE.cpp",
+      "PY_OFFSET.py",
+      "ST_ADD.st",
+    ]);
+    const py = archive.sources?.find((s) => s.fileName === "PY_OFFSET.py");
+    // Verbatim: the consumer re-derives the bridge from these exact bytes, so
+    // a published library keeps working across bridge revisions.
+    expect(py?.source).toBe(PY_BLOCK);
+  });
+
+  it("keeps native sources under --no-source and drops only the ST", () => {
+    const { archive } = build(true);
+    expect(archive.sources?.map((s) => s.fileName).sort()).toEqual([
+      "CPP_SCALE.cpp",
+      "PY_OFFSET.py",
+    ]);
+  });
+
+  it("produces an archive its own loader accepts, native metadata intact", () => {
+    const { archive } = build(false);
+    const loaded = loadStlibFromString(JSON.stringify(archive), "nativelib");
+    const native = loaded.manifest.functionBlocks.filter(
+      (fb) => fb.implementation,
+    );
+    expect(
+      native.map((fb) => `${fb.name}:${fb.implementation}`).sort(),
+    ).toEqual(["CPP_SCALE:cpp", "PY_OFFSET:python"]);
+    expect(loaded.sources?.length).toBe(3);
+  });
+
+  it("round-trips an all-native library through the loader", () => {
+    const { success, archive } = compileStlib(
+      [{ fileName: "PY_OFFSET.py", source: PY_BLOCK }],
+      OPTS,
+    );
+    expect(success).toBe(true);
+    const loaded = loadStlibFromString(JSON.stringify(archive), "nativelib");
+    expect(loaded.chunks).toEqual([]);
+    expect(loaded.manifest.functionBlocks[0]?.sourceFile).toBe("PY_OFFSET.py");
+  });
+});


### PR DESCRIPTION
Enables [DOPE-585](https://autonomylogic.atlassian.net/browse/DOPE-585). Consumer PRs: Autonomy-Logic/openplc-web#699, Autonomy-Logic/openplc-editor#1042 — both depend on this and will need `binary-versions.json` bumped to the release that carries it.

## What this adds

A library may ship function blocks whose bodies are C/C++ or Python. STruC++ does not compile those bodies — it **transports** them. The archive carries the authored file verbatim, and the consuming toolchain lowers it at *its* build time against whatever native bridge that toolchain implements.

That distinction is the whole point. Compiling the bodies here would bake one fixed bridge ABI into every archive, so a bridge change would break every library published before it until each was rebuilt. Transporting the source keeps a published library working across bridge revisions. **It is worth guarding in review: making STruC++ compile these bodies looks like an obvious optimisation to anyone who does not know the history.**

What *is* read is the ST header every such file already carries — the `FUNCTION_BLOCK` line and its `VAR_*` blocks. That's ordinary ST, so the interface is recovered by projecting the file down to a header-only block and running it through the normal front end: one declaration parser, no second implementation to drift, and a bad declaration in a `.py` gets the same diagnostics an `.st` would. The body between the last `END_VAR` and the closing `END_FUNCTION_BLOCK` never reaches the parser.

Native blocks land in `manifest.functionBlocks` looking like any other, distinguished by `implementation: "cpp" | "python"` and pointing at their file via `sourceFile`. They emit no chunk.

## The four changes

1. **`--compile-lib <dir>` discovers `.cpp`/`.c`/`.cc`/`.cxx`/`.py`** alongside `.st`/`.il`, so an author drops `Block.py` in the folder next to `Other.st` and both end up in the archive. Discovery routes them into a separate bucket — feeding a `.py` to the ST parser was never going to work.
2. **The interface is parsed from the ST header**, exactly as for any other language; the body is skipped and carried as source.
3. **`--no-source` strips ST sources only.** Native bodies are exempt and must be: they have no chunk, so the source *is* the deliverable and an archive without it is unbuildable by anyone. A native block cannot be shipped closed-source in this format.
4. **The Node API accepts them too** — `compileStlib` routes by file extension, so a caller just includes `.cpp`/`.py` entries in the same `sources` array. That's the path the editor uses.

Plus: a library whose every input is native no longer fails. There's nothing for the compiler to do, so it isn't called. Previously this reached `compile()` with an empty translation unit and died on `No source files provided`, which is what made an all-native library unbuildable and is the production failure behind DOPE-585.

## Compatibility

Archives that contain no native blocks are **unchanged**, so the existing corpus and older editors are unaffected. An archive that *does* contain them is a newer artifact by definition: an older consumer finds no chunk for those blocks and fails loudly at compile rather than silently linking nothing.

A library with no inputs at all still fails, as before.

## Why this landed here rather than in the editors

An earlier iteration fixed this editor-side: the editor hand-built the archive strucpp refused to produce, and stamped non-standard `cppBlocks` / `pythonBlocks` fields onto it afterwards. Two problems with that, both of which this PR removes:

- The editor was duplicating this package's archive schema — `formatVersion`, the manifest field set, `chunks`, `sources` — making it the only thing holding an invariant it doesn't own. With web on 0.6.1 and editor on 0.6.3, that had to hold for two versions simultaneously.
- Those fields were non-standard, and `loadStlibFromString` normalises unknown top-level fields away. They survived only because the install path happens to persist the archive *text* rather than the parsed object. `manifest` and `sources` are first-class, so native blocks now survive every round-trip by construction.

The editors delete more than they gain: the synthesized archive, the post-hoc stamping, a `PLCVariable` projection in the archive, and an `originalPythonPous` sidecar all go away.

## Testing

- `tests/library/native-blocks.test.ts` — 25 new tests: extension mapping, source partitioning, header projection (including the rejections: no header, no variables, `PROGRAM`), all-native and mixed builds, chunk emission, the `--no-source` exemption, and loader round-trips.
- Full suite: **2240 passed, 7 skipped** — no regressions.
- CLI, by hand: all-native from a directory, mixed ST + native, and `--no-source`, each inspected for chunks / sources / manifest markers.

## Verified end-to-end on hardware

Built `nettest.stlib` (one C++ block, one Python block) with `strucpp --compile-lib`, installed it through the editor's real install path (`installFromFile` → `prepareStlibUpload` → `loadStlibFromString` → pool), created a consumer project that instantiates both, and compiled + uploaded to a device (`slm-rp4`, runtime v4.1.10, board `SLM-RP4`). The device compiled `pou_NETTEST__CPP_SCALE.cpp` and `pou_NETTEST__PY_OFFSET.cpp` and linked both into `new_libplc.so`.

Values read back over the debug channel:

| Variable | Expected | Device |
|---|---|---|
| `SCALER.SCALED` (C++ block) | 42 | **42** ✅ |
| `OFFSETTER.OUT_VAL` (Python block) | 142 | **142** ✅ |

Negative control — inputs changed to `RAW := 6, GAIN := 7, OFFSET := 9`, rebuilt and re-uploaded: **42** and **51**, both correct, so the blocks are computing on-device rather than returning anything stale.

Also driven from the openplc-web UI (`dev:local`, this branch's `dist` overlaid on its `node_modules/strucpp`): Build Library completed through the real flow including the avr-gcc verification stage — `Verification passed.` → `Library built successfully: build/nettest.stlib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qaJbNUTA9kMLL9Jr5FjUU

[DOPE-585]: https://autonomylogic.atlassian.net/browse/DOPE-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ