### PR TITLE
fix(tests): use -pedantic-errors instead of a Clang-only warning name

### DIFF
--- a/tests/integration/integer-literal-exact-cpp.test.ts
+++ b/tests/integration/integer-literal-exact-cpp.test.ts
@@ -12,6 +12,13 @@
  * -Werror is deliberate: `18446744073709551615` without the `ULL` suffix is a
  * GCC extension that warns rather than fails, and a warning is exactly the
  * failure mode this test exists to catch.
+ *
+ * `-pedantic-errors`, not a named `-Werror=`: GCC emits this diagnostic
+ * ("integer constant is so large that it is unsigned") unconditionally, with
+ * no `-W` name of its own to target — `-Werror=implicitly-unsigned-literal`
+ * is a Clang-only spelling that GCC rejects outright as an unknown option,
+ * aborting the compile before it reaches the check. `-pedantic-errors` is
+ * the portable way to turn this specific warning into a hard error on both.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
@@ -50,7 +57,7 @@ describeIfGpp("64-bit integer literals — generated C++", () => {
       testName,
       // An unsuffixed `18446744073709551615` is a GCC *extension* that warns
       // rather than fails, so the warning has to be the failure here.
-      extraFlags: ["-Werror=implicitly-unsigned-literal", "-Werror=overflow"],
+      extraFlags: ["-pedantic-errors", "-Werror=overflow"],
       mainCode: `#include <iostream>\n\nint main() {\n    using namespace strucpp;\n${mainBody}\n    return 0;\n}\n`,
     });
   }


### PR DESCRIPTION
## What's broken

`tests/integration/integer-literal-exact-cpp.test.ts` compiles generated C++ with `-Werror=implicitly-unsigned-literal`, a **Clang-only** warning name. On real GCC (the Linux CI runner), `g++` doesn't recognize it and aborts outright:

```
cc1plus: error: '-Werror=implicitly-unsigned-literal': no option '-Wimplicitly-unsigned-literal'
```

That fails all 7 tests in the file — not because the code under test is wrong, but because the compile never gets far enough to check it. It passes on macOS dev machines because `g++` there is Apple Clang.

This isn't new: the same 7 tests failed identically on Linux CI for the last two `development`→`main` release merges (v0.6.3, v0.6.4) — both shipped anyway. Discovered while opening [#227](https://github.com/Autonomy-Logic/STruCpp/pull/227) (development → main for v0.6.5), which is currently red because of it.

## The fix

Swap the Clang-only flag for `-pedantic-errors`. GCC's diagnostic for this case ("integer constant is so large that it is unsigned") has no `-W` name of its own — it's unconditional — so it can't be targeted with a named `-Werror=`. `-pedantic-errors` is the portable way to turn it into a hard error on both compilers.

## Verification

Ran in a Node 22 + GCC 13.3.0 / Ubuntu 24.04 container matching the CI runner exactly (confirmed via the failing run's own "Operating System" log):

- `integer-literal-exact-cpp.test.ts`: 7/7 passing (was 0/7).
- Full suite: **93 files, 2322 passed, 7 skipped**, coverage gate green.
- `npm run lint`: 0 errors. `npm run typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQ239CtwGVnDMSeLA2Lx93
