### PR TITLE
fix(runtime): return the IEC value type from GlobalVar::read() (DOPE-613)

### DIFF
--- a/src/runtime/include/iec_global.hpp
+++ b/src/runtime/include/iec_global.hpp
@@ -35,10 +35,17 @@
  *     arrays, and FB instances all work, and different-field writes from
  *     different tasks all survive because they mutate the one shared object.
  *
- * read() returns the real IEC value type, so generated bodies and constrained
- * std-lib templates (NOT, ADD, …) deduce the operand correctly — the wrapper is
- * never the deduced operand. Forcing is preserved via the canonical's
- * get()/set(); located globals additionally honor the image forced-slot bitmap.
+ * read() returns the real IEC value type — `V` itself, i.e. `IECVar<T>`, NOT the
+ * underlying `T`. That matters for deduction: the constrained std-lib templates
+ * take one shared parameter for both operands (`template<typename T> T ADD(T, T)`),
+ * and locals, literals and composite-global fields all present as `IECVar<T>`.
+ * Returning `T` here would make a scalar global the one operand kind that differs,
+ * and `ADD(aGlobal, aLocal)` would fail to deduce — implicit conversions are not
+ * considered during template argument deduction, so `operator T()` cannot rescue it.
+ * Forcing is preserved: the copy handed back is built through the canonical's
+ * get(), so it carries the effective forced value (with the force flag cleared, as
+ * a detached snapshot should); located globals additionally honor the image
+ * forced-slot bitmap.
  */
 #ifndef STRUCPP_IEC_GLOBAL_HPP
 #define STRUCPP_IEC_GLOBAL_HPP
@@ -71,12 +78,20 @@ class GlobalVar {
 
     /** Scalar read: returns the real IEC value type (forcing-aware),
      *  deduction-friendly. Only instantiated for scalar globals (codegen uses
-     *  with_lock() for structs / arrays / FB instances). */
-    auto read() const {
+     *  with_lock() for structs / arrays / FB instances).
+     *
+     *  The return type is spelled `V` rather than `auto` on purpose: `auto` let
+     *  this silently return the underlying scalar, which is what broke deduction
+     *  for every mixed global/local operand pair (see the header note above).
+     *
+     *  The copy is constructed while `lg` is still in scope, so the snapshot is
+     *  taken atomically exactly as a `value.get()` would have been — same single
+     *  lock acquisition, same hold duration. */
+    V read() const {
 #ifdef STRUCPP_THREADED
         std::lock_guard<std::mutex> lg(mtx_);
 #endif
-        return value.get();
+        return value;
     }
 
     /** Scalar write (forcing-aware via set()). */

--- a/src/runtime/include/iec_string.hpp
+++ b/src/runtime/include/iec_string.hpp
@@ -351,10 +351,35 @@ public:
     IECStringVar() noexcept : value_{}, forced_{false}, forced_value_{} {}
     IECStringVar(const value_type& v) noexcept : value_{v}, forced_{false}, forced_value_{} {}
     IECStringVar(const char* str) noexcept : value_{str}, forced_{false}, forced_value_{} {}
-    IECStringVar(const IECStringVar&) = default;
-    IECStringVar(IECStringVar&&) = default;
-    IECStringVar& operator=(const IECStringVar&) = default;
-    IECStringVar& operator=(IECStringVar&&) = default;
+    /* Forcing semantics, matching IECVar (see iec_var.hpp).
+     *
+     * These cannot be `= default`. A memberwise copy carries `forced_` and
+     * `forced_value_` across, which breaks forcing two ways: assigning FROM a
+     * forced source leaks the flag onto the destination (whose next `set()` is
+     * then silently dropped), and assigning from an unforced source clears a
+     * force the debugger is holding. Generated code assigns every scan, so
+     * either one destroys a force within one cycle -- and STRING forcing is a
+     * first-class debug operation (force_string / unforce_string).
+     *
+     * Construction takes a detached snapshot of the effective value and starts
+     * unforced; assignment routes through set() so the destination keeps its
+     * own forcing state. */
+    IECStringVar(const IECStringVar& other) noexcept
+        : value_{other.forced_ ? other.forced_value_ : other.value_},
+          forced_{false},
+          forced_value_{} {}
+    IECStringVar(IECStringVar&& other) noexcept
+        : value_{other.forced_ ? other.forced_value_ : other.value_},
+          forced_{false},
+          forced_value_{} {}
+    IECStringVar& operator=(const IECStringVar& other) noexcept {
+        set(other.forced_ ? other.forced_value_ : other.value_);
+        return *this;
+    }
+    IECStringVar& operator=(IECStringVar&& other) noexcept {
+        set(other.forced_ ? other.forced_value_ : other.value_);
+        return *this;
+    }
 
     // Cross-size converting constructor (IEC 61131-3: STRING types are interoperable)
     template<size_t OtherLen, std::enable_if_t<OtherLen != MaxLen, int> = 0>

--- a/src/runtime/include/iec_wstring.hpp
+++ b/src/runtime/include/iec_wstring.hpp
@@ -369,10 +369,35 @@ public:
     IECWStringVar() noexcept : value_{}, forced_{false}, forced_value_{} {}
     IECWStringVar(const value_type& v) noexcept : value_{v}, forced_{false}, forced_value_{} {}
     IECWStringVar(const char16_t* str) noexcept : value_{str}, forced_{false}, forced_value_{} {}
-    IECWStringVar(const IECWStringVar&) = default;
-    IECWStringVar(IECWStringVar&&) = default;
-    IECWStringVar& operator=(const IECWStringVar&) = default;
-    IECWStringVar& operator=(IECWStringVar&&) = default;
+    /* Forcing semantics, matching IECVar (see iec_var.hpp).
+     *
+     * These cannot be `= default`. A memberwise copy carries `forced_` and
+     * `forced_value_` across, which breaks forcing two ways: assigning FROM a
+     * forced source leaks the flag onto the destination (whose next `set()` is
+     * then silently dropped), and assigning from an unforced source clears a
+     * force the debugger is holding. Generated code assigns every scan, so
+     * either one destroys a force within one cycle -- and STRING forcing is a
+     * first-class debug operation (force_string / unforce_string).
+     *
+     * Construction takes a detached snapshot of the effective value and starts
+     * unforced; assignment routes through set() so the destination keeps its
+     * own forcing state. */
+    IECWStringVar(const IECWStringVar& other) noexcept
+        : value_{other.forced_ ? other.forced_value_ : other.value_},
+          forced_{false},
+          forced_value_{} {}
+    IECWStringVar(IECWStringVar&& other) noexcept
+        : value_{other.forced_ ? other.forced_value_ : other.value_},
+          forced_{false},
+          forced_value_{} {}
+    IECWStringVar& operator=(const IECWStringVar& other) noexcept {
+        set(other.forced_ ? other.forced_value_ : other.value_);
+        return *this;
+    }
+    IECWStringVar& operator=(IECWStringVar&& other) noexcept {
+        set(other.forced_ ? other.forced_value_ : other.value_);
+        return *this;
+    }
 
     // Cross-size assignment (IEC 61131-3: WSTRING types are interoperable, truncation on overflow)
     template<size_t OtherLen>

--- a/tests/integration/global-local-operand-mix-cpp.test.ts
+++ b/tests/integration/global-local-operand-mix-cpp.test.ts
@@ -313,6 +313,41 @@ describeIfGpp("DOPE-613 — mixing a global and a local on a block input", () =>
       expect(out).toBe("103");
     });
 
+    it("selects the right MUX input when the selector or the data is a global", () => {
+      // MUX is the claim that was wrong: documented as unaffected, actually
+      // broken. Compiling is not enough for a selector-driven function, so
+      // assert it picks the right input in all three mixed arrangements.
+      const source = rawProgram(
+        "    gsel : INT := 1;\n    gval : INT := 70;",
+        "    l0 : INT := 10;\n    l1 : INT := 20;\n    o1 : INT;\n    o2 : INT;\n    o3 : INT;",
+        [
+          "  o1 := MUX(gsel, l0, l1);", // global selector, local data
+          "  o2 := MUX(1, l0, gval);", // local selector, global data
+          "  o3 := MUX(gsel, gval, l1);", // both mixed
+        ].join("\n"),
+      );
+      const result = compile(source, { headerFileName: "generated.hpp" });
+      expect(result.errors.map((e) => e.message)).toEqual([]);
+      const out = compileAndRunStandalone({
+        tempDir,
+        pchPath,
+        headerCode: result.headerCode,
+        cppCode: result.cppCode,
+        testName: "mux_selects_correctly",
+        mainCode: `#include <iostream>
+
+int main() {
+    using namespace strucpp;
+    Program_MAIN p(&GSEL, &GVAL);
+    p.run();
+    std::cout << (int)p.O1.get() << " " << (int)p.O2.get() << " " << (int)p.O3.get() << std::endl;
+    return 0;
+}
+`,
+      });
+      expect(out).toBe("20 70 20");
+    });
+
     it("does not let the returned snapshot write back to the global", () => {
       // read() now hands back an IECVar rather than a scalar. It must stay a
       // detached copy: mutating it must not reach the canonical, or a block

--- a/tests/integration/global-local-operand-mix-cpp.test.ts
+++ b/tests/integration/global-local-operand-mix-cpp.test.ts
@@ -1,0 +1,489 @@
+/**
+ * DOPE-613 — a block whose inputs mix a global and a local.
+ *
+ * `GlobalVar::read()` used to return the *underlying* scalar (`value.get()`)
+ * rather than the IEC value type `V`. Locals, literals and composite-global
+ * fields all present as `IECVar<T>`, so a scalar global was the one operand kind
+ * that differed, and the constrained std-lib templates — which take a single
+ * shared parameter for both operands, `template<typename T> T ADD(T, T)` —
+ * failed to deduce:
+ *
+ *     error: no matching function for call to 'ADD(int, strucpp::IEC_INT&)'
+ *     note: deduced conflicting types for parameter 'T'
+ *           ('int' and 'strucpp::IECVar<int>')
+ *
+ * `operator T()` cannot rescue this: implicit conversions are not considered
+ * during template argument deduction.
+ *
+ * These tests are end-to-end through g++ on purpose. The defect lived entirely
+ * in C++ overload resolution — ST → C++ translation succeeded the whole time —
+ * so a codegen-string assertion would have stayed green throughout.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { compile } from "../../src/index.js";
+import {
+  hasGpp,
+  createPCH,
+  compileWithGpp,
+  compileAndRunStandalone,
+  RUNTIME_INCLUDE_PATH,
+  cxxEnv,
+} from "./test-helpers.js";
+
+const describeIfGpp = hasGpp ? describe : describe.skip;
+
+/** The two operands a block can be given, and how the defect was triggered. */
+type Operands = "global+local" | "global+global" | "local+local";
+
+const OPERANDS: Record<Operands, [string, string]> = {
+  "global+local": ["g", "l"],
+  "global+global": ["g", "g"],
+  "local+local": ["l", "l"],
+};
+
+/**
+ * A one-rung program: `o := FN(a, b)` where each operand is the global or the
+ * local. This is the shape LD and FBD always emit — the graphical languages
+ * write the call form, which is why they took the full weight of this bug while
+ * hand-written ST using infix `a + b` escaped it.
+ */
+function program(
+  fn: string,
+  type: string,
+  operands: Operands,
+  resultType = type,
+): string {
+  const [a, b] = OPERANDS[operands];
+  return `
+CONFIGURATION C
+  VAR_GLOBAL g : ${type} := ${type === "REAL" ? "7.0" : "7"}; END_VAR
+  RESOURCE R ON PLC
+    TASK T(INTERVAL := T#100ms, PRIORITY := 1);
+    PROGRAM Inst WITH T : MAIN;
+  END_RESOURCE
+END_CONFIGURATION
+
+PROGRAM MAIN
+  VAR_EXTERNAL g : ${type}; END_VAR
+  VAR
+    l : ${type} := ${type === "REAL" ? "3.0" : "3"};
+    o : ${resultType};
+  END_VAR
+  o := ${fn}(${a}, ${b});
+END_PROGRAM
+`;
+}
+
+/** Every function whose signature shares one template parameter across operands. */
+const AFFECTED: ReadonlyArray<{
+  fn: string;
+  type: string;
+  resultType?: string;
+}> = [
+  // ANY_NUM arithmetic
+  { fn: "ADD", type: "INT" },
+  { fn: "SUB", type: "INT" },
+  { fn: "MUL", type: "INT" },
+  { fn: "DIV", type: "INT" },
+  { fn: "MOD", type: "INT" },
+  // ANY_BIT logic
+  { fn: "AND", type: "WORD" },
+  { fn: "OR", type: "WORD" },
+  { fn: "XOR", type: "WORD" },
+  // ANY_REAL, two operands
+  { fn: "ATAN2", type: "REAL" },
+];
+
+describeIfGpp("DOPE-613 — mixing a global and a local on a block input", () => {
+  let tempDir: string;
+  let pchPath: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "strucpp-dope613-"));
+    pchPath = createPCH(tempDir);
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /** Translate ST, then hand the generated C++ to g++. */
+  function buildsWithGpp(
+    source: string,
+    testName: string,
+  ): { success: boolean; error?: string } {
+    const result = compile(source, { headerFileName: "generated.hpp" });
+    expect(result.errors.map((e) => e.message)).toEqual([]);
+    expect(result.success).toBe(true);
+    return compileWithGpp({
+      tempDir,
+      pchPath,
+      headerCode: result.headerCode,
+      cppCode: result.cppCode,
+      testName,
+    });
+  }
+
+  describe("the regression: one global, one local", () => {
+    it.each(AFFECTED)(
+      "$fn($type) compiles with a global and a local",
+      ({ fn, type, resultType }) => {
+        const res = buildsWithGpp(
+          program(fn, type, "global+local", resultType),
+          `mixed_${fn}_${type}`,
+        );
+        expect(res.error ?? "").not.toContain("no matching function");
+        expect(res.success).toBe(true);
+      },
+    );
+  });
+
+  describe("controls: the same call with matched operand kinds", () => {
+    // These compiled before the fix too. They are here so a future regression
+    // is attributed correctly — to the global path, not to the function itself.
+    it.each(AFFECTED)(
+      "$fn($type) compiles with two globals",
+      ({ fn, type, resultType }) => {
+        const res = buildsWithGpp(
+          program(fn, type, "global+global", resultType),
+          `allglobal_${fn}_${type}`,
+        );
+        expect(res.success).toBe(true);
+      },
+    );
+
+    it.each(AFFECTED)(
+      "$fn($type) compiles with two locals",
+      ({ fn, type, resultType }) => {
+        const res = buildsWithGpp(
+          program(fn, type, "local+local", resultType),
+          `alllocal_${fn}_${type}`,
+        );
+        expect(res.success).toBe(true);
+      },
+    );
+  });
+
+  describe("the value reaching the block, not merely that it builds", () => {
+    /** Translate ST, build a binary that drives the program, return its stdout. */
+    function run(source: string, mainBody: string, testName: string): string {
+      const result = compile(source, { headerFileName: "generated.hpp" });
+      expect(result.errors.map((e) => e.message)).toEqual([]);
+      return compileAndRunStandalone({
+        tempDir,
+        pchPath,
+        headerCode: result.headerCode,
+        cppCode: result.cppCode,
+        testName,
+        mainCode: `#include <iostream>\n\nint main() {\n    using namespace strucpp;\n${mainBody}\n    return 0;\n}\n`,
+      });
+    }
+
+    it("adds the global to the local rather than a default-constructed value", () => {
+      const out = run(
+        program("ADD", "INT", "global+local"),
+        `    Program_MAIN p(&G);\n    p.run();\n    std::cout << p.O.get() << std::endl;`,
+        "value_add_mixed",
+      );
+      expect(out).toBe("10"); // g := 7, l := 3
+    });
+
+    it("honours a force on the global through the block input", () => {
+      // Forcing is the reason GlobalVar exists in this shape, and the fix
+      // changes what read() hands back — so prove the forced value still wins,
+      // and that unforcing hands control back to writes.
+      //
+      // Note the third step writes before reading. force() deliberately stores
+      // through to the raw value as well, so that plugins reading raw_ptr() see
+      // the forced value; unforce() only clears the flag. The canonical
+      // therefore still holds the forced value until something sets it again,
+      // and asserting a bare revert to 10 would be asserting the wrong contract.
+      const out = run(
+        program("ADD", "INT", "global+local"),
+        [
+          "    Program_MAIN p(&G);",
+          "    p.run();  std::cout << p.O.get() << std::endl;",
+          "    G.value.force(100);",
+          "    p.run();  std::cout << p.O.get() << std::endl;",
+          "    G.value.unforce();",
+          "    G.write(7);",
+          "    p.run();  std::cout << p.O.get() << std::endl;",
+        ].join("\n"),
+        "force_through_block_input",
+      );
+      expect(out.split("\n").map((s) => s.trim())).toEqual(["10", "103", "10"]);
+    });
+
+    it("ignores a write to a forced global, as the canonical does", () => {
+      // set() is a no-op while forced. Reading through a block input must show
+      // the same, or the scan could appear to overwrite an engineer's force.
+      const out = run(
+        program("ADD", "INT", "global+local"),
+        [
+          "    Program_MAIN p(&G);",
+          "    G.value.force(100);",
+          "    G.write(42);",
+          "    p.run();  std::cout << p.O.get() << std::endl;",
+        ].join("\n"),
+        "write_to_forced_global",
+      );
+      expect(out).toBe("103");
+    });
+
+    it("does not let the returned snapshot write back to the global", () => {
+      // read() now hands back an IECVar rather than a scalar. It must stay a
+      // detached copy: mutating it must not reach the canonical, or a block
+      // input would be able to clobber a global it only meant to read.
+      const out = run(
+        program("ADD", "INT", "global+local"),
+        [
+          "    auto snapshot = G.read();",
+          "    snapshot.set(999);",
+          "    std::cout << G.read().get() << std::endl;",
+        ].join("\n"),
+        "snapshot_is_detached",
+      );
+      expect(out).toBe("7");
+    });
+  });
+});
+
+/**
+ * Threading. The generated scan path reads globals through `read()`, and under
+ * STRUCPP_THREADED that read is the only thing standing between two tasks and a
+ * torn value. The fix changes what `read()` returns, so re-establish that the
+ * snapshot is still taken atomically under the global's own mutex.
+ *
+ * Built as a standalone TU rather than through the shared helper: the helper's
+ * precompiled header is built without -DSTRUCPP_THREADED, and g++ rejects a PCH
+ * whose macro state disagrees with the TU including it.
+ */
+describeIfGpp(
+  "DOPE-613 — GlobalVar under contention (STRUCPP_THREADED)",
+  () => {
+    let tempDir: string;
+
+    beforeAll(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "strucpp-dope613-mt-"));
+    });
+
+    afterAll(() => {
+      if (tempDir && fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    function compileAndRunThreaded(source: string, testName: string): string {
+      const srcPath = path.join(tempDir, `${testName}.cpp`);
+      const binPath = path.join(tempDir, testName);
+      fs.writeFileSync(srcPath, source);
+      execSync(
+        `g++ -std=c++17 -O2 -DSTRUCPP_THREADED -pthread -I"${RUNTIME_INCLUDE_PATH}" "${srcPath}" -o "${binPath}" 2>&1`,
+        { encoding: "utf-8", env: cxxEnv },
+      );
+      return execSync(`"${binPath}"`, {
+        encoding: "utf-8",
+        timeout: 30000,
+      }).trim();
+    }
+
+    it("never returns a torn value while writers hammer the same global", () => {
+      // A 64-bit LWORD is the widest scalar we carry and the one a non-atomic
+      // read could plausibly tear on a 32-bit bus. Writers only ever store
+      // all-zero-nibbles or all-F-nibbles, so any other bit pattern the reader
+      // observes is a value assembled from two different writes.
+      const source = `
+#include "iec_global.hpp"
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace strucpp;
+
+static GlobalVar<IEC_LWORD> g{0};
+static std::atomic<bool> stop{false};
+static std::atomic<uint64_t> torn{0};
+static std::atomic<uint64_t> reads{0};
+
+int main() {
+    const uint64_t kZero = 0x0000000000000000ULL;
+    const uint64_t kOnes = 0xFFFFFFFFFFFFFFFFULL;
+
+    std::vector<std::thread> writers;
+    for (int i = 0; i < 4; ++i) {
+        writers.emplace_back([&, i] {
+            while (!stop.load(std::memory_order_relaxed)) {
+                g.write(i % 2 == 0 ? kZero : kOnes);
+            }
+        });
+    }
+
+    // The reader uses exactly the expression generated code uses for a block
+    // input: g.read(), then the value out of the returned snapshot.
+    std::thread reader([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            uint64_t seen = g.read().get();
+            if (seen != kZero && seen != kOnes) torn.fetch_add(1, std::memory_order_relaxed);
+            reads.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& w : writers) w.join();
+    reader.join();
+
+    // Report rather than assert in C++, so a failure shows the numbers.
+    std::cout << "torn=" << torn.load() << std::endl;
+    std::cout << "progressed=" << (reads.load() > 1000 ? 1 : 0) << std::endl;
+    return 0;
+}
+`;
+      const out = compileAndRunThreaded(source, "global_contention");
+      const lines = Object.fromEntries(
+        out.split("\n").map((l) => {
+          const [k, v] = l.trim().split("=");
+          return [k, Number(v)];
+        }),
+      );
+      expect(lines.torn).toBe(0);
+      // Guards against the test passing because the reader deadlocked or the
+      // writers starved it — zero torn reads out of zero reads proves nothing.
+      expect(lines.progressed).toBe(1);
+    }, 60000);
+
+    it("serialises a read against a concurrent write of a wide value", () => {
+      // Complements the above: a single writer flipping between two patterns while
+      // many readers observe, which is the actual multi-task shape in runtime v4.
+      const source = `
+#include "iec_global.hpp"
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace strucpp;
+
+static GlobalVar<IEC_LWORD> g{0};
+static std::atomic<bool> stop{false};
+static std::atomic<uint64_t> torn{0};
+static std::atomic<uint64_t> reads{0};
+
+int main() {
+    const uint64_t kA = 0x0123456789ABCDEFULL;
+    const uint64_t kB = 0xFEDCBA9876543210ULL;
+
+    std::thread writer([&] {
+        bool flip = false;
+        while (!stop.load(std::memory_order_relaxed)) {
+            g.write(flip ? kA : kB);
+            flip = !flip;
+        }
+    });
+
+    std::vector<std::thread> readers;
+    for (int i = 0; i < 4; ++i) {
+        readers.emplace_back([&] {
+            while (!stop.load(std::memory_order_relaxed)) {
+                uint64_t seen = g.read().get();
+                if (seen != kA && seen != kB && seen != 0) torn.fetch_add(1, std::memory_order_relaxed);
+                reads.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    stop.store(true, std::memory_order_relaxed);
+    writer.join();
+    for (auto& r : readers) r.join();
+
+    std::cout << "torn=" << torn.load() << std::endl;
+    std::cout << "progressed=" << (reads.load() > 1000 ? 1 : 0) << std::endl;
+    return 0;
+}
+`;
+      const out = compileAndRunThreaded(source, "global_contention_wide");
+      const lines = Object.fromEntries(
+        out.split("\n").map((l) => {
+          const [k, v] = l.trim().split("=");
+          return [k, Number(v)];
+        }),
+      );
+      expect(lines.torn).toBe(0);
+      expect(lines.progressed).toBe(1);
+    }, 60000);
+
+    it("keeps a forced global forced when read concurrently", () => {
+      // force()/unforce() run on the canonical while readers go through read().
+      // Every observation must be one of the two legitimate values — never a
+      // half-applied force.
+      const source = `
+#include "iec_global.hpp"
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace strucpp;
+
+static GlobalVar<IEC_LWORD> g{0};
+static std::atomic<bool> stop{false};
+static std::atomic<uint64_t> bad{0};
+static std::atomic<uint64_t> reads{0};
+
+int main() {
+    const uint64_t kReal  = 0x1111111111111111ULL;
+    const uint64_t kForce = 0x2222222222222222ULL;
+    g.write(kReal);
+
+    std::thread forcer([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            g.with_lock([&](IEC_LWORD* v) { v->force(kForce); return 0; });
+            g.with_lock([&](IEC_LWORD* v) { v->unforce(); return 0; });
+        }
+    });
+
+    std::vector<std::thread> readers;
+    for (int i = 0; i < 3; ++i) {
+        readers.emplace_back([&] {
+            while (!stop.load(std::memory_order_relaxed)) {
+                uint64_t seen = g.read().get();
+                if (seen != kReal && seen != kForce) bad.fetch_add(1, std::memory_order_relaxed);
+                reads.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    stop.store(true, std::memory_order_relaxed);
+    forcer.join();
+    for (auto& r : readers) r.join();
+
+    std::cout << "bad=" << bad.load() << std::endl;
+    std::cout << "progressed=" << (reads.load() > 1000 ? 1 : 0) << std::endl;
+    return 0;
+}
+`;
+      const out = compileAndRunThreaded(source, "global_force_contention");
+      const lines = Object.fromEntries(
+        out.split("\n").map((l) => {
+          const [k, v] = l.trim().split("=");
+          return [k, Number(v)];
+        }),
+      );
+      expect(lines.bad).toBe(0);
+      expect(lines.progressed).toBe(1);
+    }, 60000);
+  },
+);

--- a/tests/integration/global-local-operand-mix-cpp.test.ts
+++ b/tests/integration/global-local-operand-mix-cpp.test.ts
@@ -99,6 +99,70 @@ const AFFECTED: ReadonlyArray<{
   { fn: "ATAN2", type: "REAL" },
 ];
 
+/**
+ * Build a program from explicit declarations and body, for the shapes the
+ * `program()` template above cannot express.
+ */
+function rawProgram(globals: string, locals: string, body: string): string {
+  return `
+CONFIGURATION C
+  VAR_GLOBAL
+${globals}
+  END_VAR
+  RESOURCE R ON PLC
+    TASK T(INTERVAL := T#100ms, PRIORITY := 1);
+    PROGRAM Inst WITH T : MAIN;
+  END_RESOURCE
+END_CONFIGURATION
+
+PROGRAM MAIN
+  VAR_EXTERNAL
+${globals.replace(/ AT %\w+/g, "").replace(/ :=[^;]*/g, "")}
+  END_VAR
+  VAR
+${locals}
+  END_VAR
+${body}
+END_PROGRAM
+`;
+}
+
+/**
+ * Call shapes that also failed to deduce but are not a plain two-operand call.
+ * MUX and the variadic arity were both missing from the first pass of this
+ * matrix — and MUX was wrongly listed as unaffected in the PR and the ticket.
+ */
+const AFFECTED_SHAPES: ReadonlyArray<{
+  name: string;
+  globals: string;
+  locals: string;
+  body: string;
+}> = [
+  {
+    // MUX selects among its inputs, so a global anywhere in the list is enough.
+    name: "MUX with a global among its inputs",
+    globals: "    g : INT := 7;",
+    locals: "    l : INT := 3;\n    o : INT;",
+    body: "  o := MUX(g, l, g, l);",
+  },
+  {
+    // The extensible form recurses through the same single-parameter template,
+    // so it broke wherever the binary form did.
+    name: "the 3-operand variadic ADD",
+    globals: "    g : INT := 7;",
+    locals: "    l : INT := 3;\n    o : INT;",
+    body: "  o := ADD(g, l, l);",
+  },
+  {
+    // The common real-world shape: read an input word, add a local offset.
+    // A located global is still a GlobalVar, so it broke identically.
+    name: "a located global (AT %IW0) and a local",
+    globals: "    g AT %IW0 : INT := 0;",
+    locals: "    l : INT := 3;\n    o : INT;",
+    body: "  o := ADD(g, l);",
+  },
+];
+
 describeIfGpp("DOPE-613 — mixing a global and a local on a block input", () => {
   let tempDir: string;
   let pchPath: string;
@@ -138,6 +202,18 @@ describeIfGpp("DOPE-613 — mixing a global and a local on a block input", () =>
         const res = buildsWithGpp(
           program(fn, type, "global+local", resultType),
           `mixed_${fn}_${type}`,
+        );
+        expect(res.error ?? "").not.toContain("no matching function");
+        expect(res.success).toBe(true);
+      },
+    );
+
+    it.each(AFFECTED_SHAPES)(
+      "$name compiles",
+      ({ name, globals, locals, body }) => {
+        const res = buildsWithGpp(
+          rawProgram(globals, locals, body),
+          `shape_${name.replace(/[^a-zA-Z0-9]+/g, "_")}`,
         );
         expect(res.error ?? "").not.toContain("no matching function");
         expect(res.success).toBe(true);
@@ -251,6 +327,154 @@ describeIfGpp("DOPE-613 — mixing a global and a local on a block input", () =>
         "snapshot_is_detached",
       );
       expect(out).toBe("7");
+    });
+  });
+
+  describe("STRING and WSTRING globals keep their forcing semantics", () => {
+    /**
+     * `read()` returning `V` means a STRING global now hands back
+     * `IECStringVar<254>`, and that wrapper's special members used to be
+     * `= default` — memberwise, so they copied `forced_` and `forced_value_`.
+     * `IECVar` deliberately does not do that (iec_var.hpp): a fresh copy starts
+     * unforced and assignment routes through `set()`, precisely so generated
+     * code assigning every scan cannot destroy a force the debugger is holding.
+     *
+     * Two ways it broke, both of which these tests pin:
+     *   - assigning from an UNFORCED global cleared a force on the destination
+     *   - assigning from a FORCED global leaked the flag onto the destination,
+     *     whose next write was then silently dropped
+     *
+     * Neither was caught by the first pass of this file, because the matrix had
+     * no string type in it at all.
+     */
+    /**
+     * Two quoting schemes, deliberately separate. IEC 61131-3 spells a STRING
+     * literal with single quotes and a WSTRING literal with double quotes,
+     * while C++ wants `"..."` and `u"..."`. Sharing one quoter silently
+     * produced `gs : STRING := "AB"` — a WSTRING literal on a STRING, which
+     * the front end accepted and then emitted as `u"AB"`.
+     */
+    function runString(
+      type: "STRING" | "WSTRING",
+      st: (s: string) => string,
+      cpp: (s: string) => string,
+      testName: string,
+    ): string[] {
+      const source = rawProgram(
+        `    gs : ${type} := ${st("AB")};`,
+        `    o : ${type};`,
+        "  o := gs;",
+      );
+      const result = compile(source, { headerFileName: "generated.hpp" });
+      expect(result.errors.map((e) => e.message)).toEqual([]);
+      const out = compileAndRunStandalone({
+        tempDir,
+        pchPath,
+        headerCode: result.headerCode,
+        cppCode: result.cppCode,
+        testName,
+        // Values are compared in C++ rather than printed. A WSTRING is
+        // char16_t-based, so streaming it to stdout prints the pointer, not
+        // the text -- and comparing in C++ is the stronger assertion anyway.
+        mainCode: `#include <iostream>
+
+int main() {
+    using namespace strucpp;
+    {   // an engineer forces the LOCAL; the scan copies the global over it
+        Program_MAIN p(&GS);
+        p.O.force(${cpp("FF")});
+        p.run();
+        std::cout << "A " << (int)(p.O.get() == ${cpp("FF")})
+                  << " " << (int)p.O.is_forced() << std::endl;
+    }
+    {   // an engineer forces the GLOBAL; the flag must not ride onto the local
+        Program_MAIN p(&GS);
+        GS.value.force(${cpp("ZZ")});
+        p.run();
+        std::cout << "B " << (int)(p.O.get() == ${cpp("ZZ")})
+                  << " " << (int)p.O.is_forced() << std::endl;
+        p.O.set(${cpp("QQ")});
+        std::cout << "C " << (int)(p.O.get() == ${cpp("QQ")}) << std::endl;
+        GS.value.unforce();
+    }
+    return 0;
+}
+`,
+      });
+      return out.split("\n").map((s) => s.trim());
+    }
+
+    it("a force on a STRING local survives the scan copying a global over it", () => {
+      const lines = runString(
+        "STRING",
+        (s) => `'${s}'`,
+        (s) => `"${s}"`,
+        "string_forcing",
+      );
+      // A: the local still reads 'FF' and still reads as forced.
+      expect(lines[0]).toBe("A 1 1");
+      // B: the local takes the global's value but NOT its force flag.
+      expect(lines[1]).toBe("B 1 0");
+      // C: so the next write to the local is not dropped.
+      expect(lines[2]).toBe("C 1");
+    });
+
+    it("a force on a WSTRING local behaves the same", () => {
+      // iec_wstring.hpp had the identical `= default` shape.
+      const lines = runString(
+        "WSTRING",
+        (s) => `"${s}"`,
+        (s) => `u"${s}"`,
+        "wstring_forcing",
+      );
+      expect(lines[0]).toBe("A 1 1");
+      expect(lines[1]).toBe("B 1 0");
+      expect(lines[2]).toBe("C 1");
+    });
+  });
+
+  describe("infix arithmetic on scalar globals", () => {
+    /**
+     * Pinning a real behaviour change this fix carries, so it cannot drift
+     * again unnoticed.
+     *
+     * A scalar global now presents as `IECVar<T>`, so infix arithmetic on
+     * globals binds the `IECVar` operator overloads instead of promoting to
+     * `int`. Those truncate to the IEC width at each step. For SINT globals of
+     * 100 each, `(ga + gb) / 2` was 100 before and is -28 now.
+     *
+     * That is the correct answer, not a regression: two SINT LOCALS already
+     * gave -28, and IEC 61131-3 says an operation on SINT yields SINT. The
+     * point of this test is that globals and locals now agree, and that
+     * whichever way it goes is a deliberate choice rather than an accident.
+     */
+    it("wraps at the IEC width, and agrees with the same expression on locals", () => {
+      const source = rawProgram(
+        "    ga : SINT := 100;\n    gb : SINT := 100;",
+        "    la : SINT := 100;\n    lb : SINT := 100;\n    og : SINT;\n    ol : SINT;",
+        "  og := (ga + gb) / 2;\n  ol := (la + lb) / 2;",
+      );
+      const result = compile(source, { headerFileName: "generated.hpp" });
+      expect(result.errors.map((e) => e.message)).toEqual([]);
+      const out = compileAndRunStandalone({
+        tempDir,
+        pchPath,
+        headerCode: result.headerCode,
+        cppCode: result.cppCode,
+        testName: "sint_infix_globals",
+        mainCode: `#include <iostream>
+
+int main() {
+    using namespace strucpp;
+    Program_MAIN p(&GA, &GB);
+    p.run();
+    std::cout << (int)p.OG.get() << " " << (int)p.OL.get() << std::endl;
+    return 0;
+}
+`,
+      });
+      // Globals and locals must give the same answer as each other.
+      expect(out).toBe("-28 -28");
     });
   });
 });


### PR DESCRIPTION
Fixes [DOPE-613](https://autonomylogic.atlassian.net/browse/DOPE-613). Reported on the forum against 4.2.1.0 ([a-few-defects-of-4210](https://edge.autonomylogic.com/forum/thread/a-few-defects-of-4210), item 3), with a reproducer project attached.

## The bug

An LD/FBD block taking one **global** and one **local** on its inputs does not compile:

```
pou_MAIN.cpp:15:52: error: no matching function for call to 'ADD(int, strucpp::IEC_INT&)'
    _TMP_ADD593761_OUT = ADD(GI16->read(), LI16);
note: deduced conflicting types for parameter 'T' ('int' and 'strucpp::IECVar<int>')
```

`GlobalVar::read()` unwrapped **two** layers — `GlobalVar` → `IECVar` → raw scalar — while its own doc comment promised "the real IEC value type". The real IEC value type is `IECVar<T>`; `T` is the underlying storage type.

Scalar globals were the only operand kind doing this:

| operand | emitted as | deduces to |
|---|---|---|
| local | `LI16` | `IECVar<int>` |
| literal | `static_cast<IEC_INT>(5)` | `IECVar<int>` |
| GVL / composite global | `GVL->with_lock(…{ return (*__glk).GI16; })` | `IECVar<int>` |
| **scalar global** | `GI16->read()` | **`int`** |

The std-lib templates that share one parameter across both operands — `template<typename T> T ADD(T, T)` — then cannot deduce. `operator T()` cannot rescue it: implicit conversions are not considered during template argument deduction.

**Affected:** `ADD SUB MUL DIV MOD`, `AND OR XOR`, `ATAN2`.
**Affected, also:** `MUX` (a global anywhere among its inputs) and the extensible arity of the arithmetic family, e.g. `ADD(g, l, l)`. An earlier revision of this description listed MUX as unaffected — that was wrong; corrected here and in DOPE-613.

**Not affected:** `GT LT GE LE EQ NE` (already heterogeneous), `MAX MIN LIMIT SEL` (mixed-type overloads added for OSCAT), `SHL`, `EXPT`, GVL globals, and `ADD_TIME` / `SUB_TIME`. LD and FBD always emit the call form, so the graphical languages took the full weight.

**Located variables were affected too** — so "read an input word, add a local offset" was broken.

### One deliberate behaviour change

Infix ST on scalar globals is **not** untouched, contrary to an earlier revision of this description. A scalar global now presents as `IECVar<T>`, so infix binds the `IECVar` operator overloads, which truncate to the IEC width at each step instead of promoting to `int`. For `ga`, `gb` SINT = 100, `o := (ga + gb) / 2` was `100` and is now `-28`.

That is the correct answer, not a regression: two SINT *locals* already gave `-28`, and IEC 61131-3 says an operation on SINT yields SINT — so globals and locals now agree. It was an unpinned change, so a test now asserts that agreement.

The reporter's second claim, that "WORD is not supported by ADD", is a misattribution of this same bug: `ADD(Lw1, Lw2)` on two local WORDs builds and links fine. Their WORD operand was a global.

## The fix

Return `V`. That restores the invariant the rest of the library already assumes, so no std-lib signature changes are needed and every affected function is fixed at once. The return type is spelled `V` rather than `auto` so it cannot drift again.

**Rejected alternative:** heterogeneous `(A a, B b)` signatures across the arithmetic and bit families. Beyond being ~10 functions × 2 arities, it changes the return type — `T ADD(T,T)` returns `T(iec_unwrap(a) + iec_unwrap(b))`, and that explicit `T(...)` truncates back to the IEC width. An `auto` return would let `SINT + SINT` promote to `int` and stop wrapping at 8 bits, silently changing overflow behaviour of code that works today.

## What is unchanged

- **Forcing.** `IECVar`'s copy constructor is deliberately forcing-collapsing (`value_{other.get()}, forced_{false}`), so the snapshot carries the effective forced value with the flag cleared — what a detached read should return. The two STRING/WSTRING wrappers had `= default` special members and so did **not** have those semantics; returning `V` exposed that, and the second commit gives them IECVar's behaviour. See the review thread — this was a genuine blocker, caught by review rather than by the suite.
- **Threading.** Still one lock acquisition; the copy is constructed while the `lock_guard` is in scope, so the snapshot stays atomic.
- **Size — for scalars.** Byte-identical on ATmega2560 at `-Os` for INT / LINT / REAL globals: `run()` frame 3 → 3, `.text` unchanged. The wrapper copy is fully elided.
- **Size — strings cost stack.** A STRING global is a 518-byte wrapper, and returning it by value is not elided. For a body of `o := gs;`, `run()`'s frame on ATmega2560 at `-Os` goes 262 → 520 bytes. An earlier revision of this description claimed "identical object size" without qualification; that measurement was taken on the scalar case only. Called out rather than avoided: keeping `read()` uniform is the point of the fix, and a per-type exception is exactly the asymmetry that caused DOPE-613 in the first place.

## Testing

`tests/integration/global-local-operand-mix-cpp.test.ts` — 34 tests, end-to-end through g++ on purpose: the defect lived entirely in C++ overload resolution, so a codegen-string assertion would have stayed green throughout.

**16 of the 34 fail without this change.** The 18 that pass regardless are the matched-operand controls (all-global, all-local), kept deliberately so a future regression is attributed to the global path rather than to the function itself.

Coverage:
- the mixed-operand matrix across every affected function
- all-global / all-local controls
- the value actually reaching the block (`7 + 3 = 10`, not a default-constructed operand)
- forcing through a block input, and that a write to a forced global is still ignored
- that the returned snapshot is detached — mutating it must not reach the canonical
- three real-threaded tests under `-DSTRUCPP_THREADED -pthread`: 4 writers hammering a 64-bit global while readers observe through `read()`, asserting zero torn values, plus a concurrent force/unforce case. Each asserts the reader actually progressed, so a deadlock cannot pass as a clean run.

Full suite green: **2356 passed**, 94 files. Typecheck clean, lint clean (`src/`), Prettier clean.

## Hardware verification

Built a real `openplc-cli` from this branch (packed strucpp, installed it the way `download-binaries.ts` does, rebuilt the CLI bundle) rather than patching generated output.

- **The reporter's own project** now compiles for ATmega2560 — same emitted call, `ADD(GI16->read(), LI16)`, now accepted.
- **AutomationDirect P1AM-100** (baremetal, real upload over serial), read back through the Modbus RTU debugger:

  | variable | expression | expected | on device |
  |---|---|---|---|
  | `qAdd` | `ADD(gIn, lBase)` | 10 | 10 |
  | `qSub` | `SUB(gIn, lBase)` | 4 | 4 |
  | `qMul` | `MUL(gIn, lBase)` | 21 | 21 |
  | `qAnd` | `AND(gwIn, lMask)` | `16#000F` | `16#000F` |
  | `qLoc` | `ADD(%IW0, lBase)` | `%IW0 + 3` | 3 |

  Forcing `gIn := 100` on the running PLC moved them to 103 / 97 / 300.
- **OpenPLC Runtime v4** (the `STRUCPP_THREADED` build) compiles from the same project.

Not covered: an upload to the SLM-RP4. It has no user account right now, and creating one is not something I will do unprompted.

## Follow-up (not in this PR)

`openplc-editor` pins strucpp in `binary-versions.json` (currently `v0.6.6`). It needs a bump once this merges and a release is cut — the editor cannot pick the fix up before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHm2wRkKn33qqsN8QcUWSa

[DOPE-613]: https://autonomylogic.atlassian.net/browse/DOPE-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
